### PR TITLE
chore(examples): ignore same host request logs

### DIFF
--- a/examples/with-next-js-pages/tests/interceptors/utils.ts
+++ b/examples/with-next-js-pages/tests/interceptors/utils.ts
@@ -1,4 +1,17 @@
+import { http } from 'zimic/interceptor';
+
 import githubInterceptor, { githubFixtures } from './github';
+
+http.default.onUnhandledRequest(async (request, context) => {
+  const url = new URL(request.url);
+
+  // Ignore requests to the same host
+  if (url.host === window.location.host) {
+    return;
+  }
+
+  await context.log();
+});
 
 export async function loadInterceptors() {
   await githubInterceptor.start();


### PR DESCRIPTION
### Chore
- [examples-next-js-pages] Ignored logs for requests to the same host.