### PR TITLE
docs: `zimicjs` organization links (#168)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
   <a href="#examples">Examples</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
-  <a href="https://github.com/diego-aquino/zimic/issues/new">Issues</a>
+  <a href="https://github.com/zimicjs/zimic/issues/new">Issues</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
-  <a href="https://github.com/users/diego-aquino/projects/5/views/5">Roadmap</a>
+  <a href="https://github.com/orgs/zimicjs/projects/1/views/5">Roadmap</a>
 </div>
 
 ---
@@ -28,8 +28,7 @@
 >
 > 🚧 This project is still experimental and under active development!
 >
-> Check our [roadmap to v1](https://github.com/users/diego-aquino/projects/5/views/6). Contributors and ideas are
-> welcome!
+> Check our [roadmap to v1](https://github.com/orgs/zimicjs/projects/1/views/5). Contributors and ideas are welcome!
 
 Zimic is a lightweight, TypeScript-first HTTP request mocking library, inspired by
 [Zod](https://github.com/colinhacks/zod)'s type inference and using [MSW](https://github.com/mswjs/msw) under the hood.
@@ -1525,4 +1524,4 @@ should automatically stop after the command finishes.
 
 ## Changelog
 
-The changelog is available on our [GitHub Releases](https://github.com/diego-aquino/zimic/releases) page.
+The changelog is available on our [GitHub Releases](https://github.com/zimicjs/zimic/releases) page.

--- a/examples/with-jest-jsdom/README.md
+++ b/examples/with-jest-jsdom/README.md
@@ -52,7 +52,7 @@ where the repository is found and another where it is not.
    mkdir zimic
    cd zimic
    git init
-   git remote add origin git@github.com:diego-aquino/zimic.git
+   git remote add origin git@github.com:zimicjs/zimic.git
    git sparse-checkout init
    git sparse-checkout set examples/with-jest-jsdom
    git pull origin main

--- a/examples/with-jest-jsdom/tests/example.test.ts
+++ b/examples/with-jest-jsdom/tests/example.test.ts
@@ -6,13 +6,13 @@ import renderApp, { GitHubRepository } from '../src/app';
 import githubInterceptor from './interceptors/github';
 
 describe('Example tests', () => {
-  const ownerName = 'diego-aquino';
-  const repositoryName = 'zimic';
+  const ownerName = 'owner';
+  const repositoryName = 'example';
 
   const repository: GitHubRepository = {
     id: 1,
-    full_name: 'diego-aquino/zimic',
-    html_url: 'https://github.com/diego-aquino/zimic',
+    full_name: `${ownerName}/${repositoryName}`,
+    html_url: `https://github.com/${ownerName}/${repositoryName}`,
   };
 
   beforeEach(() => {

--- a/examples/with-jest-node/README.md
+++ b/examples/with-jest-node/README.md
@@ -41,7 +41,7 @@ where the repository is found and another where it is not.
    mkdir zimic
    cd zimic
    git init
-   git remote add origin git@github.com:diego-aquino/zimic.git
+   git remote add origin git@github.com:zimicjs/zimic.git
    git sparse-checkout init
    git sparse-checkout set examples/with-jest-node
    git pull origin main

--- a/examples/with-jest-node/tests/example.test.ts
+++ b/examples/with-jest-node/tests/example.test.ts
@@ -5,13 +5,13 @@ import app, { GitHubRepository } from '../src/app';
 import githubInterceptor from './interceptors/github';
 
 describe('Example tests', () => {
-  const ownerName = 'diego-aquino';
-  const repositoryName = 'zimic';
+  const ownerName = 'owner';
+  const repositoryName = 'example';
 
   const repository: GitHubRepository = {
     id: 1,
-    full_name: 'diego-aquino/zimic',
-    html_url: 'https://github.com/diego-aquino/zimic',
+    full_name: `${ownerName}/${repositoryName}`,
+    html_url: `https://github.com/${ownerName}/${repositoryName}`,
   };
 
   beforeAll(async () => {

--- a/examples/with-next-js-app/README.md
+++ b/examples/with-next-js-app/README.md
@@ -44,7 +44,7 @@ GitHub API and simulate a test case where the repository is found and another wh
    mkdir zimic
    cd zimic
    git init
-   git remote add origin git@github.com:diego-aquino/zimic.git
+   git remote add origin git@github.com:zimicjs/zimic.git
    git sparse-checkout init
    git sparse-checkout set examples/with-next-js-app
    git pull origin main

--- a/examples/with-next-js-pages/README.md
+++ b/examples/with-next-js-pages/README.md
@@ -46,7 +46,7 @@ GitHub API and simulate a test case where the repository is found and another wh
    mkdir zimic
    cd zimic
    git init
-   git remote add origin git@github.com:diego-aquino/zimic.git
+   git remote add origin git@github.com:zimicjs/zimic.git
    git sparse-checkout init
    git sparse-checkout set examples/with-next-js-pages
    git pull origin main

--- a/examples/with-playwright/README.md
+++ b/examples/with-playwright/README.md
@@ -44,7 +44,7 @@ GitHub API and simulate a test case where the repository is found and another wh
    mkdir zimic
    cd zimic
    git init
-   git remote add origin git@github.com:diego-aquino/zimic.git
+   git remote add origin git@github.com:zimicjs/zimic.git
    git sparse-checkout init
    git sparse-checkout set examples/with-playwright
    git pull origin main

--- a/examples/with-vitest-browser/README.md
+++ b/examples/with-vitest-browser/README.md
@@ -46,7 +46,7 @@ where the repository is found and another where it is not.
    mkdir zimic
    cd zimic
    git init
-   git remote add origin git@github.com:diego-aquino/zimic.git
+   git remote add origin git@github.com:zimicjs/zimic.git
    git sparse-checkout init
    git sparse-checkout set examples/with-vitest-browser
    git pull origin main

--- a/examples/with-vitest-browser/tests/example.test.ts
+++ b/examples/with-vitest-browser/tests/example.test.ts
@@ -8,13 +8,13 @@ import githubInterceptor from './interceptors/github';
 import './setup';
 
 describe('Example tests', () => {
-  const ownerName = 'diego-aquino';
-  const repositoryName = 'zimic';
+  const ownerName = 'owner';
+  const repositoryName = 'example';
 
   const repository: GitHubRepository = {
     id: 1,
-    full_name: 'diego-aquino/zimic',
-    html_url: 'https://github.com/diego-aquino/zimic',
+    full_name: `${ownerName}/${repositoryName}`,
+    html_url: `https://github.com/${ownerName}/${repositoryName}`,
   };
 
   beforeEach(() => {

--- a/examples/with-vitest-jsdom/README.md
+++ b/examples/with-vitest-jsdom/README.md
@@ -35,7 +35,7 @@ where the repository is found and another where it is not.
    mkdir zimic
    cd zimic
    git init
-   git remote add origin git@github.com:diego-aquino/zimic.git
+   git remote add origin git@github.com:zimicjs/zimic.git
    git sparse-checkout init
    git sparse-checkout set examples/with-vitest-jsdom
    git pull origin main

--- a/examples/with-vitest-jsdom/tests/example.test.ts
+++ b/examples/with-vitest-jsdom/tests/example.test.ts
@@ -6,13 +6,13 @@ import renderApp, { GitHubRepository } from '../src/app';
 import githubInterceptor from './interceptors/github';
 
 describe('Example tests', () => {
-  const ownerName = 'diego-aquino';
-  const repositoryName = 'zimic';
+  const ownerName = 'owner';
+  const repositoryName = 'example';
 
   const repository: GitHubRepository = {
     id: 1,
-    full_name: 'diego-aquino/zimic',
-    html_url: 'https://github.com/diego-aquino/zimic',
+    full_name: `${ownerName}/${repositoryName}`,
+    html_url: `https://github.com/${ownerName}/${repositoryName}`,
   };
 
   beforeEach(() => {

--- a/examples/with-vitest-node/README.md
+++ b/examples/with-vitest-node/README.md
@@ -36,7 +36,7 @@ where the repository is found and another where it is not.
    mkdir zimic
    cd zimic
    git init
-   git remote add origin git@github.com:diego-aquino/zimic.git
+   git remote add origin git@github.com:zimicjs/zimic.git
    git sparse-checkout init
    git sparse-checkout set examples/with-vitest-node
    git pull origin main

--- a/examples/with-vitest-node/tests/example.test.ts
+++ b/examples/with-vitest-node/tests/example.test.ts
@@ -5,13 +5,13 @@ import app, { GitHubRepository } from '../src/app';
 import githubInterceptor from './interceptors/github';
 
 describe('Example tests', () => {
-  const ownerName = 'diego-aquino';
-  const repositoryName = 'zimic';
+  const ownerName = 'owner';
+  const repositoryName = 'example';
 
   const repository: GitHubRepository = {
     id: 1,
-    full_name: 'diego-aquino/zimic',
-    html_url: 'https://github.com/diego-aquino/zimic',
+    full_name: `${ownerName}/${repositoryName}`,
+    html_url: `https://github.com/${ownerName}/${repositoryName}`,
   };
 
   beforeAll(async () => {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.5.0-canary.4",
   "repository": {
     "type": "git",
-    "url": "https://github.com/diego-aquino/zimic.git"
+    "url": "https://github.com/zimicjs/zimic.git"
   },
   "private": false,
   "packageManager": "pnpm@9.0.6",

--- a/packages/release/src/cli/__tests__/cli.test.ts
+++ b/packages/release/src/cli/__tests__/cli.test.ts
@@ -41,7 +41,7 @@ describe('Release CLI', () => {
     ],
     tagSuffix: '-suffix',
     github: {
-      repositoryOwner: 'diego-aquino',
+      repositoryOwner: 'zimicjs',
       repositoryName: 'zimic',
       productionBranch: 'main',
     },

--- a/packages/release/src/config/release-config/__tests__/fixtures/valid/release.config.js
+++ b/packages/release/src/config/release-config/__tests__/fixtures/valid/release.config.js
@@ -15,7 +15,7 @@ module.exports = {
   ],
   tagSuffix: '-suffix',
   github: {
-    repositoryOwner: 'diego-aquino',
+    repositoryOwner: 'zimicjs',
     repositoryName: 'zimic',
     productionBranch: 'main',
   },

--- a/packages/release/src/config/release-config/__tests__/release-config.test.ts
+++ b/packages/release/src/config/release-config/__tests__/release-config.test.ts
@@ -25,7 +25,7 @@ describe('Release config', () => {
     ],
     tagSuffix: '-suffix',
     github: {
-      repositoryOwner: 'diego-aquino',
+      repositoryOwner: 'zimicjs',
       repositoryName: 'zimic',
       productionBranch: 'main',
     },

--- a/packages/zimic/package.json
+++ b/packages/zimic/package.json
@@ -104,7 +104,7 @@
     "bufferutil": "^4.0.8"
   },
   "peerDependencies": {
-    "typescript": ">=4.7.x <5.5"
+    "typescript": ">=4.7"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/packages/zimic/package.json
+++ b/packages/zimic/package.json
@@ -13,7 +13,7 @@
   "version": "0.5.0-canary.4",
   "repository": {
     "type": "git",
-    "url": "https://github.com/diego-aquino/zimic.git",
+    "url": "https://github.com/zimicjs/zimic.git",
     "directory": "packages/zimic"
   },
   "private": false,

--- a/packages/zimic/src/http/headers/types.ts
+++ b/packages/zimic/src/http/headers/types.ts
@@ -12,7 +12,7 @@ export type HttpHeadersSchemaTuple<Schema extends HttpHeadersSchema> = {
   [Key in keyof Schema & string]: [Key, Defined<Schema[Key]>];
 }[keyof Schema & string];
 
-/** An initialization value for {@link https://github.com/diego-aquino/zimic#httpheaders `HttpHeaders`}. */
+/** An initialization value for {@link https://github.com/zimicjs/zimic#httpheaders `HttpHeaders`}. */
 export type HttpHeadersInit<Schema extends HttpHeadersSchema> =
   | Headers
   | Schema

--- a/packages/zimic/src/http/searchParams/types.ts
+++ b/packages/zimic/src/http/searchParams/types.ts
@@ -12,7 +12,7 @@ export type HttpSearchParamsSchemaTuple<Schema extends HttpSearchParamsSchema> =
   [Key in keyof Schema & string]: [Key, ArrayItemIfArray<Defined<Schema[Key]>>];
 }[keyof Schema & string];
 
-/** An initialization value for {@link https://github.com/diego-aquino/zimic#httpsearchparams `HttpSearchParams`}. */
+/** An initialization value for {@link https://github.com/zimicjs/zimic#httpsearchparams `HttpSearchParams`}. */
 export type HttpSearchParamsInit<Schema extends HttpSearchParamsSchema> =
   | string
   | URLSearchParams

--- a/packages/zimic/src/http/types/schema.ts
+++ b/packages/zimic/src/http/types/schema.ts
@@ -14,7 +14,7 @@ export type HttpMethod = (typeof HTTP_METHODS)[number];
 /**
  * A schema representing the structure of an HTTP request.
  *
- * @see {@link https://github.com/diego-aquino/zimic#declaring-http-service-schemas Declaring HTTP Service Schemas}
+ * @see {@link https://github.com/zimicjs/zimic#declaring-http-service-schemas Declaring HTTP Service Schemas}
  */
 export interface HttpServiceRequestSchema {
   headers?: HttpHeadersSchema;
@@ -25,7 +25,7 @@ export interface HttpServiceRequestSchema {
 /**
  * A schema representing the structure of an HTTP response.
  *
- * @see {@link https://github.com/diego-aquino/zimic#declaring-http-service-schemas Declaring HTTP Service Schemas}
+ * @see {@link https://github.com/zimicjs/zimic#declaring-http-service-schemas Declaring HTTP Service Schemas}
  */
 export interface HttpServiceResponseSchema {
   headers?: HttpHeadersSchema;
@@ -41,7 +41,7 @@ export namespace HttpServiceResponseSchema {
 /**
  * A schema representing the structure of HTTP responses by status code.
  *
- * @see {@link https://github.com/diego-aquino/zimic#declaring-http-service-schemas Declaring HTTP Service Schemas}
+ * @see {@link https://github.com/zimicjs/zimic#declaring-http-service-schemas Declaring HTTP Service Schemas}
  */
 export type HttpServiceResponseSchemaByStatusCode = {
   [statusCode: number]: HttpServiceResponseSchema;
@@ -59,7 +59,7 @@ export namespace HttpServiceResponseSchemaByStatusCode {
 /**
  * Extracts the status codes used in a response schema by status code.
  *
- * @see {@link https://github.com/diego-aquino/zimic#declaring-http-service-schemas Declaring HTTP Service Schemas}
+ * @see {@link https://github.com/zimicjs/zimic#declaring-http-service-schemas Declaring HTTP Service Schemas}
  */
 export type HttpServiceResponseSchemaStatusCode<
   ResponseSchemaByStatusCode extends HttpServiceResponseSchemaByStatusCode,
@@ -68,7 +68,7 @@ export type HttpServiceResponseSchemaStatusCode<
 /**
  * A schema representing the structure of an HTTP request and response for a given method.
  *
- * @see {@link https://github.com/diego-aquino/zimic#declaring-http-service-schemas Declaring HTTP Service Schemas}
+ * @see {@link https://github.com/zimicjs/zimic#declaring-http-service-schemas Declaring HTTP Service Schemas}
  */
 export interface HttpServiceMethodSchema {
   request?: HttpServiceRequestSchema;
@@ -88,7 +88,7 @@ export namespace HttpServiceMethodSchema {
 /**
  * A schema representing the structure of HTTP request and response by method.
  *
- * @see {@link https://github.com/diego-aquino/zimic#declaring-http-service-schemas Declaring HTTP Service Schemas}
+ * @see {@link https://github.com/zimicjs/zimic#declaring-http-service-schemas Declaring HTTP Service Schemas}
  */
 export interface HttpServiceMethodsSchema {
   GET?: HttpServiceMethodSchema.NoRequestBody;
@@ -103,7 +103,7 @@ export interface HttpServiceMethodsSchema {
 /**
  * A schema representing the structure of paths, methods, requests, and responses for an HTTP service.
  *
- * @see {@link https://github.com/diego-aquino/zimic#declaring-http-service-schemas Declaring HTTP Service Schemas}
+ * @see {@link https://github.com/zimicjs/zimic#declaring-http-service-schemas Declaring HTTP Service Schemas}
  */
 export interface HttpServiceSchema {
   [path: string]: HttpServiceMethodsSchema;
@@ -112,7 +112,7 @@ export interface HttpServiceSchema {
 /**
  * A namespace containing utility types for validating HTTP type schemas.
  *
- * @see {@link https://github.com/diego-aquino/zimic#declaring-http-service-schemas Declaring HTTP Service Schemas}
+ * @see {@link https://github.com/zimicjs/zimic#declaring-http-service-schemas Declaring HTTP Service Schemas}
  */
 export namespace HttpSchema {
   /** Validates that a type is a valid HTTP service schema. */
@@ -136,7 +136,7 @@ export namespace HttpSchema {
 /**
  * Extracts the methods from an HTTP service schema.
  *
- * @see {@link https://github.com/diego-aquino/zimic#declaring-http-service-schemas Declaring HTTP Service Schemas}
+ * @see {@link https://github.com/zimicjs/zimic#declaring-http-service-schemas Declaring HTTP Service Schemas}
  */
 export type HttpServiceSchemaMethod<Schema extends HttpServiceSchema> = IfAny<
   Schema,
@@ -148,7 +148,7 @@ export type HttpServiceSchemaMethod<Schema extends HttpServiceSchema> = IfAny<
  * Extracts the literal paths from an HTTP service schema containing certain methods. Only the methods defined in the
  * schema are allowed.
  *
- * @see {@link https://github.com/diego-aquino/zimic#declaring-http-service-schemas Declaring HTTP Service Schemas}
+ * @see {@link https://github.com/zimicjs/zimic#declaring-http-service-schemas Declaring HTTP Service Schemas}
  */
 export type LiteralHttpServiceSchemaPath<
   Schema extends HttpServiceSchema,
@@ -158,7 +158,7 @@ export type LiteralHttpServiceSchemaPath<
 /**
  * Extracts the literal paths from an HTTP service schema containing certain methods. Any method is allowed.
  *
- * @see {@link https://github.com/diego-aquino/zimic#declaring-http-service-schemas Declaring HTTP Service Schemas}
+ * @see {@link https://github.com/zimicjs/zimic#declaring-http-service-schemas Declaring HTTP Service Schemas}
  */
 export type LooseLiteralHttpServiceSchemaPath<Schema extends HttpServiceSchema, Method extends HttpMethod> = {
   [Path in Extract<keyof Schema, string>]: Method extends keyof Schema[Path] ? Path : never;
@@ -173,7 +173,7 @@ type AllowAnyStringInPathParams<Path extends string> = Path extends `${infer Pre
 /**
  * Extracts the non-literal paths from an HTTP service schema containing certain methods.
  *
- * @see {@link https://github.com/diego-aquino/zimic#declaring-http-service-schemas Declaring HTTP Service Schemas}
+ * @see {@link https://github.com/zimicjs/zimic#declaring-http-service-schemas Declaring HTTP Service Schemas}
  */
 export type NonLiteralHttpServiceSchemaPath<
   Schema extends HttpServiceSchema,
@@ -216,7 +216,7 @@ export type InferLiteralHttpServiceSchemaPath<
 /**
  * Extracts the paths from an HTTP service schema containing certain methods.
  *
- * @see {@link https://github.com/diego-aquino/zimic#declaring-http-service-schemas Declaring HTTP Service Schemas}
+ * @see {@link https://github.com/zimicjs/zimic#declaring-http-service-schemas Declaring HTTP Service Schemas}
  */
 export type HttpServiceSchemaPath<Schema extends HttpServiceSchema, Method extends HttpServiceSchemaMethod<Schema>> =
   | LiteralHttpServiceSchemaPath<Schema, Method>

--- a/packages/zimic/src/interceptor/http/interceptor/errors/NotStartedHttpInterceptorError.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/errors/NotStartedHttpInterceptorError.ts
@@ -1,9 +1,9 @@
 /**
  * An error thrown when the interceptor is not running and it's not possible to use the mocking utilities.
  *
- * @see {@link https://github.com/diego-aquino/zimic#http-interceptorstart `interceptor.start()` API reference}
- * @see {@link https://github.com/diego-aquino/zimic#http-interceptorstop `interceptor.stop()` API reference}
- * @see {@link https://github.com/diego-aquino/zimic#http-interceptorisrunning `interceptor.isRunning()` API reference}
+ * @see {@link https://github.com/zimicjs/zimic#http-interceptorstart `interceptor.start()` API reference}
+ * @see {@link https://github.com/zimicjs/zimic#http-interceptorstop `interceptor.stop()` API reference}
+ * @see {@link https://github.com/zimicjs/zimic#http-interceptorisrunning `interceptor.isRunning()` API reference}
  */
 class NotStartedHttpInterceptorError extends Error {
   constructor() {

--- a/packages/zimic/src/interceptor/http/interceptor/errors/UnknownHttpInterceptorPlatform.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/errors/UnknownHttpInterceptorPlatform.ts
@@ -2,7 +2,7 @@
  * An error thrown when an unknown interceptor platform is detected. Currently, the platforms `node` and `browser` are
  * supported.
  *
- * @see {@link https://github.com/diego-aquino/zimic#http-interceptorplatform `interceptor.platform()` API reference}
+ * @see {@link https://github.com/zimicjs/zimic#http-interceptorplatform `interceptor.platform()` API reference}
  */
 class UnknownHttpInterceptorPlatform extends Error {
   /* istanbul ignore next -- @preserve

--- a/packages/zimic/src/interceptor/http/interceptor/types/options.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/types/options.ts
@@ -4,14 +4,14 @@ import { PossiblePromise } from '@/types/utils';
 /**
  * An type of an HTTP interceptor.
  *
- * @see {@link https://github.com/diego-aquino/zimic#httpinterceptor `HttpInterceptor` API reference}
+ * @see {@link https://github.com/zimicjs/zimic#httpinterceptor `HttpInterceptor` API reference}
  */
 export type HttpInterceptorType = 'local' | 'remote';
 
 /**
  * The platform where an HTTP interceptor is running.
  *
- * @see {@link https://github.com/diego-aquino/zimic#http-interceptorplatform `interceptor.platform()` API reference}
+ * @see {@link https://github.com/zimicjs/zimic#http-interceptorplatform `interceptor.platform()` API reference}
  */
 export type HttpInterceptorPlatform = 'node' | 'browser';
 
@@ -21,13 +21,13 @@ export type HttpInterceptorPlatform = 'node' | 'browser';
  * When `log` is `true`, unhandled requests are logged to the console. If provided a handler, unhandled requests will be
  * logged if `await context.log()` is called.
  *
- * @see {@link https://github.com/diego-aquino/zimic#unhandled-requests Unhandled requests}
+ * @see {@link https://github.com/zimicjs/zimic#unhandled-requests Unhandled requests}
  */
 export namespace UnhandledRequestStrategy {
   /**
    * A static declaration of the strategy to handle unhandled requests.
    *
-   * @see {@link https://github.com/diego-aquino/zimic#unhandled-requests Unhandled requests}
+   * @see {@link https://github.com/zimicjs/zimic#unhandled-requests Unhandled requests}
    */
   export type Declaration = Partial<{
     log: boolean;
@@ -38,12 +38,11 @@ export namespace UnhandledRequestStrategy {
      * Logs the unhandled request to the console.
      *
      * If the request was bypassed by a
-     * {@link https://github.com/diego-aquino/zimic#local-http-interceptors local interceptor}, the log will be a
-     * warning. If the request was rejected by a
-     * {@link https://github.com/diego-aquino/zimic#local-http-interceptors remote interceptor}, the log will be an
-     * error.
+     * {@link https://github.com/zimicjs/zimic#local-http-interceptors local interceptor}, the log will be a warning. If
+     * the request was rejected by a {@link https://github.com/zimicjs/zimic#local-http-interceptors remote interceptor},
+     * the log will be an error.
      *
-     * @see {@link https://github.com/diego-aquino/zimic#unhandled-requests Unhandled requests}
+     * @see {@link https://github.com/zimicjs/zimic#unhandled-requests Unhandled requests}
      */
     log: () => Promise<void>;
   }
@@ -51,20 +50,20 @@ export namespace UnhandledRequestStrategy {
   /**
    * A dynamic handler to unhandled requests.
    *
-   * @see {@link https://github.com/diego-aquino/zimic#unhandled-requests Unhandled requests}
+   * @see {@link https://github.com/zimicjs/zimic#unhandled-requests Unhandled requests}
    */
   export type Handler = (request: HttpRequest, context: HandlerContext) => PossiblePromise<void>;
 
   /**
    * The action to take when an unhandled request is intercepted.
    *
-   * In a {@link https://github.com/diego-aquino/zimic#local-http-interceptors local interceptor}, the action is always
+   * In a {@link https://github.com/zimicjs/zimic#local-http-interceptors local interceptor}, the action is always
    * `bypass`, meaning that unhandled requests pass through the interceptor and reach the real network.
-   * {@link https://github.com/diego-aquino/zimic#local-http-interceptors Remote interceptors} always use `reject`, since
-   * unhandled requests that react an {@link https://github.com/diego-aquino/zimic#zimic-server interceptor server}
-   * cannot be bypassed.
+   * {@link https://github.com/zimicjs/zimic#local-http-interceptors Remote interceptors} always use `reject`, since
+   * unhandled requests that react an {@link https://github.com/zimicjs/zimic#zimic-server interceptor server} cannot be
+   * bypassed.
    *
-   * @see {@link https://github.com/diego-aquino/zimic#unhandled-requests Unhandled requests}
+   * @see {@link https://github.com/zimicjs/zimic#unhandled-requests Unhandled requests}
    */
   export type Action = 'bypass' | 'reject';
 }
@@ -77,10 +76,10 @@ export interface SharedHttpInterceptorOptions {
 
   /**
    * Represents the URL that should be matched by the interceptor. Any request starting with this base URL will be
-   * intercepted if a matching {@link https://github.com/diego-aquino/zimic#httprequesthandler handler} exists.
+   * intercepted if a matching {@link https://github.com/zimicjs/zimic#httprequesthandler handler} exists.
    *
-   * For {@link https://github.com/diego-aquino/zimic#remote-http-interceptors remote interceptors}, this base URL should
-   * point to an {@link https://github.com/diego-aquino/zimic#zimic-server interceptor server}. It may include additional
+   * For {@link https://github.com/zimicjs/zimic#remote-http-interceptors remote interceptors}, this base URL should
+   * point to an {@link https://github.com/zimicjs/zimic#zimic-server interceptor server}. It may include additional
    * paths to differentiate between conflicting mocks.
    */
   baseURL: string | URL;
@@ -93,22 +92,19 @@ export interface SharedHttpInterceptorOptions {
   onUnhandledRequest?: UnhandledRequestStrategy;
 }
 
-/** The options to create a {@link https://github.com/diego-aquino/zimic#local-http-interceptors local HTTP interceptor}. */
+/** The options to create a {@link https://github.com/zimicjs/zimic#local-http-interceptors local HTTP interceptor}. */
 export interface LocalHttpInterceptorOptions extends SharedHttpInterceptorOptions {
   type: 'local';
 }
 
-/**
- * The options to create a
- * {@link https://github.com/diego-aquino/zimic#remote-http-interceptors remote HTTP interceptor}.
- */
+/** The options to create a {@link https://github.com/zimicjs/zimic#remote-http-interceptors remote HTTP interceptor}. */
 export interface RemoteHttpInterceptorOptions extends SharedHttpInterceptorOptions {
   type: 'remote';
 }
 
 /**
- * The options to create an {@link https://github.com/diego-aquino/zimic#httpinterceptor HTTP interceptor}.
+ * The options to create an {@link https://github.com/zimicjs/zimic#httpinterceptor HTTP interceptor}.
  *
- * @see {@link https://github.com/diego-aquino/zimic#httpcreateinterceptor `http.createInterceptor()` API reference}
+ * @see {@link https://github.com/zimicjs/zimic#httpcreateinterceptor `http.createInterceptor()` API reference}
  */
 export type HttpInterceptorOptions = LocalHttpInterceptorOptions | RemoteHttpInterceptorOptions;

--- a/packages/zimic/src/interceptor/http/interceptor/types/public.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/types/public.ts
@@ -11,24 +11,24 @@ import { HttpInterceptorPlatform } from './options';
  * An interceptor to handle HTTP requests and return mock responses. The methods, paths, status codes, parameters, and
  * responses are statically-typed based on the provided service schema.
  *
- * @see {@link https://github.com/diego-aquino/zimic#httpinterceptor `HttpInterceptor` API reference}
+ * @see {@link https://github.com/zimicjs/zimic#httpinterceptor `HttpInterceptor` API reference}
  */
 export interface HttpInterceptor<Schema extends HttpServiceSchema> {
   /**
    * @returns The base URL used by the interceptor.
-   * @see {@link https://github.com/diego-aquino/zimic#http-interceptorbaseurl `interceptor.baseURL()` API reference}
+   * @see {@link https://github.com/zimicjs/zimic#http-interceptorbaseurl `interceptor.baseURL()` API reference}
    */
   baseURL: () => string;
 
   /**
    * @returns The platform the interceptor is running on.
-   * @see {@link https://github.com/diego-aquino/zimic#http-interceptorplatform `interceptor.platform()` API reference}
+   * @see {@link https://github.com/zimicjs/zimic#http-interceptorplatform `interceptor.platform()` API reference}
    */
   platform: () => HttpInterceptorPlatform | null;
 
   /**
    * @returns Whether the interceptor is currently running and ready to use.
-   * @see {@link https://github.com/diego-aquino/zimic#http-interceptorisrunning `interceptor.isRunning()` API reference}
+   * @see {@link https://github.com/zimicjs/zimic#http-interceptorisrunning `interceptor.isRunning()` API reference}
    */
   isRunning: () => boolean;
 
@@ -40,96 +40,96 @@ export interface HttpInterceptor<Schema extends HttpServiceSchema> {
    *
    * @throws {UnregisteredServiceWorkerError} When the worker is targeting a browser environment and the mock service
    *   worker is not registered.
-   * @see {@link https://github.com/diego-aquino/zimic#http-interceptorstart `interceptor.start()` API reference}
+   * @see {@link https://github.com/zimicjs/zimic#http-interceptorstart `interceptor.start()` API reference}
    */
   start: () => Promise<void>;
 
   /**
    * Stops the interceptor, preventing it from intercepting HTTP requests.
    *
-   * @see {@link https://github.com/diego-aquino/zimic#http-interceptorstop `interceptor.stop()` API reference}
+   * @see {@link https://github.com/zimicjs/zimic#http-interceptorstop `interceptor.stop()` API reference}
    */
   stop: () => Promise<void>;
 
   /**
    * @param path The path to intercept. Paths with dynamic parameters, such as `/users/:id`, are supported, but you need
    *   to specify the original path as a type parameter to get type-inference and type-validation.
-   * @returns A GET {@link https://github.com/diego-aquino/zimic#httprequesthandler `HttpRequestHandler`} for the
-   *   provided path. The path and method must be declared in the interceptor schema.
+   * @returns A GET {@link https://github.com/zimicjs/zimic#httprequesthandler `HttpRequestHandler`} for the provided
+   *   path. The path and method must be declared in the interceptor schema.
    * @throws {NotStartedHttpInterceptorError} If the interceptor is not running.
-   * @see {@link https://github.com/diego-aquino/zimic#http-interceptormethodpath `interceptor.<method>(path)` API reference}
+   * @see {@link https://github.com/zimicjs/zimic#http-interceptormethodpath `interceptor.<method>(path)` API reference}
    */
   get: HttpInterceptorMethodHandler<Schema, 'GET'>;
 
   /**
    * @param path The path to intercept. Paths with dynamic parameters, such as `/users/:id`, are supported, but you need
    *   to specify the original path as a type parameter to get type-inference and type-validation.
-   * @returns A POST {@link https://github.com/diego-aquino/zimic#httprequesthandler `HttpRequestHandler`} for the
-   *   provided path. The path and method must be declared in the interceptor schema.
+   * @returns A POST {@link https://github.com/zimicjs/zimic#httprequesthandler `HttpRequestHandler`} for the provided
+   *   path. The path and method must be declared in the interceptor schema.
    * @throws {NotStartedHttpInterceptorError} If the interceptor is not running.
-   * @see {@link https://github.com/diego-aquino/zimic#http-interceptormethodpath `interceptor.<method>(path)` API reference}
+   * @see {@link https://github.com/zimicjs/zimic#http-interceptormethodpath `interceptor.<method>(path)` API reference}
    */
   post: HttpInterceptorMethodHandler<Schema, 'POST'>;
 
   /**
    * @param path The path to intercept. Paths with dynamic parameters, such as `/users/:id`, are supported, but you need
    *   to specify the original path as a type parameter to get type-inference and type-validation.
-   * @returns A PATCH {@link https://github.com/diego-aquino/zimic#httprequesthandler `HttpRequestHandler`} for the
-   *   provided path. The path and method must be declared in the interceptor schema.
+   * @returns A PATCH {@link https://github.com/zimicjs/zimic#httprequesthandler `HttpRequestHandler`} for the provided
+   *   path. The path and method must be declared in the interceptor schema.
    * @throws {NotStartedHttpInterceptorError} If the interceptor is not running.
-   * @see {@link https://github.com/diego-aquino/zimic#http-interceptormethodpath `interceptor.<method>(path)` API reference}
+   * @see {@link https://github.com/zimicjs/zimic#http-interceptormethodpath `interceptor.<method>(path)` API reference}
    */
   patch: HttpInterceptorMethodHandler<Schema, 'PATCH'>;
 
   /**
    * @param path The path to intercept. Paths with dynamic parameters, such as `/users/:id`, are supported, but you need
    *   to specify the original path as a type parameter to get type-inference and type-validation.
-   * @returns A PUT {@link https://github.com/diego-aquino/zimic#httprequesthandler `HttpRequestHandler`} for the
-   *   provided path. The path and method must be declared in the interceptor schema.
+   * @returns A PUT {@link https://github.com/zimicjs/zimic#httprequesthandler `HttpRequestHandler`} for the provided
+   *   path. The path and method must be declared in the interceptor schema.
    * @throws {NotStartedHttpInterceptorError} If the interceptor is not running.
-   * @see {@link https://github.com/diego-aquino/zimic#http-interceptormethodpath `interceptor.<method>(path)` API reference}
+   * @see {@link https://github.com/zimicjs/zimic#http-interceptormethodpath `interceptor.<method>(path)` API reference}
    */
   put: HttpInterceptorMethodHandler<Schema, 'PUT'>;
 
   /**
    * @param path The path to intercept. Paths with dynamic parameters, such as `/users/:id`, are supported, but you need
    *   to specify the original path as a type parameter to get type-inference and type-validation.
-   * @returns A DELETE {@link https://github.com/diego-aquino/zimic#httprequesthandler `HttpRequestHandler`} for the
-   *   provided path. The path and method must be declared in the interceptor schema.
+   * @returns A DELETE {@link https://github.com/zimicjs/zimic#httprequesthandler `HttpRequestHandler`} for the provided
+   *   path. The path and method must be declared in the interceptor schema.
    * @throws {NotStartedHttpInterceptorError} If the interceptor is not running.
-   * @see {@link https://github.com/diego-aquino/zimic#http-interceptormethodpath `interceptor.<method>(path)` API reference}
+   * @see {@link https://github.com/zimicjs/zimic#http-interceptormethodpath `interceptor.<method>(path)` API reference}
    */
   delete: HttpInterceptorMethodHandler<Schema, 'DELETE'>;
 
   /**
    * @param path The path to intercept. Paths with dynamic parameters, such as `/users/:id`, are supported, but you need
    *   to specify the original path as a type parameter to get type-inference and type-validation.
-   * @returns A HEAD {@link https://github.com/diego-aquino/zimic#httprequesthandler `HttpRequestHandler`} for the
-   *   provided path. The path and method must be declared in the interceptor schema.
+   * @returns A HEAD {@link https://github.com/zimicjs/zimic#httprequesthandler `HttpRequestHandler`} for the provided
+   *   path. The path and method must be declared in the interceptor schema.
    * @throws {NotStartedHttpInterceptorError} If the interceptor is not running.
-   * @see {@link https://github.com/diego-aquino/zimic#http-interceptormethodpath `interceptor.<method>(path)` API reference}
+   * @see {@link https://github.com/zimicjs/zimic#http-interceptormethodpath `interceptor.<method>(path)` API reference}
    */
   head: HttpInterceptorMethodHandler<Schema, 'HEAD'>;
 
   /**
    * @param path The path to intercept. Paths with dynamic parameters, such as `/users/:id`, are supported, but you need
    *   to specify the original path as a type parameter to get type-inference and type-validation.
-   * @returns An OPTIONS {@link https://github.com/diego-aquino/zimic#httprequesthandler `HttpRequestHandler`} for the
+   * @returns An OPTIONS {@link https://github.com/zimicjs/zimic#httprequesthandler `HttpRequestHandler`} for the
    *   provided path. The path and method must be declared in the interceptor schema.
    * @throws {NotStartedHttpInterceptorError} If the interceptor is not running.
-   * @see {@link https://github.com/diego-aquino/zimic#http-interceptormethodpath `interceptor.<method>(path)` API reference}
+   * @see {@link https://github.com/zimicjs/zimic#http-interceptormethodpath `interceptor.<method>(path)` API reference}
    */
   options: HttpInterceptorMethodHandler<Schema, 'OPTIONS'>;
 
   /**
-   * Clears all of the {@link https://github.com/diego-aquino/zimic#httprequesthandler `HttpRequestHandler`} instances
-   * created by this interceptor. After calling this method, the interceptor will no longer intercept any requests until
-   * new mock responses are registered.
+   * Clears all of the {@link https://github.com/zimicjs/zimic#httprequesthandler `HttpRequestHandler`} instances created
+   * by this interceptor. After calling this method, the interceptor will no longer intercept any requests until new
+   * mock responses are registered.
    *
    * This method is useful to reset the interceptor mocks between tests.
    *
    * @throws {NotStartedHttpInterceptorError} If the interceptor is not running.
-   * @see {@link https://github.com/diego-aquino/zimic#http-interceptorclear `interceptor.clear()` API reference}
+   * @see {@link https://github.com/zimicjs/zimic#http-interceptorclear `interceptor.clear()` API reference}
    */
   clear: () => void;
 }
@@ -139,9 +139,9 @@ export interface HttpInterceptor<Schema extends HttpServiceSchema> {
  * and responses are statically-typed based on the provided service schema.
  *
  * To intercept HTTP requests, the interceptor must have been started with
- * {@link https://github.com/diego-aquino/zimic#http-interceptorstart `interceptor.start()`}.
+ * {@link https://github.com/zimicjs/zimic#http-interceptorstart `interceptor.start()`}.
  *
- * @see {@link https://github.com/diego-aquino/zimic#httpinterceptor `HttpInterceptor` API reference}
+ * @see {@link https://github.com/zimicjs/zimic#httpinterceptor `HttpInterceptor` API reference}
  */
 export interface LocalHttpInterceptor<Schema extends HttpServiceSchema> extends HttpInterceptor<Schema> {
   readonly type: 'local';
@@ -162,10 +162,10 @@ export interface LocalHttpInterceptor<Schema extends HttpServiceSchema> extends 
  * and responses are statically-typed based on the provided service schema.
  *
  * To intercept HTTP requests, the interceptor must have been started with
- * {@link https://github.com/diego-aquino/zimic#http-interceptorstart `interceptor.start()`} and an
- * {@link https://github.com/diego-aquino/zimic#zimic-server interceptor server} should be running.
+ * {@link https://github.com/zimicjs/zimic#http-interceptorstart `interceptor.start()`} and an
+ * {@link https://github.com/zimicjs/zimic#zimic-server interceptor server} should be running.
  *
- * @see {@link https://github.com/diego-aquino/zimic#httpinterceptor `HttpInterceptor` API reference}
+ * @see {@link https://github.com/zimicjs/zimic#httpinterceptor `HttpInterceptor` API reference}
  */
 export interface RemoteHttpInterceptor<Schema extends HttpServiceSchema> extends HttpInterceptor<Schema> {
   readonly type: 'remote';

--- a/packages/zimic/src/interceptor/http/interceptor/types/schema.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/types/schema.ts
@@ -3,7 +3,7 @@ import { HttpInterceptor } from './public';
 /**
  * A utility type to extract the schema of an HTTP interceptor.
  *
- * @see {@link https://github.com/diego-aquino/zimic#declaring-service-schemas Declaring service schemas}
+ * @see {@link https://github.com/zimicjs/zimic#declaring-service-schemas Declaring service schemas}
  */
 export type ExtractHttpInterceptorSchema<Interceptor> =
   Interceptor extends HttpInterceptor<infer Schema> ? Schema : never;

--- a/packages/zimic/src/interceptor/http/interceptorWorker/HttpInterceptorWorker.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/HttpInterceptorWorker.ts
@@ -324,7 +324,7 @@ abstract class HttpInterceptorWorker {
         formatObjectToLog(Object.fromEntries(request.searchParams)),
         '\n    Body:',
         formatObjectToLog(request.body),
-        '\n\nLearn more about unhandled requests: https://github.com/diego-aquino/zimic#unhandled-requests',
+        '\n\nLearn more about unhandled requests: https://github.com/zimicjs/zimic#unhandled-requests',
       ],
       { method: action === 'bypass' ? 'warn' : 'error' },
     );

--- a/packages/zimic/src/interceptor/http/interceptorWorker/errors/UnregisteredServiceWorkerError.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/errors/UnregisteredServiceWorkerError.ts
@@ -3,7 +3,7 @@ import { SERVICE_WORKER_FILE_NAME } from '@/cli/browser/shared/constants';
 /**
  * An error thrown when the browser mock service worker is not found.
  *
- * @see {@link https://github.com/diego-aquino/zimic#zimic-browser-init `zimic browser init` API reference}
+ * @see {@link https://github.com/zimicjs/zimic#zimic-browser-init `zimic browser init` API reference}
  */
 class UnregisteredServiceWorkerError extends Error {
   constructor() {
@@ -11,7 +11,7 @@ class UnregisteredServiceWorkerError extends Error {
       `[zimic] Failed to register the browser service worker: ` +
         `script '${window.location.origin}/${SERVICE_WORKER_FILE_NAME}' not found.\n\n` +
         'Did you forget to run "npx zimic browser init <public-directory>"?\n\n' +
-        'Learn more at https://github.com/diego-aquino/zimic#browser-post-install.',
+        'Learn more at https://github.com/zimicjs/zimic#browser-post-install.',
     );
     this.name = 'UnregisteredServiceWorkerError';
   }

--- a/packages/zimic/src/interceptor/http/namespace/types.ts
+++ b/packages/zimic/src/interceptor/http/namespace/types.ts
@@ -7,7 +7,7 @@ export interface HttpInterceptorNamespaceDefault {
    * Sets the default strategy for unhandled requests. If a request does not start with the base URL of any
    * interceptors, this strategy will be used. If a function is provided, it will be called with the unhandled request.
    * You can override this default for specific interceptors by using `onUnhandledRequest` in
-   * {@link https://github.com/diego-aquino/zimic#httpcreateinterceptor `http.createInterceptor`}.
+   * {@link https://github.com/zimicjs/zimic#httpcreateinterceptor `http.createInterceptor`}.
    *
    * @param strategy The default strategy to be set.
    */
@@ -17,7 +17,7 @@ export interface HttpInterceptorNamespaceDefault {
 /**
  * A set of interceptor resources for mocking HTTP requests.
  *
- * @see {@link https://github.com/diego-aquino/zimic#zimicinterceptor-api-reference `zimic/interceptor` API reference}
+ * @see {@link https://github.com/zimicjs/zimic#zimicinterceptor-api-reference `zimic/interceptor` API reference}
  */
 export interface HttpInterceptorNamespace {
   /**
@@ -27,8 +27,8 @@ export interface HttpInterceptorNamespace {
    * @returns The created HTTP interceptor.
    * @throws {InvalidURLError} If the base URL is invalid.
    * @throws {UnsupportedURLProtocolError} If the base URL protocol is not either `http` or `https`.
-   * @see {@link https://github.com/diego-aquino/zimic#httpcreateinterceptor `http.createInterceptor` API reference}
-   * @see {@link https://github.com/diego-aquino/zimic#declaring-http-service-schemas Declaring service schemas}
+   * @see {@link https://github.com/zimicjs/zimic#httpcreateinterceptor `http.createInterceptor` API reference}
+   * @see {@link https://github.com/zimicjs/zimic#declaring-http-service-schemas Declaring service schemas}
    */
   createInterceptor: typeof createHttpInterceptor;
 

--- a/packages/zimic/src/interceptor/http/requestHandler/types/public.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/types/public.ts
@@ -21,7 +21,7 @@ import {
 /**
  * A static headers restriction to match intercepted requests.
  *
- * @see {@link https://github.com/diego-aquino/zimic#http-handlerwithrestriction `handler.with()` API reference}
+ * @see {@link https://github.com/zimicjs/zimic#http-handlerwithrestriction `handler.with()` API reference}
  */
 export type HttpRequestHandlerHeadersStaticRestriction<
   Schema extends HttpServiceSchema,
@@ -34,7 +34,7 @@ export type HttpRequestHandlerHeadersStaticRestriction<
 /**
  * A static search params restriction to match intercepted requests.
  *
- * @see {@link https://github.com/diego-aquino/zimic#http-handlerwithrestriction `handler.with()` API reference}
+ * @see {@link https://github.com/zimicjs/zimic#http-handlerwithrestriction `handler.with()` API reference}
  */
 export type HttpRequestHandlerSearchParamsStaticRestriction<
   Schema extends HttpServiceSchema,
@@ -47,7 +47,7 @@ export type HttpRequestHandlerSearchParamsStaticRestriction<
 /**
  * A static body restriction to match intercepted requests.
  *
- * @see {@link https://github.com/diego-aquino/zimic#http-handlerwithrestriction `handler.with()` API reference}
+ * @see {@link https://github.com/zimicjs/zimic#http-handlerwithrestriction `handler.with()` API reference}
  */
 export type HttpRequestHandlerBodyStaticRestriction<
   Schema extends HttpServiceSchema,
@@ -58,7 +58,7 @@ export type HttpRequestHandlerBodyStaticRestriction<
 /**
  * A static restriction to match intercepted requests.
  *
- * @see {@link https://github.com/diego-aquino/zimic#http-handlerwithrestriction `handler.with()` API reference}
+ * @see {@link https://github.com/zimicjs/zimic#http-handlerwithrestriction `handler.with()` API reference}
  */
 export interface HttpRequestHandlerStaticRestriction<
   Schema extends HttpServiceSchema,
@@ -74,7 +74,7 @@ export interface HttpRequestHandlerStaticRestriction<
 /**
  * A computed restriction to match intercepted requests.
  *
- * @see {@link https://github.com/diego-aquino/zimic#http-handlerwithrestriction `handler.with()` API reference}
+ * @see {@link https://github.com/zimicjs/zimic#http-handlerwithrestriction `handler.with()` API reference}
  */
 export type HttpRequestHandlerComputedRestriction<
   Schema extends HttpServiceSchema,
@@ -85,7 +85,7 @@ export type HttpRequestHandlerComputedRestriction<
 /**
  * A restriction to match intercepted requests.
  *
- * @see {@link https://github.com/diego-aquino/zimic#http-handlerwithrestriction `handler.with()` API reference}
+ * @see {@link https://github.com/zimicjs/zimic#http-handlerwithrestriction `handler.with()` API reference}
  */
 export type HttpRequestHandlerRestriction<
   Schema extends HttpServiceSchema,
@@ -99,9 +99,9 @@ export type HttpRequestHandlerRestriction<
  * An HTTP request handler to declare responses for intercepted requests.
  *
  * When multiple handlers of the same interceptor match the same method and path, the _last_ handler created with
- * {@link https://github.com/diego-aquino/zimic#http-interceptormethodpath `interceptor.<method>(path)`} will be used.
+ * {@link https://github.com/zimicjs/zimic#http-interceptormethodpath `interceptor.<method>(path)`} will be used.
  *
- * @see {@link https://github.com/diego-aquino/zimic#httprequesthandler `HttpRequestHandler` API reference}
+ * @see {@link https://github.com/zimicjs/zimic#httprequesthandler `HttpRequestHandler` API reference}
  */
 export interface HttpRequestHandler<
   Schema extends HttpServiceSchema,
@@ -111,14 +111,14 @@ export interface HttpRequestHandler<
 > {
   /**
    * @returns The method that matches this handler.
-   * @see {@link https://github.com/diego-aquino/zimic#http-handlermethod `handler.method()` API reference}
+   * @see {@link https://github.com/zimicjs/zimic#http-handlermethod `handler.method()` API reference}
    */
   method: () => Method;
 
   /**
    * @returns The path that matches this handler. The base URL of the interceptor is not included, but it is used when
    *   matching requests.
-   * @see {@link https://github.com/diego-aquino/zimic#http-handlerpath `handler.path()` API reference}
+   * @see {@link https://github.com/zimicjs/zimic#http-handlerpath `handler.path()` API reference}
    */
   path: () => Path;
 
@@ -136,7 +136,7 @@ export interface HttpRequestHandler<
    *
    * @param restriction The restriction to match intercepted requests.
    * @returns The same handler, now considering the specified restriction.
-   * @see {@link https://github.com/diego-aquino/zimic#http-handlerwithrestriction `handler.with()` API reference}
+   * @see {@link https://github.com/zimicjs/zimic#http-handlerwithrestriction `handler.with()` API reference}
    */
 
   with: (
@@ -152,7 +152,7 @@ export interface HttpRequestHandler<
    * @param declaration The response declaration or a factory to create it.
    * @returns The same handler, now including type information about the response declaration based on the specified
    *   status code.
-   * @see {@link https://github.com/diego-aquino/zimic#http-handlerrespond `handler.respond()` API reference}
+   * @see {@link https://github.com/zimicjs/zimic#http-handlerrespond `handler.respond()` API reference}
    */
   respond: <StatusCode extends HttpServiceResponseSchemaStatusCode<Default<Default<Schema[Path][Method]>['response']>>>(
     declaration:
@@ -162,46 +162,46 @@ export interface HttpRequestHandler<
 
   /**
    * Clears any response declared with
-   * [`handler.respond(declaration)`](https://github.com/diego-aquino/zimic#http-handlerresponddeclaration), making the
+   * [`handler.respond(declaration)`](https://github.com/zimicjs/zimic#http-handlerresponddeclaration), making the
    * handler stop matching requests. The next handler, created before this one, that matches the same method and path
    * will be used if present. If not, the requests of the method and path will not be intercepted.
    *
    * To make the handler match requests again, register a new response with
-   * {@link https://github.com/diego-aquino/zimic#http-handlerrespond `handler.respond()`}.
+   * {@link https://github.com/zimicjs/zimic#http-handlerrespond `handler.respond()`}.
    *
    * This method is useful to skip a handler. It is more gentle than
-   * [`handler.clear()`](https://github.com/diego-aquino/zimic#http-handlerclear), as it only removed the response,
-   * keeping restrictions and intercepted requests.
+   * [`handler.clear()`](https://github.com/zimicjs/zimic#http-handlerclear), as it only removed the response, keeping
+   * restrictions and intercepted requests.
    *
    * @returns The same handler, now without a declared responses.
-   * @see {@link https://github.com/diego-aquino/zimic#http-handlerbypass `handler.bypass()` API reference}
+   * @see {@link https://github.com/zimicjs/zimic#http-handlerbypass `handler.bypass()` API reference}
    */
   bypass: () => HttpRequestHandler<Schema, Method, Path, StatusCode>;
 
   /**
    * Clears any response declared with
-   * [`handler.respond(declaration)`](https://github.com/diego-aquino/zimic#http-handlerresponddeclaration),
-   * restrictions declared with
-   * [`handler.with(restriction)`](https://github.com/diego-aquino/zimic#http-handlerwithrestriction), and intercepted
-   * requests, making the handler stop matching requests. The next handler, created before this one, that matches the
-   * same method and path will be used if present. If not, the requests of the method and path will not be intercepted.
+   * [`handler.respond(declaration)`](https://github.com/zimicjs/zimic#http-handlerresponddeclaration), restrictions
+   * declared with [`handler.with(restriction)`](https://github.com/zimicjs/zimic#http-handlerwithrestriction), and
+   * intercepted requests, making the handler stop matching requests. The next handler, created before this one, that
+   * matches the same method and path will be used if present. If not, the requests of the method and path will not be
+   * intercepted.
    *
    * To make the handler match requests again, register a new response with
-   * {@link https://github.com/diego-aquino/zimic#http-handlerrespond `handler.respond()`}.
+   * {@link https://github.com/zimicjs/zimic#http-handlerrespond `handler.respond()`}.
    *
    * This method is useful to reset handlers to a clean state between tests. It is more aggressive than
-   * [`handler.bypass()`](https://github.com/diego-aquino/zimic#http-handlerbypass), as it also clears restrictions and
+   * [`handler.bypass()`](https://github.com/zimicjs/zimic#http-handlerbypass), as it also clears restrictions and
    * intercepted requests.
    *
    * @returns The same handler, now cleared of any declared responses, restrictions, and intercepted requests.
-   * @see {@link https://github.com/diego-aquino/zimic#http-handlerclear `handler.clear()` API reference}
+   * @see {@link https://github.com/zimicjs/zimic#http-handlerclear `handler.clear()` API reference}
    */
   clear: () => HttpRequestHandler<Schema, Method, Path, StatusCode>;
 
   /**
    * @returns The intercepted requests that matched this handler, along with the responses returned to each of them.
    *   This is useful for testing that the correct requests were made by your application.
-   * @see {@link https://github.com/diego-aquino/zimic#http-handlerrequests `handler.requests()` API reference}
+   * @see {@link https://github.com/zimicjs/zimic#http-handlerrequests `handler.requests()` API reference}
    */
   requests:
     | (() => readonly TrackedHttpInterceptorRequest<Path, Default<Schema[Path][Method]>, StatusCode>[])
@@ -213,9 +213,9 @@ export interface HttpRequestHandler<
  * operations are synchronous and are executed in the same process where it was created.
  *
  * When multiple handlers of the same interceptor match the same method and path, the _last_ handler created with
- * {@link https://github.com/diego-aquino/zimic#http-interceptormethodpath `interceptor.<method>(path)`} will be used.
+ * {@link https://github.com/zimicjs/zimic#http-interceptormethodpath `interceptor.<method>(path)`} will be used.
  *
- * @see {@link https://github.com/diego-aquino/zimic#httprequesthandler `HttpRequestHandler` API reference}
+ * @see {@link https://github.com/zimicjs/zimic#httprequesthandler `HttpRequestHandler` API reference}
  */
 export interface LocalHttpRequestHandler<
   Schema extends HttpServiceSchema,
@@ -244,10 +244,9 @@ export interface LocalHttpRequestHandler<
 
 /**
  * A synced remote HTTP request handler. When a remote handler is synced, it is guaranteed that all of the mocking
- * operations were committed to the connected
- * {@link https://github.com/diego-aquino/zimic#zimic-server interceptor server}.
+ * operations were committed to the connected {@link https://github.com/zimicjs/zimic#zimic-server interceptor server}.
  *
- * @see {@link https://github.com/diego-aquino/zimic#httprequesthandler `HttpRequestHandler` API reference}
+ * @see {@link https://github.com/zimicjs/zimic#httprequesthandler `HttpRequestHandler` API reference}
  */
 export interface SyncedRemoteHttpRequestHandler<
   Schema extends HttpServiceSchema,
@@ -274,13 +273,12 @@ export interface SyncedRemoteHttpRequestHandler<
 
 /**
  * A pending remote HTTP request handler. When a remote handler is pending, it is not guaranteed that all of the mocking
- * operations were committed to the connected
- * {@link https://github.com/diego-aquino/zimic#zimic-server interceptor server}.
+ * operations were committed to the connected {@link https://github.com/zimicjs/zimic#zimic-server interceptor server}.
  *
  * To commit a remote interceptor, you can `await` it or use the methods {@link then handler.then()},
  * {@link catch handler.catch()}, and {@link finally handler.finally()}.
  *
- * @see {@link https://github.com/diego-aquino/zimic#httprequesthandler `HttpRequestHandler` API reference}
+ * @see {@link https://github.com/zimicjs/zimic#httprequesthandler `HttpRequestHandler` API reference}
  */
 export interface PendingRemoteHttpRequestHandler<
   Schema extends HttpServiceSchema,
@@ -290,7 +288,7 @@ export interface PendingRemoteHttpRequestHandler<
 > extends SyncedRemoteHttpRequestHandler<Schema, Method, Path, StatusCode> {
   /**
    * Waits for the remote handler to be synced with the connected
-   * {@link https://github.com/diego-aquino/zimic#zimic-server interceptor server}.
+   * {@link https://github.com/zimicjs/zimic#zimic-server interceptor server}.
    */
   then: <FulfilledResult = SyncedRemoteHttpRequestHandler<Schema, Method, Path, StatusCode>, RejectedResult = never>(
     onFulfilled?:
@@ -303,7 +301,7 @@ export interface PendingRemoteHttpRequestHandler<
 
   /**
    * Waits for the remote handler to be synced with the connected
-   * {@link https://github.com/diego-aquino/zimic#zimic-server interceptor server}.
+   * {@link https://github.com/zimicjs/zimic#zimic-server interceptor server}.
    */
   catch: <RejectedResult = never>(
     onRejected?: ((reason: unknown) => PossiblePromise<RejectedResult>) | null,
@@ -311,7 +309,7 @@ export interface PendingRemoteHttpRequestHandler<
 
   /**
    * Waits for the remote handler to be synced with the connected
-   * {@link https://github.com/diego-aquino/zimic#zimic-server interceptor server}.
+   * {@link https://github.com/zimicjs/zimic#zimic-server interceptor server}.
    */
   finally: (
     onFinally?: (() => void) | null,
@@ -321,12 +319,12 @@ export interface PendingRemoteHttpRequestHandler<
 /**
  * A remote HTTP request handler to declare responses for intercepted requests. In a remote handler, the mocking
  * operations are asynchronous and include remote calls to the connected
- * {@link https://github.com/diego-aquino/zimic#zimic-server interceptor server}.
+ * {@link https://github.com/zimicjs/zimic#zimic-server interceptor server}.
  *
  * When multiple handlers of the same interceptor match the same method and path, the _last_ handler created with
- * {@link https://github.com/diego-aquino/zimic#http-interceptormethodpath `interceptor.<method>(path)`} will be used.
+ * {@link https://github.com/zimicjs/zimic#http-interceptormethodpath `interceptor.<method>(path)`} will be used.
  *
- * @see {@link https://github.com/diego-aquino/zimic#httprequesthandler `HttpRequestHandler` API reference}
+ * @see {@link https://github.com/zimicjs/zimic#httprequesthandler `HttpRequestHandler` API reference}
  */
 export interface RemoteHttpRequestHandler<
   Schema extends HttpServiceSchema,

--- a/packages/zimic/src/interceptor/index.ts
+++ b/packages/zimic/src/interceptor/index.ts
@@ -44,6 +44,6 @@ export type { HttpInterceptorNamespace, HttpInterceptorNamespaceDefault } from '
 /**
  * A set of interceptor resources for mocking HTTP requests.
  *
- * @see {@link https://github.com/diego-aquino/zimic#zimicinterceptor-api-reference `zimic/interceptor` API reference}
+ * @see {@link https://github.com/zimicjs/zimic#zimicinterceptor-api-reference `zimic/interceptor` API reference}
  */
 export const http = Object.freeze(new HttpInterceptorNamespace());

--- a/release.config.js
+++ b/release.config.js
@@ -11,7 +11,7 @@ module.exports = {
     },
   ],
   github: {
-    repositoryOwner: 'diego-aquino',
+    repositoryOwner: 'zimicjs',
     repositoryName: 'zimic',
     productionBranch: 'main',
   },


### PR DESCRIPTION
### Documentation
- Migrated all links from `diego-aquino/zimic` to `zimicjs/zimic`.

### Chore
- [#zimic] Removed the upper version limit for typescript as a peer dependency. Only a lower limit is necessary.

Closes #168.