### PR TITLE
feat(#zimic): computed response and interceptor server error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -651,7 +651,8 @@ by default.
 >
 > If you expected a request to be handled, but it was not, make sure that the interceptor
 > [base URL](#httpcreateinterceptor), [path](#http-interceptormethodpath), [method](#http-interceptormethodpath), and
-> [restrictions](#http-handlerwithrestriction) correctly match the request.
+> [restrictions](#http-handlerwithrestriction) correctly match the request. Additionally, confirm that no errors
+> occurred while creating the response.
 
 In a [local interceptor](#local-http-interceptors), unhandled requests are always bypassed, meaning that they pass
 through the interceptor and reach the real network. [Remote interceptors](#remote-http-interceptors) in pair with an

--- a/packages/zimic/src/cli/__tests__/server.cli.node.test.ts
+++ b/packages/zimic/src/cli/__tests__/server.cli.node.test.ts
@@ -5,12 +5,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { http } from '@/interceptor';
 import { verifyUnhandledRequestMessage } from '@/interceptor/http/interceptor/__tests__/shared/utils';
+import { createHttpInterceptor } from '@/interceptor/http/interceptor/factory';
 import { DEFAULT_SERVER_LIFE_CYCLE_TIMEOUT } from '@/interceptor/server/constants';
 import { PossiblePromise } from '@/types/utils';
 import { getCrypto } from '@/utils/crypto';
 import { HttpServerStartTimeoutError, HttpServerStopTimeoutError } from '@/utils/http';
 import { CommandError, PROCESS_EXIT_EVENTS } from '@/utils/processes';
 import WebSocketClient from '@/webSocket/WebSocketClient';
+import WebSocketServer from '@/webSocket/WebSocketServer';
 import { usingIgnoredConsole } from '@tests/utils/console';
 import { expectFetchError } from '@tests/utils/fetch';
 
@@ -407,6 +409,7 @@ describe('CLI (server)', async () => {
 
     it.each(PROCESS_EXIT_EVENTS)('should stop the sever after a process exit event: %s', async (exitEvent) => {
       const exitEventListeners = watchExitEventListeners(exitEvent);
+
       processArgvSpy.mockReturnValue(['node', 'cli.js', 'server', 'start']);
 
       await usingIgnoredConsole(['log'], async (spies) => {
@@ -435,6 +438,7 @@ describe('CLI (server)', async () => {
 
     it('should stop the server even if a client is connected', async () => {
       const exitEventListeners = watchExitEventListeners(PROCESS_EXIT_EVENTS[0]);
+
       processArgvSpy.mockReturnValue(['node', 'cli.js', 'server', 'start']);
 
       await usingIgnoredConsole(['log'], async (spies) => {
@@ -451,8 +455,6 @@ describe('CLI (server)', async () => {
           `Server is running on http://localhost:${server!.port()}`,
         );
 
-        expect(exitEventListeners).toHaveLength(1);
-
         const webSocketClient = new WebSocketClient({
           url: `ws://localhost:${server!.port()}`,
         });
@@ -460,6 +462,8 @@ describe('CLI (server)', async () => {
         try {
           await webSocketClient.start();
           expect(webSocketClient.isRunning()).toBe(true);
+
+          expect(exitEventListeners).toHaveLength(1);
 
           for (const listener of exitEventListeners) {
             await listener();
@@ -482,6 +486,7 @@ describe('CLI (server)', async () => {
       'should show an error if logging is enabled when a request is received and does not match any interceptors: override default $overrideDefault',
       async ({ overrideDefault }) => {
         const exitEventListeners = watchExitEventListeners(PROCESS_EXIT_EVENTS[0]);
+
         processArgvSpy.mockReturnValue([
           'node',
           'cli.js',
@@ -500,41 +505,45 @@ describe('CLI (server)', async () => {
           });
         }
 
-        await usingIgnoredConsole(['log', 'warn', 'error'], async (spies) => {
-          await runCLI();
+        try {
+          await usingIgnoredConsole(['log', 'warn', 'error'], async (spies) => {
+            await runCLI();
 
-          expect(server).toBeDefined();
-          expect(server!.isRunning()).toBe(true);
-          expect(server!.hostname()).toBe('localhost');
-          expect(server!.port()).toBeGreaterThan(0);
+            expect(server).toBeDefined();
+            expect(server!.isRunning()).toBe(true);
+            expect(server!.hostname()).toBe('localhost');
+            expect(server!.port()).toBeGreaterThan(0);
 
-          expect(spies.log).toHaveBeenCalledTimes(1);
-          expect(spies.warn).toHaveBeenCalledTimes(0);
-          expect(spies.error).toHaveBeenCalledTimes(0);
+            expect(spies.log).toHaveBeenCalledTimes(1);
+            expect(spies.warn).toHaveBeenCalledTimes(0);
+            expect(spies.error).toHaveBeenCalledTimes(0);
 
-          expect(spies.log).toHaveBeenCalledWith(
-            `${chalk.cyan('[zimic]')}`,
-            `Server is running on http://localhost:${server!.port()}`,
-          );
+            expect(spies.log).toHaveBeenCalledWith(
+              `${chalk.cyan('[zimic]')}`,
+              `Server is running on http://localhost:${server!.port()}`,
+            );
 
-          expect(exitEventListeners).toHaveLength(1);
+            const request = new Request(`http://localhost:${server!.port()}`, { method: 'GET' });
 
-          const request = new Request(`http://localhost:${server!.port()}`, { method: 'GET' });
+            const response = fetch(request);
+            await expectFetchError(response);
 
-          const response = fetch(request);
-          await expectFetchError(response);
+            expect(spies.log).toHaveBeenCalledTimes(1);
+            expect(spies.warn).toHaveBeenCalledTimes(0);
+            expect(spies.error).toHaveBeenCalledTimes(1);
 
-          expect(spies.log).toHaveBeenCalledTimes(1);
-          expect(spies.warn).toHaveBeenCalledTimes(0);
-          expect(spies.error).toHaveBeenCalledTimes(1);
-
-          const errorMessage = spies.error.mock.calls[0].join(' ');
-          await verifyUnhandledRequestMessage(errorMessage, {
-            type: 'error',
-            platform: 'node',
-            request,
+            const errorMessage = spies.error.mock.calls[0].join(' ');
+            await verifyUnhandledRequestMessage(errorMessage, {
+              type: 'error',
+              platform: 'node',
+              request,
+            });
           });
-        });
+        } finally {
+          for (const listener of exitEventListeners) {
+            await listener();
+          }
+        }
       },
     );
 
@@ -556,35 +565,103 @@ describe('CLI (server)', async () => {
           http.default.onUnhandledRequest(vi.fn());
         }
 
-        await usingIgnoredConsole(['log', 'warn', 'error'], async (spies) => {
+        try {
+          await usingIgnoredConsole(['log', 'warn', 'error'], async (spies) => {
+            await runCLI();
+
+            expect(server).toBeDefined();
+            expect(server!.isRunning()).toBe(true);
+            expect(server!.hostname()).toBe('localhost');
+            expect(server!.port()).toBeGreaterThan(0);
+
+            expect(spies.log).toHaveBeenCalledTimes(1);
+            expect(spies.warn).toHaveBeenCalledTimes(0);
+            expect(spies.error).toHaveBeenCalledTimes(0);
+
+            expect(spies.log).toHaveBeenCalledWith(
+              `${chalk.cyan('[zimic]')}`,
+              `Server is running on http://localhost:${server!.port()}`,
+            );
+
+            const request = new Request(`http://localhost:${server!.port()}`, { method: 'GET' });
+
+            const response = fetch(request);
+            await expectFetchError(response);
+
+            expect(spies.log).toHaveBeenCalledTimes(1);
+            expect(spies.warn).toHaveBeenCalledTimes(0);
+            expect(spies.error).toHaveBeenCalledTimes(0);
+          });
+        } finally {
+          for (const listener of exitEventListeners) {
+            await listener();
+          }
+        }
+      },
+    );
+
+    it('should log an error and reject the request if it could not be handled due to an error', async () => {
+      const exitEventListeners = watchExitEventListeners(PROCESS_EXIT_EVENTS[0]);
+
+      const port = 5000;
+
+      processArgvSpy.mockReturnValue([
+        'node',
+        'cli.js',
+        'server',
+        'start',
+        '--port',
+        port.toString(),
+        '--log-unhandled-requests',
+      ]);
+
+      const interceptor = createHttpInterceptor<{
+        '/users': {
+          GET: { response: { 204: {} } };
+        };
+      }>({
+        type: 'remote',
+        baseURL: `http://localhost:${port}`,
+      });
+
+      try {
+        await usingIgnoredConsole(['error', 'log'], async (spies) => {
           await runCLI();
 
           expect(server).toBeDefined();
           expect(server!.isRunning()).toBe(true);
           expect(server!.hostname()).toBe('localhost');
-          expect(server!.port()).toBeGreaterThan(0);
+          expect(server!.port()).toBe(port);
 
-          expect(spies.log).toHaveBeenCalledTimes(1);
-          expect(spies.warn).toHaveBeenCalledTimes(0);
-          expect(spies.error).toHaveBeenCalledTimes(0);
+          await interceptor.start();
+          await interceptor.get('/users').respond({ status: 204 });
 
-          expect(spies.log).toHaveBeenCalledWith(
-            `${chalk.cyan('[zimic]')}`,
-            `Server is running on http://localhost:${server!.port()}`,
-          );
+          const error = new Error('An error ocurred.');
+          vi.spyOn(WebSocketServer.prototype, 'request').mockRejectedValue(error);
 
-          expect(exitEventListeners).toHaveLength(1);
+          const request = new Request(`http://localhost:${port}/users`, { method: 'GET' });
+          const fetchPromise = fetch(request);
+          await expectFetchError(fetchPromise);
 
-          const request = new Request(`http://localhost:${server!.port()}`, { method: 'GET' });
+          expect(server!.isRunning()).toBe(true);
 
-          const response = fetch(request);
-          await expectFetchError(response);
+          expect(spies.error).toHaveBeenCalledTimes(2);
+          expect(spies.error.mock.calls[0]).toEqual([error]);
 
-          expect(spies.log).toHaveBeenCalledTimes(1);
-          expect(spies.warn).toHaveBeenCalledTimes(0);
-          expect(spies.error).toHaveBeenCalledTimes(0);
+          const errorMessage = spies.error.mock.calls[1].join(' ');
+          await verifyUnhandledRequestMessage(errorMessage, {
+            type: 'error',
+            platform: 'node',
+            request,
+          });
         });
-      },
-    );
+      } finally {
+        await interceptor.stop();
+
+        for (const listener of exitEventListeners) {
+          await listener();
+        }
+      }
+    });
   });
 });

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/index.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/index.ts
@@ -73,7 +73,7 @@ export function declareSharedHttpInterceptorTests(options: SharedHttpInterceptor
       declareBaseURLHttpInterceptorTests(runtimeOptions);
     });
 
-    describe('Handler', () => {
+    describe('Handlers', () => {
       declareHandlerHttpInterceptorTests(runtimeOptions);
     });
 

--- a/packages/zimic/src/interceptor/http/interceptorWorker/HttpInterceptorWorker.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/HttpInterceptorWorker.ts
@@ -112,17 +112,21 @@ abstract class HttpInterceptorWorker {
     const action: UnhandledRequestStrategy.Action = this.type === 'local' ? 'bypass' : 'reject';
 
     if (typeof declarationOrHandler === 'function') {
-      await HttpInterceptorWorker.useUnhandledRequestStrategyHandler(request, declarationOrHandler, action);
+      await HttpInterceptorWorker.logUnhandledRequestWithHandler(request, declarationOrHandler, action);
     } else if (declarationOrHandler?.log !== undefined) {
-      await HttpInterceptorWorker.useStaticUnhandledStrategy(request, { log: declarationOrHandler.log }, action);
+      await HttpInterceptorWorker.logUnhandledRequestWithStaticStrategy(
+        request,
+        { log: declarationOrHandler.log },
+        action,
+      );
     } else if (typeof defaultDeclarationOrHandler === 'function') {
-      await HttpInterceptorWorker.useUnhandledRequestStrategyHandler(request, defaultDeclarationOrHandler, action);
+      await HttpInterceptorWorker.logUnhandledRequestWithHandler(request, defaultDeclarationOrHandler, action);
     } else {
-      await HttpInterceptorWorker.useStaticUnhandledStrategy(request, defaultDeclarationOrHandler, action);
+      await HttpInterceptorWorker.logUnhandledRequestWithStaticStrategy(request, defaultDeclarationOrHandler, action);
     }
   }
 
-  static async useUnhandledRequestStrategyHandler(
+  static async logUnhandledRequestWithHandler(
     request: Request,
     handler: UnhandledRequestStrategy.Handler,
     action: UnhandledRequestStrategy.Action,
@@ -140,7 +144,7 @@ abstract class HttpInterceptorWorker {
     }
   }
 
-  static async useStaticUnhandledStrategy(
+  static async logUnhandledRequestWithStaticStrategy(
     request: Request,
     declaration: Required<UnhandledRequestStrategy.Declaration>,
     action: UnhandledRequestStrategy.Action,

--- a/packages/zimic/src/interceptor/http/interceptorWorker/HttpInterceptorWorker.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/HttpInterceptorWorker.ts
@@ -423,7 +423,7 @@ abstract class HttpInterceptorWorker {
 
     logWithPrefix(
       [
-        `${action === 'bypass' ? 'Warning:' : 'Error:'} Request did not match any handlers and was ` +
+        `${action === 'bypass' ? 'Warning:' : 'Error:'} Request was not handled and was ` +
           `${action === 'bypass' ? chalk.yellow('bypassed') : chalk.red('rejected')}.\n\n `,
         `${request.method} ${request.url}`,
         '\n    Headers:',

--- a/packages/zimic/src/interceptor/http/interceptorWorker/RemoteHttpInterceptorWorker.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/RemoteHttpInterceptorWorker.ts
@@ -72,12 +72,19 @@ class RemoteHttpInterceptorWorker extends HttpInterceptorWorker {
 
     const handler = this.httpHandlers.get(handlerId);
     const request = deserializeRequest(serializedRequest);
-    const rawResponse = (await handler?.createResponse({ request })) ?? null;
-    const response = rawResponse && request.method === 'HEAD' ? new Response(null, rawResponse) : rawResponse;
 
-    if (response) {
-      return { response: await serializeResponse(response) };
-    } else {
+    try {
+      const rawResponse = (await handler?.createResponse({ request })) ?? null;
+      const response = rawResponse && request.method === 'HEAD' ? new Response(null, rawResponse) : rawResponse;
+
+      if (response) {
+        return { response: await serializeResponse(response) };
+      } else {
+        await super.handleUnhandledRequest(request);
+        return { response: null };
+      }
+    } catch (error) {
+      console.error(error);
       await super.handleUnhandledRequest(request);
       return { response: null };
     }


### PR DESCRIPTION
### Features
- [#zimic] Added error handling mechanisms for when computed response handlers throw or the interceptor server could not handle a request due to an error. In both cases, the request is treated as bypassed (local) or rejected (remote) and logged to the console as unhandled.

### Documentation
- [#zimic] Improved the unhandled request message and added a sentence mentioning that errors might cause a request to be unhandled.

Closes #190.