### PR TITLE
fix: include server export types

### DIFF
--- a/packages/tsconfig/tsconfig.base.json
+++ b/packages/tsconfig/tsconfig.base.json
@@ -10,6 +10,7 @@
     "forceConsistentCasingInFileNames": true,
     "inlineSources": false,
     "isolatedModules": true,
+    "module": "esnext",
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "noUnusedLocals": false,

--- a/packages/tsconfig/tsconfig.node.json
+++ b/packages/tsconfig/tsconfig.node.json
@@ -4,7 +4,6 @@
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "lib": ["esnext", "webworker"],
-    "module": "esnext",
     "incremental": false
   }
 }

--- a/packages/tsconfig/tsconfig.react.json
+++ b/packages/tsconfig/tsconfig.react.json
@@ -4,7 +4,6 @@
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "lib": ["dom", "dom.iterable", "esnext"],
-    "module": "esnext",
     "jsx": "preserve",
     "incremental": true,
     "allowJs": true,

--- a/packages/zimic/interceptor/browser.d.ts
+++ b/packages/zimic/interceptor/browser.d.ts
@@ -1,1 +1,0 @@
-export * from '../dist/interceptor/browser';

--- a/packages/zimic/interceptor/node.d.ts
+++ b/packages/zimic/interceptor/node.d.ts
@@ -1,1 +1,0 @@
-export * from '../dist/interceptor/node';

--- a/packages/zimic/package.json
+++ b/packages/zimic/package.json
@@ -32,8 +32,7 @@
     "dist",
     "index.d.ts",
     "interceptor.d.ts",
-    "interceptor/node.d.ts",
-    "interceptor/browser.d.ts"
+    "interceptor/server.d.ts"
   ],
   "types": "index.d.ts",
   "bin": {

--- a/packages/zimic/package.json
+++ b/packages/zimic/package.json
@@ -32,7 +32,7 @@
     "dist",
     "index.d.ts",
     "interceptor.d.ts",
-    "interceptor/server.d.ts"
+    "server.d.ts"
   ],
   "types": "index.d.ts",
   "bin": {

--- a/packages/zimic/tsup.config.ts
+++ b/packages/zimic/tsup.config.ts
@@ -10,7 +10,7 @@ const sharedConfig: Options = {
   sourcemap: true,
   treeshake: isProductionBuild,
   minify: false,
-  clean: true,
+  clean: false,
   env: {
     SERVER_ACCESS_CONTROL_MAX_AGE: '',
   },
@@ -22,6 +22,12 @@ export default defineConfig([
     entry: {
       index: 'src/index.ts',
       interceptor: 'src/interceptor/index.ts',
+    },
+  },
+  {
+    ...sharedConfig,
+    platform: 'node',
+    entry: {
       server: 'src/interceptor/server/index.ts',
     },
   },


### PR DESCRIPTION
### Build
- [#zimic] Include server type entry point when publishing.

### Refactoring
- [#tsconfig] Moved the common `module` option to the base tsconfig file.

### Chore
- [#zimic] Removed no longer necessary type entry points.
