### PR TITLE
feat(#zimic): support non-json body restrictions (#14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 >
 > Check our [roadmap to v1](https://github.com/orgs/zimicjs/projects/1/views/5). Contributors and ideas are welcome!
 
-Zimic is a lightweight, TypeScript-first HTTP request mocking library, inspired by
+Zimic is a lightweight, thoroughly tested, TypeScript-first HTTP request mocking library, inspired by
 [Zod](https://github.com/colinhacks/zod)'s type inference and using [MSW](https://github.com/mswjs/msw) under the hood.
 
 ## Features

--- a/packages/zimic/src/http/formData/HttpFormData.ts
+++ b/packages/zimic/src/http/formData/HttpFormData.ts
@@ -1,5 +1,5 @@
 import { ArrayItemIfArray, ArrayKey, Defined, NonArrayKey, ReplaceBy } from '@/types/utils';
-import { fileContains, fileEquals } from '@/utils/files';
+import { fileEquals } from '@/utils/files';
 
 import { HttpFormDataSchema } from './types';
 
@@ -177,8 +177,8 @@ class HttpFormData<Schema extends HttpFormDataSchema = HttpFormDataSchema> exten
       for (const value of values) {
         if (
           value === otherValue ||
-          (typeof value === 'string' && typeof otherValue === 'string' && value.includes(otherValue)) ||
-          (value instanceof Blob && otherValue instanceof Blob && (await fileContains(value, otherValue)))
+          (typeof value === 'string' && typeof otherValue === 'string' && value === otherValue) ||
+          (value instanceof Blob && otherValue instanceof Blob && (await fileEquals(value, otherValue)))
         ) {
           valueExists = true;
           break;

--- a/packages/zimic/src/http/formData/HttpFormData.ts
+++ b/packages/zimic/src/http/formData/HttpFormData.ts
@@ -146,10 +146,8 @@ class HttpFormData<Schema extends HttpFormDataSchema = HttpFormDataSchema> exten
     }
 
     for (const key of this.keys()) {
-      const otherValues = super.getAll.call(otherData, key);
-
-      const haveSameNumberOfValues = otherValues.length === super.getAll.call(this, key).length;
-      if (!haveSameNumberOfValues) {
+      const otherHasKey = super.has.call(otherData, key);
+      if (!otherHasKey) {
         return false;
       }
     }

--- a/packages/zimic/src/http/formData/__tests__/HttpFormData.test.ts
+++ b/packages/zimic/src/http/formData/__tests__/HttpFormData.test.ts
@@ -468,7 +468,7 @@ describe('HttpFormData', async () => {
     expect(await formData.contains(otherFormData)).toBe(false);
 
     formData.append('descriptions', description);
-    expect(await formData.contains(otherFormData)).toBe(true);
+    expect(await formData.contains(otherFormData)).toBe(false);
 
     otherFormData.delete('descriptions');
     expect(await formData.contains(otherFormData)).toBe(true);
@@ -490,5 +490,8 @@ describe('HttpFormData', async () => {
 
     formData.delete('blob');
     expect(await formData.contains(otherFormData)).toBe(true);
+
+    formData.delete('description');
+    expect(await formData.contains(otherFormData)).toBe(false);
   });
 });

--- a/packages/zimic/src/http/formData/__tests__/HttpFormData.test.ts
+++ b/packages/zimic/src/http/formData/__tests__/HttpFormData.test.ts
@@ -337,12 +337,14 @@ describe('HttpFormData', async () => {
       file?: File;
       blob: Blob[];
       description: string;
+      descriptions: string[];
     }>();
 
     const otherFormData = new HttpFormData<{
       file?: File;
       blob: Blob[];
       description: string;
+      descriptions: string[];
     }>();
 
     expect(await formData.equals(otherFormData)).toBe(true);
@@ -357,10 +359,17 @@ describe('HttpFormData', async () => {
     otherFormData.append('blob', blob, blobName);
     expect(await formData.equals(otherFormData)).toBe(false);
 
+    formData.delete('blob');
     otherFormData.delete('blob');
+
+    formData.append('blob', blob, blobName);
+    otherFormData.append('blob', blob);
     expect(await formData.equals(otherFormData)).toBe(false);
 
-    otherFormData.append('blob', blob);
+    formData.delete('blob');
+    expect(await formData.equals(otherFormData)).toBe(false);
+
+    formData.append('blob', blob);
     expect(await formData.equals(otherFormData)).toBe(true);
 
     otherFormData.set('description', description);
@@ -369,6 +378,21 @@ describe('HttpFormData', async () => {
     otherFormData.delete('description');
     expect(await formData.equals(otherFormData)).toBe(true);
 
+    formData.append('descriptions', description);
+    expect(await formData.equals(otherFormData)).toBe(false);
+
+    otherFormData.append('descriptions', description);
+    expect(await formData.equals(otherFormData)).toBe(true);
+
+    otherFormData.append('descriptions', description.slice(0, -1));
+    expect(await formData.equals(otherFormData)).toBe(false);
+
+    formData.append('descriptions', description.slice(0, -1));
+    expect(await formData.equals(otherFormData)).toBe(true);
+
+    otherFormData.delete('descriptions');
+    expect(await formData.equals(otherFormData)).toBe(false);
+
     otherFormData.set('description', description);
     otherFormData.delete('file');
 
@@ -376,6 +400,9 @@ describe('HttpFormData', async () => {
 
     formData.delete('file');
     formData.set('description', description);
+    expect(await formData.equals(otherFormData)).toBe(false);
+
+    formData.delete('descriptions');
     expect(await formData.equals(otherFormData)).toBe(true);
 
     otherFormData.delete('blob');
@@ -390,12 +417,14 @@ describe('HttpFormData', async () => {
       file?: File;
       blob: Blob[];
       description: string;
+      descriptions: string[];
     }>();
 
     const otherFormData = new HttpFormData<{
       file?: File;
       blob: Blob[];
       description: string;
+      descriptions: string[];
     }>();
 
     expect(await formData.contains(otherFormData)).toBe(true);
@@ -410,7 +439,20 @@ describe('HttpFormData', async () => {
     otherFormData.append('blob', blob, blobName);
     expect(await formData.contains(otherFormData)).toBe(false);
 
+    formData.delete('blob');
     otherFormData.delete('blob');
+
+    formData.append('blob', blob, blobName);
+    otherFormData.append('blob', blob);
+    expect(await formData.contains(otherFormData)).toBe(true);
+
+    otherFormData.delete('blob');
+    expect(await formData.contains(otherFormData)).toBe(true);
+
+    otherFormData.append('blob', blob);
+    expect(await formData.contains(otherFormData)).toBe(true);
+
+    formData.append('blob', blob);
     expect(await formData.contains(otherFormData)).toBe(true);
 
     otherFormData.append('blob', blob);
@@ -422,6 +464,21 @@ describe('HttpFormData', async () => {
     otherFormData.delete('description');
     expect(await formData.contains(otherFormData)).toBe(true);
 
+    formData.append('descriptions', description);
+    expect(await formData.contains(otherFormData)).toBe(true);
+
+    otherFormData.append('descriptions', description);
+    expect(await formData.contains(otherFormData)).toBe(true);
+
+    otherFormData.append('descriptions', description.slice(0, -1));
+    expect(await formData.contains(otherFormData)).toBe(false);
+
+    formData.append('descriptions', description);
+    expect(await formData.contains(otherFormData)).toBe(true);
+
+    otherFormData.delete('descriptions');
+    expect(await formData.contains(otherFormData)).toBe(true);
+
     otherFormData.set('description', description);
     otherFormData.delete('file');
 
@@ -431,13 +488,13 @@ describe('HttpFormData', async () => {
     formData.set('description', description);
     expect(await formData.contains(otherFormData)).toBe(true);
 
+    formData.delete('descriptions');
+    expect(await formData.contains(otherFormData)).toBe(true);
+
     otherFormData.delete('blob');
     expect(await formData.contains(otherFormData)).toBe(true);
 
     formData.delete('blob');
     expect(await formData.contains(otherFormData)).toBe(true);
-
-    formData.delete('description');
-    expect(await formData.contains(otherFormData)).toBe(false);
   });
 });

--- a/packages/zimic/src/http/formData/__tests__/HttpFormData.test.ts
+++ b/packages/zimic/src/http/formData/__tests__/HttpFormData.test.ts
@@ -444,13 +444,7 @@ describe('HttpFormData', async () => {
 
     formData.append('blob', blob, blobName);
     otherFormData.append('blob', blob);
-    expect(await formData.contains(otherFormData)).toBe(true);
-
-    otherFormData.delete('blob');
-    expect(await formData.contains(otherFormData)).toBe(true);
-
-    otherFormData.append('blob', blob);
-    expect(await formData.contains(otherFormData)).toBe(true);
+    expect(await formData.contains(otherFormData)).toBe(false);
 
     formData.append('blob', blob);
     expect(await formData.contains(otherFormData)).toBe(true);

--- a/packages/zimic/src/http/headers/HttpHeaders.ts
+++ b/packages/zimic/src/http/headers/HttpHeaders.ts
@@ -151,8 +151,7 @@ class HttpHeaders<Schema extends HttpHeadersSchema = HttpHeadersSchema> extends 
     return value
       .split(',')
       .map((item) => item.trim())
-      .filter((item) => item.length > 0)
-      .sort();
+      .filter((item) => item.length > 0);
   }
 }
 

--- a/packages/zimic/src/http/headers/HttpHeaders.ts
+++ b/packages/zimic/src/http/headers/HttpHeaders.ts
@@ -133,22 +133,14 @@ class HttpHeaders<Schema extends HttpHeadersSchema = HttpHeadersSchema> extends 
       const otherValueItems = this.splitHeaderValues(otherValue);
 
       const haveCompatibleNumberOfValues = valueItems.length >= otherValueItems.length;
-
       if (!haveCompatibleNumberOfValues) {
         return false;
       }
 
-      let valueExists = false;
-
-      for (const valueItem of otherValueItems) {
-        if (valueItems.some((item) => item.includes(valueItem))) {
-          valueExists = true;
-          break;
+      for (const otherValueItem of otherValueItems) {
+        if (!valueItems.includes(otherValueItem)) {
+          return false;
         }
-      }
-
-      if (!valueExists) {
-        return false;
       }
     }
 

--- a/packages/zimic/src/http/headers/__tests__/HttpHeaders.test.ts
+++ b/packages/zimic/src/http/headers/__tests__/HttpHeaders.test.ts
@@ -374,6 +374,23 @@ describe('HttpHeaders', () => {
     expect(headers.equals(otherHeaders)).toBe(false);
     headers.delete('keep-alive');
     expect(headers.equals(otherHeaders)).toBe(true);
+
+    headers.set('accept', '*/*');
+    headers.append('accept', 'application/json');
+
+    otherHeaders.set('accept', 'application/json');
+    expect(headers.equals(otherHeaders)).toBe(false);
+
+    otherHeaders.append('accept', '*/*');
+    expect(headers.equals(otherHeaders)).toBe(true);
+
+    otherHeaders.delete('accept');
+    otherHeaders.set('accept', 'application');
+    otherHeaders.append('accept', '*/*');
+    expect(headers.equals(otherHeaders)).toBe(false);
+
+    otherHeaders.append('accept', '*/*');
+    expect(headers.equals(otherHeaders)).toBe(false);
   });
 
   it('should support checking containment with other headers', () => {
@@ -433,5 +450,22 @@ describe('HttpHeaders', () => {
     expect(headers.contains(otherHeaders)).toBe(true);
     headers.delete('keep-alive');
     expect(headers.contains(otherHeaders)).toBe(true);
+
+    headers.set('accept', '*/*');
+    headers.append('accept', 'application/json');
+
+    otherHeaders.set('accept', 'application/json');
+    expect(headers.contains(otherHeaders)).toBe(true);
+
+    otherHeaders.append('accept', '*/*');
+    expect(headers.contains(otherHeaders)).toBe(true);
+
+    otherHeaders.delete('accept');
+    otherHeaders.set('accept', 'application');
+    otherHeaders.append('accept', '*/*');
+    expect(headers.contains(otherHeaders)).toBe(true);
+
+    otherHeaders.append('accept', '*/*');
+    expect(headers.contains(otherHeaders)).toBe(false);
   });
 });

--- a/packages/zimic/src/http/headers/__tests__/HttpHeaders.test.ts
+++ b/packages/zimic/src/http/headers/__tests__/HttpHeaders.test.ts
@@ -463,7 +463,7 @@ describe('HttpHeaders', () => {
     otherHeaders.delete('accept');
     otherHeaders.set('accept', 'application');
     otherHeaders.append('accept', '*/*');
-    expect(headers.contains(otherHeaders)).toBe(true);
+    expect(headers.contains(otherHeaders)).toBe(false);
 
     otherHeaders.append('accept', '*/*');
     expect(headers.contains(otherHeaders)).toBe(false);

--- a/packages/zimic/src/http/searchParams/HttpSearchParams.ts
+++ b/packages/zimic/src/http/searchParams/HttpSearchParams.ts
@@ -106,7 +106,29 @@ class HttpSearchParams<Schema extends HttpSearchParamsSchema = HttpSearchParamsS
    * @returns `true` if the search parameters are equal, `false` otherwise.
    */
   equals<OtherSchema extends Schema>(otherParams: HttpSearchParams<OtherSchema>): boolean {
-    return this.contains(otherParams) && this.size === otherParams.size;
+    for (const [key, otherValue] of otherParams.entries()) {
+      const values = super.getAll.call(this, key);
+
+      const haveSameNumberOfValues = values.length === super.getAll.call(otherParams, key).length;
+      if (!haveSameNumberOfValues) {
+        return false;
+      }
+
+      let valueExists = false;
+
+      for (const value of values) {
+        if (value === otherValue) {
+          valueExists = true;
+          break;
+        }
+      }
+
+      if (!valueExists) {
+        return false;
+      }
+    }
+
+    return this.size === otherParams.size;
   }
 
   /**
@@ -118,11 +140,28 @@ class HttpSearchParams<Schema extends HttpSearchParamsSchema = HttpSearchParamsS
    * @returns `true` if these search parameters contain the other search parameters, `false` otherwise.
    */
   contains<OtherSchema extends Schema>(otherParams: HttpSearchParams<OtherSchema>): boolean {
-    for (const [key, value] of otherParams.entries()) {
-      if (!super.has.call(this, key, value)) {
+    for (const [key, otherValue] of otherParams.entries()) {
+      const values = super.getAll.call(this, key);
+
+      const haveCompatibleNumberOfValues = values.length >= super.getAll.call(otherParams, key).length;
+      if (!haveCompatibleNumberOfValues) {
+        return false;
+      }
+
+      let valueExists = false;
+
+      for (const value of values) {
+        if (value.includes(otherValue)) {
+          valueExists = true;
+          break;
+        }
+      }
+
+      if (!valueExists) {
         return false;
       }
     }
+
     return true;
   }
 }

--- a/packages/zimic/src/http/searchParams/HttpSearchParams.ts
+++ b/packages/zimic/src/http/searchParams/HttpSearchParams.ts
@@ -114,15 +114,7 @@ class HttpSearchParams<Schema extends HttpSearchParamsSchema = HttpSearchParamsS
         return false;
       }
 
-      let valueExists = false;
-
-      for (const value of values) {
-        if (value === otherValue) {
-          valueExists = true;
-          break;
-        }
-      }
-
+      const valueExists = values.includes(otherValue);
       if (!valueExists) {
         return false;
       }
@@ -148,15 +140,7 @@ class HttpSearchParams<Schema extends HttpSearchParamsSchema = HttpSearchParamsS
         return false;
       }
 
-      let valueExists = false;
-
-      for (const value of values) {
-        if (value.includes(otherValue)) {
-          valueExists = true;
-          break;
-        }
-      }
-
+      const valueExists = values.includes(otherValue);
       if (!valueExists) {
         return false;
       }

--- a/packages/zimic/src/http/searchParams/__tests__/HttpSearchParams.test.ts
+++ b/packages/zimic/src/http/searchParams/__tests__/HttpSearchParams.test.ts
@@ -376,6 +376,14 @@ describe('HttpSearchParams', () => {
     otherSearchParams.delete('names', 'User3');
     expect(searchParams.equals(otherSearchParams)).toBe(true);
 
+    otherSearchParams.delete('names', 'User2');
+    otherSearchParams.append('names', 'Use');
+    expect(searchParams.equals(otherSearchParams)).toBe(false);
+
+    otherSearchParams.append('names', 'User2');
+    otherSearchParams.delete('names', 'Use');
+    expect(searchParams.equals(otherSearchParams)).toBe(true);
+
     otherSearchParams.set('page', '2');
     expect(searchParams.equals(otherSearchParams)).toBe(false);
     otherSearchParams.set('page', '1');
@@ -417,13 +425,20 @@ describe('HttpSearchParams', () => {
     searchParams.delete('names', 'User3');
     expect(searchParams.contains(otherSearchParams)).toBe(true);
 
+    otherSearchParams.delete('names', 'User2');
+    otherSearchParams.append('names', 'Use');
+    expect(searchParams.contains(otherSearchParams)).toBe(true);
+
+    otherSearchParams.delete('names', 'User1');
+    expect(searchParams.contains(otherSearchParams)).toBe(true);
+
     searchParams.set('page', '2');
     expect(searchParams.contains(otherSearchParams)).toBe(false);
     searchParams.set('page', '1');
     expect(searchParams.contains(otherSearchParams)).toBe(true);
 
     searchParams.delete('names', 'User2');
-    expect(searchParams.contains(otherSearchParams)).toBe(false);
+    expect(searchParams.contains(otherSearchParams)).toBe(true);
     searchParams.append('names', 'User2');
     expect(searchParams.contains(otherSearchParams)).toBe(true);
 

--- a/packages/zimic/src/http/searchParams/__tests__/HttpSearchParams.test.ts
+++ b/packages/zimic/src/http/searchParams/__tests__/HttpSearchParams.test.ts
@@ -427,9 +427,9 @@ describe('HttpSearchParams', () => {
 
     otherSearchParams.delete('names', 'User2');
     otherSearchParams.append('names', 'Use');
-    expect(searchParams.contains(otherSearchParams)).toBe(true);
+    expect(searchParams.contains(otherSearchParams)).toBe(false);
 
-    otherSearchParams.delete('names', 'User1');
+    otherSearchParams.delete('names', 'Use');
     expect(searchParams.contains(otherSearchParams)).toBe(true);
 
     searchParams.set('page', '2');

--- a/packages/zimic/src/interceptor/http/interceptor/HttpInterceptorClient.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/HttpInterceptorClient.ts
@@ -226,6 +226,8 @@ class HttpInterceptorClient<
     parsedRequest: HttpInterceptorRequest<Path, Default<Schema[Path][Method]>>,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ): Promise<HttpRequestHandlerClient<Schema, Method, Path, any> | undefined> {
+    /* istanbul ignore next -- @preserve
+     * Ignoring because there will always be a handler for the given method and path at this point. */
     const methodPathHandlers = this.handlerClientsByMethod[method].get(path) ?? [];
 
     for (let handlerIndex = methodPathHandlers.length - 1; handlerIndex >= 0; handlerIndex--) {

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/index.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/index.ts
@@ -85,8 +85,8 @@ export function declareSharedHttpInterceptorTests(options: SharedHttpInterceptor
       await declareBodyHttpInterceptorTests(runtimeOptions);
     });
 
-    describe('Restrictions', () => {
-      declareRestrictionsHttpInterceptorTests(runtimeOptions);
+    describe('Restrictions', async () => {
+      await declareRestrictionsHttpInterceptorTests(runtimeOptions);
     });
 
     describe('Bypass', () => {

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/restrictions.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/restrictions.ts
@@ -1,14 +1,18 @@
 import { beforeEach, describe, expect, expectTypeOf, it } from 'vitest';
 
+import HttpFormData from '@/http/formData/HttpFormData';
 import HttpHeaders from '@/http/headers/HttpHeaders';
 import HttpSearchParams from '@/http/searchParams/HttpSearchParams';
-import { HTTP_METHODS, HttpSchema } from '@/http/types/schema';
+import { HTTP_METHODS, HTTP_METHODS_WITH_REQUEST_BODY, HttpSchema } from '@/http/types/schema';
 import { promiseIfRemote } from '@/interceptor/http/interceptorWorker/__tests__/utils/promises';
+import InvalidFormDataError from '@/interceptor/http/interceptorWorker/errors/InvalidFormDataError';
 import LocalHttpRequestHandler from '@/interceptor/http/requestHandler/LocalHttpRequestHandler';
 import RemoteHttpRequestHandler from '@/interceptor/http/requestHandler/RemoteHttpRequestHandler';
 import { AccessControlHeaders, DEFAULT_ACCESS_CONTROL_HEADERS } from '@/interceptor/server/constants';
+import { getFile } from '@/utils/files';
 import { joinURL } from '@/utils/urls';
-import { expectFetchErrorOrPreflightResponse } from '@tests/utils/fetch';
+import { usingIgnoredConsole } from '@tests/utils/console';
+import { expectFetchError, expectFetchErrorOrPreflightResponse } from '@tests/utils/fetch';
 import { assessPreflightInterference, usingHttpInterceptor } from '@tests/utils/interceptors';
 
 import { HttpInterceptorOptions } from '../../types/options';
@@ -29,6 +33,23 @@ export function declareRestrictionsHttpInterceptorTests(options: RuntimeSharedHt
     Handler = type === 'local' ? LocalHttpRequestHandler : RemoteHttpRequestHandler;
   });
 
+  type UserRequestHeaders = HttpSchema.Headers<{
+    'content-language'?: string;
+    accept?: string;
+  }>;
+
+  type UserSearchParams = HttpSchema.SearchParams<{
+    tag?: string;
+  }>;
+
+  type MethodSchema = HttpSchema.Method<{
+    request: {
+      headers: UserRequestHeaders;
+      searchParams: UserSearchParams;
+    };
+    response: { 200: { headers: AccessControlHeaders } };
+  }>;
+
   describe.each(HTTP_METHODS)('Method: %s', (method) => {
     const { overridesPreflightResponse, numberOfRequestsIncludingPreflight } = assessPreflightInterference({
       method,
@@ -38,23 +59,6 @@ export function declareRestrictionsHttpInterceptorTests(options: RuntimeSharedHt
 
     // TODO: improve handler.with() type performance
     const lowerMethod = method.toLowerCase<'POST'>();
-
-    type UserRequestHeaders = HttpSchema.Headers<{
-      'content-language'?: string;
-      accept?: string;
-    }>;
-
-    type UserSearchParams = HttpSchema.SearchParams<{
-      tag?: string;
-    }>;
-
-    type MethodSchema = HttpSchema.Method<{
-      request: {
-        headers: UserRequestHeaders;
-        searchParams: UserSearchParams;
-      };
-      response: { 200: { headers: AccessControlHeaders } };
-    }>;
 
     it(`should support intercepting ${method} requests having headers restrictions`, async () => {
       await usingHttpInterceptor<{
@@ -103,6 +107,7 @@ export function declareRestrictionsHttpInterceptorTests(options: RuntimeSharedHt
 
         let response = await fetch(joinURL(baseURL, '/users'), { method, headers });
         expect(response.status).toBe(200);
+
         requests = await promiseIfRemote(handler.requests(), interceptor);
         expect(requests).toHaveLength(1);
 
@@ -110,6 +115,7 @@ export function declareRestrictionsHttpInterceptorTests(options: RuntimeSharedHt
 
         response = await fetch(joinURL(baseURL, '/users'), { method, headers });
         expect(response.status).toBe(200);
+
         requests = await promiseIfRemote(handler.requests(), interceptor);
         expect(requests).toHaveLength(2);
 
@@ -119,6 +125,7 @@ export function declareRestrictionsHttpInterceptorTests(options: RuntimeSharedHt
         await expectFetchErrorOrPreflightResponse(promise, {
           shouldBePreflight: overridesPreflightResponse,
         });
+
         requests = await promiseIfRemote(handler.requests(), interceptor);
         expect(requests).toHaveLength(2);
 
@@ -182,6 +189,7 @@ export function declareRestrictionsHttpInterceptorTests(options: RuntimeSharedHt
           method,
         });
         expect(response.status).toBe(200);
+
         requests = await promiseIfRemote(handler.requests(), interceptor);
         expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
 
@@ -195,6 +203,342 @@ export function declareRestrictionsHttpInterceptorTests(options: RuntimeSharedHt
         });
         requests = await promiseIfRemote(handler.requests(), interceptor);
         expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+      });
+    });
+  });
+
+  describe.each(HTTP_METHODS_WITH_REQUEST_BODY)('Method: %s', (method) => {
+    // TODO: improve handler.with() type performance
+    const lowerMethod = method.toLowerCase<'POST'>();
+
+    it(`should support intercepting ${method} requests having exact body JSON restrictions`, async () => {
+      type MethodSchemaWithBody = HttpSchema.Method<{
+        request: { body: { message: string } };
+        response: { 200: {} };
+      }>;
+
+      await usingHttpInterceptor<{
+        '/users': {
+          POST: MethodSchemaWithBody;
+          PUT: MethodSchemaWithBody;
+          PATCH: MethodSchemaWithBody;
+          DELETE: MethodSchemaWithBody;
+        };
+      }>(interceptorOptions, async (interceptor) => {
+        const handler = await promiseIfRemote(
+          interceptor[lowerMethod]('/users')
+            .with({
+              body: { message: 'ok' },
+              exact: true,
+            })
+            .respond((request) => {
+              expectTypeOf(request.body).toEqualTypeOf<{ message: string }>();
+              expect(request.body).toEqual({ message: 'ok' });
+
+              return { status: 200 };
+            }),
+          interceptor,
+        );
+        expect(handler).toBeInstanceOf(Handler);
+
+        let requests = await promiseIfRemote(handler.requests(), interceptor);
+        expect(requests).toHaveLength(0);
+
+        const response = await fetch(joinURL(baseURL, '/users'), {
+          method,
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ message: 'ok' }),
+        });
+        expect(response.status).toBe(200);
+
+        requests = await promiseIfRemote(handler.requests(), interceptor);
+        expect(requests).toHaveLength(1);
+
+        for (const body of [JSON.stringify({ message: 'other' }), JSON.stringify({}), undefined]) {
+          const promise = fetch(joinURL(baseURL, '/users'), {
+            method,
+            headers: body ? { 'content-type': 'application/json' } : undefined,
+            body,
+          });
+          await expectFetchError(promise);
+
+          requests = await promiseIfRemote(handler.requests(), interceptor);
+          expect(requests).toHaveLength(1);
+        }
+      });
+    });
+
+    it(`should support intercepting ${method} requests having exact body form data restrictions`, async () => {
+      type FormDataSchema = HttpSchema.FormData<{
+        tag?: File;
+      }>;
+
+      type MethodSchemaWithBody = HttpSchema.Method<{
+        request: { body: HttpFormData<FormDataSchema> };
+        response: { 200: {} };
+      }>;
+
+      await usingHttpInterceptor<{
+        '/users': {
+          POST: MethodSchemaWithBody;
+          PUT: MethodSchemaWithBody;
+          PATCH: MethodSchemaWithBody;
+          DELETE: MethodSchemaWithBody;
+        };
+      }>(interceptorOptions, async (interceptor) => {
+        const File = await getFile();
+
+        const restrictedFormData = new HttpFormData<FormDataSchema>();
+        const tagFile = new File(['content'], 'tag.txt', { type: 'text/plain' });
+        restrictedFormData.append('tag', tagFile);
+
+        const handler = await promiseIfRemote(
+          interceptor[lowerMethod]('/users')
+            .with({
+              body: restrictedFormData,
+              exact: true,
+            })
+            .respond((request) => {
+              expectTypeOf(request.body).toEqualTypeOf<HttpFormData<FormDataSchema>>();
+              expect(request.body).toEqual(restrictedFormData);
+
+              return { status: 200 };
+            }),
+          interceptor,
+        );
+        expect(handler).toBeInstanceOf(Handler);
+
+        let requests = await promiseIfRemote(handler.requests(), interceptor);
+        expect(requests).toHaveLength(0);
+
+        const response = await fetch(joinURL(baseURL, '/users'), {
+          method,
+          body: restrictedFormData,
+        });
+        expect(response.status).toBe(200);
+
+        requests = await promiseIfRemote(handler.requests(), interceptor);
+        expect(requests).toHaveLength(1);
+
+        const differentTagFile = new File(['other-content'], 'tag.txt', { type: 'text/plain' });
+
+        const extendedFormData = new HttpFormData<FormDataSchema>();
+        extendedFormData.append('tag', tagFile);
+        extendedFormData.append('tag', differentTagFile);
+
+        const differentFormData = new HttpFormData<FormDataSchema>();
+        differentFormData.append('tag', differentTagFile);
+
+        for (const body of [extendedFormData, differentFormData, new HttpFormData<FormDataSchema>(), undefined]) {
+          await usingIgnoredConsole(['error'], async (spies) => {
+            const promise = fetch(joinURL(baseURL, '/users'), {
+              method,
+              body,
+            });
+            await expectFetchError(promise);
+
+            requests = await promiseIfRemote(handler.requests(), interceptor);
+            expect(requests).toHaveLength(1);
+
+            if (body && !body.has('tag') && platform === 'browser') {
+              expect(spies.error).toHaveBeenCalledTimes(1);
+              expect(spies.error).toHaveBeenCalledWith(expect.any(InvalidFormDataError));
+            } else {
+              expect(spies.error).toHaveBeenCalledTimes(0);
+            }
+          });
+        }
+      });
+    });
+
+    it(`should support intercepting ${method} requests having exact body search params restrictions`, async () => {
+      type SearchParamsSchema = HttpSchema.SearchParams<{
+        tag?: string;
+        other?: string;
+      }>;
+
+      type MethodSchema = HttpSchema.Method<{
+        request: { body: HttpSearchParams<SearchParamsSchema> };
+        response: { 200: { body: HttpSearchParams<SearchParamsSchema> } };
+      }>;
+
+      await usingHttpInterceptor<{
+        '/users': {
+          POST: MethodSchema;
+          PUT: MethodSchema;
+          PATCH: MethodSchema;
+          DELETE: MethodSchema;
+        };
+      }>(interceptorOptions, async (interceptor) => {
+        const restrictedSearchParams = new HttpSearchParams<SearchParamsSchema>({ tag: 'admin' });
+
+        const handler = await promiseIfRemote(
+          interceptor[lowerMethod]('/users')
+            .with({
+              body: restrictedSearchParams,
+              exact: true,
+            })
+            .respond((request) => {
+              expectTypeOf(request.body).toEqualTypeOf<HttpSearchParams<SearchParamsSchema>>();
+              expect(request.body).toEqual(restrictedSearchParams);
+
+              return { status: 200, body: request.body };
+            }),
+          interceptor,
+        );
+        expect(handler).toBeInstanceOf(Handler);
+
+        let requests = await promiseIfRemote(handler.requests(), interceptor);
+        expect(requests).toHaveLength(0);
+
+        const response = await fetch(joinURL(baseURL, '/users'), {
+          method,
+          body: restrictedSearchParams,
+        });
+        expect(response.status).toBe(200);
+
+        requests = await promiseIfRemote(handler.requests(), interceptor);
+        expect(requests).toHaveLength(1);
+
+        for (const body of [
+          new HttpSearchParams<SearchParamsSchema>({ tag: 'admin', other: 'other' }),
+          new HttpSearchParams<SearchParamsSchema>({ tag: 'other' }),
+          new HttpSearchParams<SearchParamsSchema>(),
+          undefined,
+        ]) {
+          const promise = fetch(joinURL(baseURL, `/users?tag=admin`), {
+            method,
+            body,
+          });
+          await expectFetchError(promise);
+
+          requests = await promiseIfRemote(handler.requests(), interceptor);
+          expect(requests).toHaveLength(1);
+        }
+      });
+    });
+
+    it(`should support intercepting ${method} requests having exact body text restrictions`, async () => {
+      type MethodSchemaWithBody = HttpSchema.Method<{
+        request: { body: string };
+        response: { 200: {} };
+      }>;
+
+      await usingHttpInterceptor<{
+        '/users': {
+          POST: MethodSchemaWithBody;
+          PUT: MethodSchemaWithBody;
+          PATCH: MethodSchemaWithBody;
+          DELETE: MethodSchemaWithBody;
+        };
+      }>(interceptorOptions, async (interceptor) => {
+        const restrictedBody = 'content';
+
+        const handler = await promiseIfRemote(
+          interceptor[lowerMethod]('/users')
+            .with({
+              body: restrictedBody,
+              exact: true,
+            })
+            .respond((request) => {
+              expectTypeOf(request.body).toEqualTypeOf<string>();
+              expect(request.body).toBe(restrictedBody);
+
+              return { status: 200 };
+            }),
+          interceptor,
+        );
+        expect(handler).toBeInstanceOf(Handler);
+
+        let requests = await promiseIfRemote(handler.requests(), interceptor);
+        expect(requests).toHaveLength(0);
+
+        const response = await fetch(joinURL(baseURL, '/users'), {
+          method,
+          body: restrictedBody,
+        });
+        expect(response.status).toBe(200);
+
+        requests = await promiseIfRemote(handler.requests(), interceptor);
+        expect(requests).toHaveLength(1);
+
+        for (const body of ['other-content', 'cont', '']) {
+          const promise = fetch(joinURL(baseURL, '/users'), {
+            method,
+            body,
+          });
+          await expectFetchError(promise);
+
+          requests = await promiseIfRemote(handler.requests(), interceptor);
+          expect(requests).toHaveLength(1);
+        }
+      });
+    });
+
+    it(`should support intercepting ${method} requests having exact body blob restrictions`, async () => {
+      type MethodSchemaWithBody = HttpSchema.Method<{
+        request: { body: Blob };
+        response: { 200: {} };
+      }>;
+
+      await usingHttpInterceptor<{
+        '/users': {
+          POST: MethodSchemaWithBody;
+          PUT: MethodSchemaWithBody;
+          PATCH: MethodSchemaWithBody;
+          DELETE: MethodSchemaWithBody;
+        };
+      }>(interceptorOptions, async (interceptor) => {
+        const restrictedBody = new File(['content'], 'file.bin', { type: 'application/octet-stream' });
+
+        const handler = await promiseIfRemote(
+          interceptor[lowerMethod]('/users')
+            .with({
+              body: restrictedBody,
+              exact: true,
+            })
+            .respond(async (request) => {
+              expectTypeOf(request.body).toEqualTypeOf<Blob>();
+              expect(request.body).toBeInstanceOf(Blob);
+              expect(request.body.type).toBe(restrictedBody.type);
+              expect(request.body.size).toBe(restrictedBody.size);
+              expect(await request.body.text()).toEqual(await restrictedBody.text());
+
+              return { status: 200 };
+            }),
+          interceptor,
+        );
+        expect(handler).toBeInstanceOf(Handler);
+
+        let requests = await promiseIfRemote(handler.requests(), interceptor);
+        expect(requests).toHaveLength(0);
+
+        const response = await fetch(joinURL(baseURL, '/users'), {
+          method,
+          headers: { 'content-type': 'application/octet-stream' },
+          body: restrictedBody,
+        });
+        expect(response.status).toBe(200);
+
+        requests = await promiseIfRemote(handler.requests(), interceptor);
+        expect(requests).toHaveLength(1);
+
+        for (const body of [
+          new File(['other-content'], 'file.bin', { type: 'application/octet-stream' }),
+          new File(['content'], 'file.bin', { type: 'text/plain' }),
+          new File(['cont'], 'file.bin', { type: 'application/octet-stream' }),
+          new File([], 'file.bin', { type: 'application/octet-stream' }),
+          new File([], ''),
+        ]) {
+          const promise = fetch(joinURL(baseURL, '/users'), {
+            method,
+            body,
+          });
+          await expectFetchError(promise);
+
+          requests = await promiseIfRemote(handler.requests(), interceptor);
+          expect(requests).toHaveLength(1);
+        }
       });
     });
   });

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/restrictions.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/restrictions.ts
@@ -57,7 +57,7 @@ export function declareRestrictionsHttpInterceptorTests(options: RuntimeSharedHt
       type,
     });
 
-    // TODO: improve handler.with() type performance
+    // TODO: handler.with() restriction types are not performing well when combining many interceptor types and http methods
     const lowerMethod = method.toLowerCase<'POST'>();
 
     it(`should support intercepting ${method} requests having headers restrictions`, async () => {
@@ -208,7 +208,7 @@ export function declareRestrictionsHttpInterceptorTests(options: RuntimeSharedHt
   });
 
   describe.each(HTTP_METHODS_WITH_REQUEST_BODY)('Method: %s', (method) => {
-    // TODO: improve handler.with() type performance
+    // TODO: handler.with() restriction types are not performing well when combining many interceptor types and http methods
     const lowerMethod = method.toLowerCase<'POST'>();
 
     it(`should support intercepting ${method} requests having exact body JSON restrictions`, async () => {

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/restrictions.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/restrictions.ts
@@ -18,8 +18,10 @@ import { assessPreflightInterference, usingHttpInterceptor } from '@tests/utils/
 import { HttpInterceptorOptions } from '../../types/options';
 import { RuntimeSharedHttpInterceptorTestsOptions } from './types';
 
-export function declareRestrictionsHttpInterceptorTests(options: RuntimeSharedHttpInterceptorTestsOptions) {
+export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSharedHttpInterceptorTestsOptions) {
   const { platform, type, getBaseURL, getInterceptorOptions } = options;
+
+  const File = await getFile();
 
   let baseURL: URL;
   let interceptorOptions: HttpInterceptorOptions;
@@ -353,8 +355,6 @@ export function declareRestrictionsHttpInterceptorTests(options: RuntimeSharedHt
           DELETE: MethodSchemaWithBody;
         };
       }>(interceptorOptions, async (interceptor) => {
-        const File = await getFile();
-
         const restrictedFormData = new HttpFormData<FormDataSchema>();
         const tagFile = new File(['content'], 'tag.txt', { type: 'text/plain' });
         restrictedFormData.append('tag', tagFile);
@@ -436,8 +436,6 @@ export function declareRestrictionsHttpInterceptorTests(options: RuntimeSharedHt
           DELETE: MethodSchemaWithBody;
         };
       }>(interceptorOptions, async (interceptor) => {
-        const File = await getFile();
-
         const restrictedFormData = new HttpFormData<FormDataSchema>();
         const tagFile = new File(['content'], 'tag.txt', { type: 'text/plain' });
         restrictedFormData.append('tag', tagFile);

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/unhandledRequests.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/unhandledRequests.ts
@@ -39,7 +39,7 @@ export function declareUnhandledRequestHttpInterceptorTests(options: RuntimeShar
       type,
     });
 
-    // TODO: improve handler.with() type performance
+    // TODO: handler.with() restriction types are not performing well when combining many interceptor types and http methods
     const lowerMethod = method.toLowerCase<'POST'>();
 
     type MethodSchemaWithoutRequestBody = HttpSchema.Method<{

--- a/packages/zimic/src/interceptor/http/interceptor/errors/UnknownHttpInterceptorPlatform.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/errors/UnknownHttpInterceptorPlatform.ts
@@ -6,7 +6,7 @@
  */
 class UnknownHttpInterceptorPlatform extends Error {
   /* istanbul ignore next -- @preserve
-   * Ignoring because checking unknown platforms is currently not possible in our Vitest setup */
+   * Ignoring because checking unknown platforms is currently not possible in our Vitest setup. */
   constructor() {
     super('Unknown interceptor platform.');
     this.name = 'UnknownHttpInterceptorPlatform';

--- a/packages/zimic/src/interceptor/http/requestHandler/HttpRequestHandlerClient.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/HttpRequestHandlerClient.ts
@@ -171,22 +171,22 @@ class HttpRequestHandlerClient<
       return restriction.exact ? body === restrictionBody : body.includes(restrictionBody);
     }
 
-    if (body instanceof HttpFormData) {
-      if (!(restrictionBody instanceof HttpFormData)) {
+    if (restrictionBody instanceof HttpFormData) {
+      if (!(body instanceof HttpFormData)) {
         return false;
       }
       return restriction.exact ? body.equals(restrictionBody) : body.contains(restrictionBody);
     }
 
-    if (body instanceof HttpSearchParams) {
-      if (!(restrictionBody instanceof HttpSearchParams)) {
+    if (restrictionBody instanceof HttpSearchParams) {
+      if (!(body instanceof HttpSearchParams)) {
         return false;
       }
       return restriction.exact ? body.equals(restrictionBody) : body.contains(restrictionBody);
     }
 
-    if (body instanceof Blob) {
-      if (!(restrictionBody instanceof Blob)) {
+    if (restrictionBody instanceof Blob) {
+      if (!(body instanceof Blob)) {
         return false;
       }
       return restriction.exact ? blobEquals(body, restrictionBody) : blobContains(body, restrictionBody);

--- a/packages/zimic/src/interceptor/http/requestHandler/LocalHttpRequestHandler.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/LocalHttpRequestHandler.ts
@@ -81,7 +81,7 @@ class LocalHttpRequestHandler<
     return this._client.requests();
   }
 
-  matchesRequest(request: HttpInterceptorRequest<Path, Default<Schema[Path][Method]>>): boolean {
+  matchesRequest(request: HttpInterceptorRequest<Path, Default<Schema[Path][Method]>>): Promise<boolean> {
     return this._client.matchesRequest(request);
   }
 

--- a/packages/zimic/src/interceptor/http/requestHandler/RemoteHttpRequestHandler.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/RemoteHttpRequestHandler.ts
@@ -112,7 +112,7 @@ class RemoteHttpRequestHandler<
     return Promise.resolve(this._client.requests());
   }
 
-  matchesRequest(request: HttpInterceptorRequest<Path, Default<Schema[Path][Method]>>): boolean {
+  matchesRequest(request: HttpInterceptorRequest<Path, Default<Schema[Path][Method]>>): Promise<boolean> {
     return this._client.matchesRequest(request);
   }
 

--- a/packages/zimic/src/interceptor/http/requestHandler/__tests__/shared/default.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/__tests__/shared/default.ts
@@ -73,7 +73,7 @@ export function declareDefaultHttpRequestHandlerTests(
 
     const request = new Request(baseURL);
     const parsedRequest = await HttpInterceptorWorker.parseRawRequest<'/users', MethodSchema>(request);
-    expect(handler.matchesRequest(parsedRequest)).toBe(false);
+    expect(await handler.matchesRequest(parsedRequest)).toBe(false);
   });
 
   it('should match any request if contains a declared response and no restrictions', async () => {
@@ -84,11 +84,11 @@ export function declareDefaultHttpRequestHandlerTests(
 
     const request = new Request(baseURL);
     const parsedRequest = await HttpInterceptorWorker.parseRawRequest<'/users', MethodSchema>(request);
-    expect(handler.matchesRequest(parsedRequest)).toBe(true);
+    expect(await handler.matchesRequest(parsedRequest)).toBe(true);
 
     await promiseIfRemote(handler.with({}), interceptor);
 
-    expect(handler.matchesRequest(parsedRequest)).toBe(true);
+    expect(await handler.matchesRequest(parsedRequest)).toBe(true);
   });
 
   it('should not match any request if bypassed', async () => {
@@ -96,10 +96,10 @@ export function declareDefaultHttpRequestHandlerTests(
 
     const request = new Request(baseURL);
     const parsedRequest = await HttpInterceptorWorker.parseRawRequest<'/users', MethodSchema>(request);
-    expect(handler.matchesRequest(parsedRequest)).toBe(false);
+    expect(await handler.matchesRequest(parsedRequest)).toBe(false);
 
     await promiseIfRemote(handler.bypass(), interceptor);
-    expect(handler.matchesRequest(parsedRequest)).toBe(false);
+    expect(await handler.matchesRequest(parsedRequest)).toBe(false);
 
     await promiseIfRemote(
       handler.respond({
@@ -108,10 +108,10 @@ export function declareDefaultHttpRequestHandlerTests(
       }),
       interceptor,
     );
-    expect(handler.matchesRequest(parsedRequest)).toBe(true);
+    expect(await handler.matchesRequest(parsedRequest)).toBe(true);
 
     await promiseIfRemote(handler.bypass(), interceptor);
-    expect(handler.matchesRequest(parsedRequest)).toBe(false);
+    expect(await handler.matchesRequest(parsedRequest)).toBe(false);
 
     await promiseIfRemote(
       handler.respond({
@@ -120,7 +120,7 @@ export function declareDefaultHttpRequestHandlerTests(
       }),
       interceptor,
     );
-    expect(handler.matchesRequest(parsedRequest)).toBe(true);
+    expect(await handler.matchesRequest(parsedRequest)).toBe(true);
   });
 
   it('should not match any request if cleared', async () => {
@@ -128,10 +128,10 @@ export function declareDefaultHttpRequestHandlerTests(
 
     const request = new Request(baseURL);
     const parsedRequest = await HttpInterceptorWorker.parseRawRequest<'/users', MethodSchema>(request);
-    expect(handler.matchesRequest(parsedRequest)).toBe(false);
+    expect(await handler.matchesRequest(parsedRequest)).toBe(false);
 
     await promiseIfRemote(handler.clear(), interceptor);
-    expect(handler.matchesRequest(parsedRequest)).toBe(false);
+    expect(await handler.matchesRequest(parsedRequest)).toBe(false);
 
     await promiseIfRemote(
       handler.respond({
@@ -140,10 +140,10 @@ export function declareDefaultHttpRequestHandlerTests(
       }),
       interceptor,
     );
-    expect(handler.matchesRequest(parsedRequest)).toBe(true);
+    expect(await handler.matchesRequest(parsedRequest)).toBe(true);
 
     await promiseIfRemote(handler.clear(), interceptor);
-    expect(handler.matchesRequest(parsedRequest)).toBe(false);
+    expect(await handler.matchesRequest(parsedRequest)).toBe(false);
 
     await promiseIfRemote(
       handler.respond({
@@ -152,7 +152,7 @@ export function declareDefaultHttpRequestHandlerTests(
       }),
       interceptor,
     );
-    expect(handler.matchesRequest(parsedRequest)).toBe(true);
+    expect(await handler.matchesRequest(parsedRequest)).toBe(true);
   });
 
   it('should create response with declared status and body', async () => {
@@ -380,10 +380,10 @@ export function declareDefaultHttpRequestHandlerTests(
 
     const request = new Request(baseURL);
     const parsedRequest = await HttpInterceptorWorker.parseRawRequest<'/users', MethodSchema>(request);
-    expect(handler.matchesRequest(parsedRequest)).toBe(false);
+    expect(await handler.matchesRequest(parsedRequest)).toBe(false);
 
     await promiseIfRemote(handler.clear(), interceptor);
-    expect(handler.matchesRequest(parsedRequest)).toBe(false);
+    expect(await handler.matchesRequest(parsedRequest)).toBe(false);
 
     await promiseIfRemote(
       handler
@@ -394,10 +394,10 @@ export function declareDefaultHttpRequestHandlerTests(
         }),
       interceptor,
     );
-    expect(handler.matchesRequest(parsedRequest)).toBe(false);
+    expect(await handler.matchesRequest(parsedRequest)).toBe(false);
 
     await promiseIfRemote(handler.clear(), interceptor);
-    expect(handler.matchesRequest(parsedRequest)).toBe(false);
+    expect(await handler.matchesRequest(parsedRequest)).toBe(false);
 
     await promiseIfRemote(
       handler.respond({
@@ -406,7 +406,7 @@ export function declareDefaultHttpRequestHandlerTests(
       }),
       interceptor,
     );
-    expect(handler.matchesRequest(parsedRequest)).toBe(true);
+    expect(await handler.matchesRequest(parsedRequest)).toBe(true);
   });
 
   it('should not clear restrictions after bypassed', async () => {
@@ -414,10 +414,10 @@ export function declareDefaultHttpRequestHandlerTests(
 
     const request = new Request(baseURL);
     const parsedRequest = await HttpInterceptorWorker.parseRawRequest<'/users', MethodSchema>(request);
-    expect(handler.matchesRequest(parsedRequest)).toBe(false);
+    expect(await handler.matchesRequest(parsedRequest)).toBe(false);
 
     await promiseIfRemote(handler.bypass(), interceptor);
-    expect(handler.matchesRequest(parsedRequest)).toBe(false);
+    expect(await handler.matchesRequest(parsedRequest)).toBe(false);
 
     await promiseIfRemote(
       handler
@@ -428,10 +428,10 @@ export function declareDefaultHttpRequestHandlerTests(
         }),
       interceptor,
     );
-    expect(handler.matchesRequest(parsedRequest)).toBe(false);
+    expect(await handler.matchesRequest(parsedRequest)).toBe(false);
 
     await promiseIfRemote(handler.bypass(), interceptor);
-    expect(handler.matchesRequest(parsedRequest)).toBe(false);
+    expect(await handler.matchesRequest(parsedRequest)).toBe(false);
 
     await promiseIfRemote(
       handler.respond({
@@ -440,7 +440,7 @@ export function declareDefaultHttpRequestHandlerTests(
       }),
       interceptor,
     );
-    expect(handler.matchesRequest(parsedRequest)).toBe(false);
+    expect(await handler.matchesRequest(parsedRequest)).toBe(false);
   });
 
   if (Handler === RemoteHttpRequestHandler) {

--- a/packages/zimic/src/interceptor/http/requestHandler/__tests__/shared/restrictions.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/__tests__/shared/restrictions.ts
@@ -68,7 +68,7 @@ export function declareRestrictionHttpRequestHandlerTests(
         for (const matchingSearchParams of [new HttpSearchParams<SearchParamsSchema>({ name })]) {
           const matchingRequest = new Request(joinURL(baseURL, `?${matchingSearchParams.toString()}`));
           const parsedRequest = await HttpInterceptorWorker.parseRawRequest<'/users', MethodSchema>(matchingRequest);
-          expect(handler.matchesRequest(parsedRequest)).toBe(true);
+          expect(await handler.matchesRequest(parsedRequest)).toBe(true);
         }
 
         for (const mismatchingSearchParams of [
@@ -78,7 +78,7 @@ export function declareRestrictionHttpRequestHandlerTests(
         ]) {
           const request = new Request(joinURL(baseURL, `?${mismatchingSearchParams.toString()}`));
           const parsedRequest = await HttpInterceptorWorker.parseRawRequest<'/users', MethodSchema>(request);
-          expect(handler.matchesRequest(parsedRequest)).toBe(false);
+          expect(await handler.matchesRequest(parsedRequest)).toBe(false);
         }
       },
     );
@@ -104,7 +104,7 @@ export function declareRestrictionHttpRequestHandlerTests(
         ]) {
           const matchingRequest = new Request(joinURL(baseURL, `?${matchingSearchParams.toString()}`));
           const parsedRequest = await HttpInterceptorWorker.parseRawRequest<'/users', MethodSchema>(matchingRequest);
-          expect(handler.matchesRequest(parsedRequest)).toBe(true);
+          expect(await handler.matchesRequest(parsedRequest)).toBe(true);
         }
 
         for (const mismatchingSearchParams of [
@@ -113,7 +113,7 @@ export function declareRestrictionHttpRequestHandlerTests(
         ]) {
           const request = new Request(joinURL(baseURL, `?${mismatchingSearchParams.toString()}`));
           const parsedRequest = await HttpInterceptorWorker.parseRawRequest<'/users', MethodSchema>(request);
-          expect(handler.matchesRequest(parsedRequest)).toBe(false);
+          expect(await handler.matchesRequest(parsedRequest)).toBe(false);
         }
       },
     );
@@ -141,7 +141,7 @@ export function declareRestrictionHttpRequestHandlerTests(
       ]) {
         const matchingRequest = new Request(joinURL(baseURL, `?${matchingSearchParams.toString()}`));
         const parsedRequest = await HttpInterceptorWorker.parseRawRequest<'/users', MethodSchema>(matchingRequest);
-        expect(handler.matchesRequest(parsedRequest)).toBe(true);
+        expect(await handler.matchesRequest(parsedRequest)).toBe(true);
       }
 
       for (const mismatchingSearchParams of [
@@ -150,7 +150,7 @@ export function declareRestrictionHttpRequestHandlerTests(
       ]) {
         const request = new Request(joinURL(baseURL, `?${mismatchingSearchParams.toString()}`));
         const parsedRequest = await HttpInterceptorWorker.parseRawRequest<'/users', MethodSchema>(request);
-        expect(handler.matchesRequest(parsedRequest)).toBe(false);
+        expect(await handler.matchesRequest(parsedRequest)).toBe(false);
       }
     });
   });
@@ -174,7 +174,7 @@ export function declareRestrictionHttpRequestHandlerTests(
         for (const matchingHeaders of [new HttpHeaders<HeadersSchema>({ 'content-language': contentLanguage })]) {
           const matchingRequest = new Request(baseURL, { headers: matchingHeaders });
           const parsedRequest = await HttpInterceptorWorker.parseRawRequest<'/users', MethodSchema>(matchingRequest);
-          expect(handler.matchesRequest(parsedRequest)).toBe(true);
+          expect(await handler.matchesRequest(parsedRequest)).toBe(true);
         }
 
         for (const mismatchingHeaders of [
@@ -184,7 +184,7 @@ export function declareRestrictionHttpRequestHandlerTests(
         ]) {
           const request = new Request(baseURL, { headers: mismatchingHeaders });
           const parsedRequest = await HttpInterceptorWorker.parseRawRequest<'/users', MethodSchema>(request);
-          expect(handler.matchesRequest(parsedRequest)).toBe(false);
+          expect(await handler.matchesRequest(parsedRequest)).toBe(false);
         }
       },
     );
@@ -210,7 +210,7 @@ export function declareRestrictionHttpRequestHandlerTests(
         ]) {
           const matchingRequest = new Request(baseURL, { headers: matchingHeaders });
           const parsedRequest = await HttpInterceptorWorker.parseRawRequest<'/users', MethodSchema>(matchingRequest);
-          expect(handler.matchesRequest(parsedRequest)).toBe(true);
+          expect(await handler.matchesRequest(parsedRequest)).toBe(true);
         }
 
         for (const mismatchingHeaders of [
@@ -219,7 +219,7 @@ export function declareRestrictionHttpRequestHandlerTests(
         ]) {
           const request = new Request(baseURL, { headers: mismatchingHeaders });
           const parsedRequest = await HttpInterceptorWorker.parseRawRequest<'/users', MethodSchema>(request);
-          expect(handler.matchesRequest(parsedRequest)).toBe(false);
+          expect(await handler.matchesRequest(parsedRequest)).toBe(false);
         }
       },
     );
@@ -247,7 +247,7 @@ export function declareRestrictionHttpRequestHandlerTests(
       ]) {
         const matchingRequest = new Request(baseURL, { headers: matchingHeaders });
         const parsedRequest = await HttpInterceptorWorker.parseRawRequest<'/users', MethodSchema>(matchingRequest);
-        expect(handler.matchesRequest(parsedRequest)).toBe(true);
+        expect(await handler.matchesRequest(parsedRequest)).toBe(true);
       }
 
       for (const mismatchingHeaders of [
@@ -256,7 +256,7 @@ export function declareRestrictionHttpRequestHandlerTests(
       ]) {
         const request = new Request(baseURL, { headers: mismatchingHeaders });
         const parsedRequest = await HttpInterceptorWorker.parseRawRequest<'/users', MethodSchema>(request);
-        expect(handler.matchesRequest(parsedRequest)).toBe(false);
+        expect(await handler.matchesRequest(parsedRequest)).toBe(false);
       }
     });
   });
@@ -284,7 +284,7 @@ export function declareRestrictionHttpRequestHandlerTests(
             body: JSON.stringify(matchingBody),
           });
           const parsedRequest = await HttpInterceptorWorker.parseRawRequest<'/users', MethodSchema>(matchingRequest);
-          expect(handler.matchesRequest(parsedRequest)).toBe(true);
+          expect(await handler.matchesRequest(parsedRequest)).toBe(true);
         }
 
         for (const mismatchingBody of [
@@ -298,7 +298,7 @@ export function declareRestrictionHttpRequestHandlerTests(
             body: JSON.stringify(mismatchingBody),
           });
           const parsedRequest = await HttpInterceptorWorker.parseRawRequest<'/users', MethodSchema>(request);
-          expect(handler.matchesRequest(parsedRequest)).toBe(false);
+          expect(await handler.matchesRequest(parsedRequest)).toBe(false);
         }
       },
     );
@@ -329,7 +329,7 @@ export function declareRestrictionHttpRequestHandlerTests(
             body: JSON.stringify(matchingBody),
           });
           const parsedRequest = await HttpInterceptorWorker.parseRawRequest<'/users', MethodSchema>(matchingRequest);
-          expect(handler.matchesRequest(parsedRequest)).toBe(true);
+          expect(await handler.matchesRequest(parsedRequest)).toBe(true);
         }
 
         for (const mismatchingBody of [{}] satisfies MethodSchema['request']['body'][]) {
@@ -339,7 +339,7 @@ export function declareRestrictionHttpRequestHandlerTests(
             body: JSON.stringify(mismatchingBody),
           });
           const parsedRequest = await HttpInterceptorWorker.parseRawRequest<'/users', MethodSchema>(request);
-          expect(handler.matchesRequest(parsedRequest)).toBe(false);
+          expect(await handler.matchesRequest(parsedRequest)).toBe(false);
         }
       },
     );
@@ -369,7 +369,7 @@ export function declareRestrictionHttpRequestHandlerTests(
           body: JSON.stringify(matchingBody),
         });
         const parsedRequest = await HttpInterceptorWorker.parseRawRequest<'/users', MethodSchema>(matchingRequest);
-        expect(handler.matchesRequest(parsedRequest)).toBe(true);
+        expect(await handler.matchesRequest(parsedRequest)).toBe(true);
       }
 
       for (const mismatchingBody of [{ name: `Other ${name}` }, {}] satisfies MethodSchema['request']['body'][]) {
@@ -379,7 +379,7 @@ export function declareRestrictionHttpRequestHandlerTests(
           body: JSON.stringify(mismatchingBody),
         });
         const parsedRequest = await HttpInterceptorWorker.parseRawRequest<'/users', MethodSchema>(request);
-        expect(handler.matchesRequest(parsedRequest)).toBe(false);
+        expect(await handler.matchesRequest(parsedRequest)).toBe(false);
       }
     });
   });
@@ -443,7 +443,7 @@ export function declareRestrictionHttpRequestHandlerTests(
           headers: matchingHeaders,
         });
         const parsedRequest = await HttpInterceptorWorker.parseRawRequest<'/users', MethodSchema>(matchingRequest);
-        expect(handler.matchesRequest(parsedRequest)).toBe(true);
+        expect(await handler.matchesRequest(parsedRequest)).toBe(true);
       }
 
       for (const mismatchingSearchParams of mismatchingSearchParamsSamples) {
@@ -451,7 +451,7 @@ export function declareRestrictionHttpRequestHandlerTests(
           headers: matchingHeaders,
         });
         const parsedRequest = await HttpInterceptorWorker.parseRawRequest<'/users', MethodSchema>(request);
-        expect(handler.matchesRequest(parsedRequest)).toBe(false);
+        expect(await handler.matchesRequest(parsedRequest)).toBe(false);
       }
     }
 
@@ -461,7 +461,7 @@ export function declareRestrictionHttpRequestHandlerTests(
           headers: mismatchingHeaders,
         });
         const parsedRequest = await HttpInterceptorWorker.parseRawRequest<'/users', MethodSchema>(matchingRequest);
-        expect(handler.matchesRequest(parsedRequest)).toBe(false);
+        expect(await handler.matchesRequest(parsedRequest)).toBe(false);
       }
 
       for (const mismatchingSearchParams of mismatchingSearchParamsSamples) {
@@ -469,7 +469,7 @@ export function declareRestrictionHttpRequestHandlerTests(
           headers: mismatchingHeaders,
         });
         const parsedRequest = await HttpInterceptorWorker.parseRawRequest<'/users', MethodSchema>(request);
-        expect(handler.matchesRequest(parsedRequest)).toBe(false);
+        expect(await handler.matchesRequest(parsedRequest)).toBe(false);
       }
     }
   });

--- a/packages/zimic/src/interceptor/http/requestHandler/__tests__/shared/restrictions.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/__tests__/shared/restrictions.ts
@@ -109,6 +109,7 @@ export function declareRestrictionHttpRequestHandlerTests(
 
         for (const mismatchingSearchParams of [
           new HttpSearchParams<SearchParamsSchema>({ name: `${name} other` }),
+          new HttpSearchParams<SearchParamsSchema>({ name: 'other' }),
           new HttpSearchParams<SearchParamsSchema>({}),
         ]) {
           const request = new Request(joinURL(baseURL, `?${mismatchingSearchParams.toString()}`));
@@ -215,6 +216,7 @@ export function declareRestrictionHttpRequestHandlerTests(
 
         for (const mismatchingHeaders of [
           new HttpHeaders<HeadersSchema>({ 'content-language': `${contentLanguage}/other` }),
+          new HttpHeaders<HeadersSchema>({ 'content-language': 'other' }),
           new HttpHeaders<HeadersSchema>({}),
         ]) {
           const request = new Request(baseURL, { headers: mismatchingHeaders });

--- a/packages/zimic/src/interceptor/http/requestHandler/types/public.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/types/public.ts
@@ -80,7 +80,7 @@ export type HttpRequestHandlerComputedRestriction<
   Schema extends HttpServiceSchema,
   Method extends HttpServiceSchemaMethod<Schema>,
   Path extends HttpServiceSchemaPath<Schema, Method>,
-> = (request: HttpInterceptorRequest<Path, Default<Schema[Path][Method]>>) => boolean;
+> = (request: HttpInterceptorRequest<Path, Default<Schema[Path][Method]>>) => PossiblePromise<boolean>;
 
 /**
  * A restriction to match intercepted requests.

--- a/packages/zimic/src/utils/blob.ts
+++ b/packages/zimic/src/utils/blob.ts
@@ -1,0 +1,11 @@
+export async function blobEquals(blob: Blob, otherBlob: Blob) {
+  return (
+    blob.type === otherBlob.type && blob.size === otherBlob.size && (await blob.text()) === (await otherBlob.text())
+  );
+}
+
+export async function blobContains(blob: Blob, otherBlob: Blob) {
+  return (
+    blob.type === otherBlob.type && blob.size >= otherBlob.size && (await otherBlob.text()).includes(await blob.text())
+  );
+}

--- a/packages/zimic/src/utils/blob.ts
+++ b/packages/zimic/src/utils/blob.ts
@@ -6,6 +6,6 @@ export async function blobEquals(blob: Blob, otherBlob: Blob) {
 
 export async function blobContains(blob: Blob, otherBlob: Blob) {
   return (
-    blob.type === otherBlob.type && blob.size >= otherBlob.size && (await otherBlob.text()).includes(await blob.text())
+    blob.type === otherBlob.type && blob.size >= otherBlob.size && (await blob.text()).includes(await otherBlob.text())
   );
 }

--- a/packages/zimic/src/utils/files.ts
+++ b/packages/zimic/src/utils/files.ts
@@ -1,4 +1,4 @@
-import { blobContains, blobEquals } from './blob';
+import { blobEquals } from './blob';
 
 export async function getFile() {
   /* istanbul ignore next -- @preserve
@@ -9,8 +9,4 @@ export async function getFile() {
 
 export async function fileEquals(file: File, otherFile: File) {
   return file.name === otherFile.name && (await blobEquals(file, otherFile));
-}
-
-export async function fileContains(file: File, otherFile: File) {
-  return file.name === otherFile.name && (await blobContains(file, otherFile));
 }

--- a/packages/zimic/src/utils/files.ts
+++ b/packages/zimic/src/utils/files.ts
@@ -12,5 +12,5 @@ export async function fileEquals(file: File, otherFile: File) {
 }
 
 export async function fileContains(file: File, otherFile: File) {
-  return file.name.includes(otherFile.name) && file.size >= otherFile.size && (await blobContains(file, otherFile));
+  return file.name === otherFile.name && (await blobContains(file, otherFile));
 }

--- a/packages/zimic/src/utils/files.ts
+++ b/packages/zimic/src/utils/files.ts
@@ -1,6 +1,16 @@
+import { blobContains, blobEquals } from './blob';
+
 export async function getFile() {
   /* istanbul ignore next -- @preserve
    * Ignoring as Node.js >=20 provides a global file and the import fallback won't run. */
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   return globalThis.File ?? (await import('buffer')).File;
+}
+
+export async function fileEquals(file: File, otherFile: File) {
+  return file.name.includes(otherFile.name) && (await blobEquals(file, otherFile));
+}
+
+export async function fileContains(file: File, otherFile: File) {
+  return file.name.includes(otherFile.name) && file.size >= otherFile.size && (await blobContains(file, otherFile));
 }

--- a/packages/zimic/src/utils/files.ts
+++ b/packages/zimic/src/utils/files.ts
@@ -8,7 +8,7 @@ export async function getFile() {
 }
 
 export async function fileEquals(file: File, otherFile: File) {
-  return file.name.includes(otherFile.name) && (await blobEquals(file, otherFile));
+  return file.name === otherFile.name && (await blobEquals(file, otherFile));
 }
 
 export async function fileContains(file: File, otherFile: File) {


### PR DESCRIPTION
### Features
- [#zimic] Added support to non-JSON body restrictions, including plain text, URLSearchParams, FormData and Blobs.

### Fixes
- [#zimic] Improved the algorithm to check equality checks for http headers, search params and form data.

### Documentation
- [#zimic] Added "thoroughly tested" to `README.md`.

Closes #14.
