### PR TITLE
refactor(#zimic)!: improve error exports

### DIFF
--- a/apps/zimic-test-client/tests/v0/interceptor/exports/exports.test.ts
+++ b/apps/zimic-test-client/tests/v0/interceptor/exports/exports.test.ts
@@ -32,6 +32,8 @@ import {
   type LiteralHttpServiceSchemaPath,
   type NonLiteralHttpServiceSchemaPath,
   type PathParamsSchemaFromPath,
+  InvalidJSONError,
+  InvalidFormDataError,
 } from 'zimic0';
 import {
   http,
@@ -63,9 +65,10 @@ import {
   type HttpRequestHandlerSearchParamsStaticRestriction,
   type HttpRequestHandlerStaticRestriction,
   type HttpRequestHandlerBodyStaticRestriction,
-  UnknownHttpInterceptorPlatform,
+  UnknownHttpInterceptorPlatformError,
+  UnknownHttpInterceptorTypeError,
   NotStartedHttpInterceptorError,
-  UnregisteredServiceWorkerError,
+  UnregisteredBrowserServiceWorkerError,
 } from 'zimic0/interceptor';
 
 describe('Exports', () => {
@@ -122,6 +125,11 @@ describe('Exports', () => {
     expectTypeOf<NonLiteralHttpServiceSchemaPath<never, never>>().not.toBeAny();
     expectTypeOf<PathParamsSchemaFromPath<never>>().not.toBeAny();
 
+    expectTypeOf<InvalidJSONError>().not.toBeAny();
+    expect(typeof InvalidJSONError).toBe('function');
+    expectTypeOf<InvalidFormDataError>().not.toBeAny();
+    expect(typeof InvalidFormDataError).toBe('function');
+
     expectTypeOf<HttpInterceptorNamespace>().not.toBeAny();
     expectTypeOf<HttpInterceptorNamespaceDefault>().not.toBeAny();
 
@@ -165,11 +173,13 @@ describe('Exports', () => {
     expectTypeOf<HttpRequestHandlerStaticRestriction<never, never, never>>().not.toBeAny();
     expectTypeOf<HttpRequestHandlerBodyStaticRestriction<never, never, never>>().not.toBeAny();
 
-    expectTypeOf<UnknownHttpInterceptorPlatform>().not.toBeAny();
-    expect(typeof UnknownHttpInterceptorPlatform).toBe('function');
+    expectTypeOf<UnknownHttpInterceptorPlatformError>().not.toBeAny();
+    expect(typeof UnknownHttpInterceptorPlatformError).toBe('function');
+    expectTypeOf<UnknownHttpInterceptorTypeError>().not.toBeAny();
+    expect(typeof UnknownHttpInterceptorTypeError).toBe('function');
     expectTypeOf<NotStartedHttpInterceptorError>().not.toBeAny();
     expect(typeof NotStartedHttpInterceptorError).toBe('function');
-    expectTypeOf<UnregisteredServiceWorkerError>().not.toBeAny();
-    expect(typeof UnregisteredServiceWorkerError).toBe('function');
+    expectTypeOf<UnregisteredBrowserServiceWorkerError>().not.toBeAny();
+    expect(typeof UnregisteredBrowserServiceWorkerError).toBe('function');
   });
 });

--- a/apps/zimic-test-client/tests/v0/interceptor/exports/exports.test.ts
+++ b/apps/zimic-test-client/tests/v0/interceptor/exports/exports.test.ts
@@ -105,6 +105,7 @@ describe('Exports', () => {
     expectTypeOf<HttpSchema.Response<never>>().not.toBeAny();
     expectTypeOf<HttpSchema.Headers<never>>().not.toBeAny();
     expectTypeOf<HttpSchema.SearchParams<never>>().not.toBeAny();
+    expectTypeOf<HttpSchema.FormData<never>>().not.toBeAny();
 
     expectTypeOf<HttpMethod>().not.toBeAny();
     expectTypeOf<HttpServiceSchema>().not.toBeAny();

--- a/packages/zimic/src/http/errors/InvalidFormDataError.ts
+++ b/packages/zimic/src/http/errors/InvalidFormDataError.ts
@@ -1,4 +1,4 @@
-class InvalidFormDataError extends TypeError {
+class InvalidFormDataError extends SyntaxError {
   constructor(value: string) {
     super(`Failed to parse value as form data: ${value}`);
     this.name = 'InvalidFormDataError';

--- a/packages/zimic/src/http/errors/InvalidJSONError.ts
+++ b/packages/zimic/src/http/errors/InvalidJSONError.ts
@@ -1,4 +1,4 @@
-class InvalidJSONError extends TypeError {
+class InvalidJSONError extends SyntaxError {
   constructor(value: string) {
     super(`Failed to parse value as JSON: ${value}`);
     this.name = 'InvalidJSONError';

--- a/packages/zimic/src/http/formData/HttpFormData.ts
+++ b/packages/zimic/src/http/formData/HttpFormData.ts
@@ -8,10 +8,6 @@ import { HttpFormDataSchema } from './types';
  * {@link https://developer.mozilla.org/docs/Web/API/FormData `FormData`} class.
  */
 class HttpFormData<Schema extends HttpFormDataSchema = HttpFormDataSchema> extends FormData {
-  constructor(form?: HTMLFormElement, submitter?: HTMLElement | null) {
-    super(form, submitter);
-  }
-
   set<Name extends keyof Schema & string>(
     name: Name,
     value: Exclude<ArrayItemIfArray<Defined<Schema[Name]>>, Blob>,

--- a/packages/zimic/src/http/formData/__tests__/HttpFormData.test.ts
+++ b/packages/zimic/src/http/formData/__tests__/HttpFormData.test.ts
@@ -7,7 +7,7 @@ import HttpFormData from '../HttpFormData';
 describe('HttpFormData', async () => {
   const File = await getFile();
 
-  const file = new File(['content'], 'file.txt');
+  const file = new File(['content'], 'file.txt', { type: 'text/plain' });
 
   const blob = new Blob(['content'], { type: 'text/plain' });
   const blobName = 'blob.txt';

--- a/packages/zimic/src/http/types/schema.ts
+++ b/packages/zimic/src/http/types/schema.ts
@@ -8,9 +8,6 @@ import { HttpBody } from './requests';
 export const HTTP_METHODS_WITH_REQUEST_BODY = Object.freeze(['POST', 'PUT', 'PATCH', 'DELETE'] as const);
 export type HttpMethodWithRequestBody = (typeof HTTP_METHODS_WITH_REQUEST_BODY)[number];
 
-export const HTTP_METHODS_WITHOUT_REQUEST_BODY = Object.freeze(['GET', 'HEAD', 'OPTIONS'] as const);
-export type HttpMethodWithoutRequestBody = (typeof HTTP_METHODS_WITHOUT_REQUEST_BODY)[number];
-
 export const HTTP_METHODS_WITH_RESPONSE_BODY = Object.freeze([
   'GET',
   'POST',
@@ -21,13 +18,7 @@ export const HTTP_METHODS_WITH_RESPONSE_BODY = Object.freeze([
 ] as const);
 export type HttpMethodWithResponseBody = (typeof HTTP_METHODS_WITH_RESPONSE_BODY)[number];
 
-export const HTTP_METHODS_WITHOUT_RESPONSE_BODY = Object.freeze(['HEAD'] as const);
-export type HttpMethodWithoutResponseBody = (typeof HTTP_METHODS_WITHOUT_RESPONSE_BODY)[number];
-
-export const HTTP_METHODS = Object.freeze([
-  ...HTTP_METHODS_WITH_REQUEST_BODY,
-  ...HTTP_METHODS_WITHOUT_REQUEST_BODY,
-] as const);
+export const HTTP_METHODS = Object.freeze(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'] as const);
 /**
  * A type representing the currently supported
  * {@link https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods `HTTP methods`}.

--- a/packages/zimic/src/index.ts
+++ b/packages/zimic/src/index.ts
@@ -1,3 +1,5 @@
+import InvalidFormDataError from './http/errors/InvalidFormDataError';
+import InvalidJSONError from './http/errors/InvalidJSONError';
 import HttpFormData from './http/formData/HttpFormData';
 import HttpHeaders from './http/headers/HttpHeaders';
 import HttpSearchParams from './http/searchParams/HttpSearchParams';
@@ -40,4 +42,4 @@ export type {
   PathParamsSchemaFromPath,
 } from './http/types/schema';
 
-export { HttpSearchParams, HttpHeaders, HttpFormData };
+export { HttpSearchParams, HttpHeaders, HttpFormData, InvalidJSONError, InvalidFormDataError };

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/baseURLs.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/baseURLs.ts
@@ -64,7 +64,7 @@ export function declareBaseURLHttpInterceptorTests(options: RuntimeSharedHttpInt
         expect(request.response.status).toBe(200);
 
         expectTypeOf(request.response.body).toEqualTypeOf<null>();
-        expect(request.response.body).toEqual(null);
+        expect(request.response.body).toBe(null);
       });
     }
   });

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/bodies.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/bodies.ts
@@ -18,7 +18,10 @@ import { usingHttpInterceptor } from '@tests/utils/interceptors';
 import { HttpInterceptorOptions } from '../../types/options';
 import { RuntimeSharedHttpInterceptorTestsOptions } from './types';
 
-async function createSampleFile(format: string, content: string[]) {
+export async function createSampleFile(
+  format: 'image' | 'audio' | 'font' | 'video' | 'binary',
+  content: string[],
+): Promise<File> {
   const File = await getFile();
 
   if (format === 'image') {
@@ -1187,7 +1190,7 @@ export async function declareBodyHttpInterceptorTests(options: RuntimeSharedHttp
     });
 
     describe('Blob', () => {
-      it.each(['binary', 'image', 'audio', 'font', 'video'])(
+      it.each(['binary', 'image', 'audio', 'font', 'video'] as const)(
         `should support intercepting ${method} requests having a binary body: %s`,
         async (format) => {
           type MethodSchema = HttpSchema.Method<{

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/bodies.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/bodies.ts
@@ -1,11 +1,11 @@
 import { beforeEach, describe, expect, expectTypeOf, it } from 'vitest';
 
+import InvalidFormDataError from '@/http/errors/InvalidFormDataError';
+import InvalidJSONError from '@/http/errors/InvalidJSONError';
 import HttpFormData from '@/http/formData/HttpFormData';
 import HttpSearchParams from '@/http/searchParams/HttpSearchParams';
 import { HTTP_METHODS_WITH_REQUEST_BODY, HttpSchema } from '@/http/types/schema';
 import { promiseIfRemote } from '@/interceptor/http/interceptorWorker/__tests__/utils/promises';
-import InvalidFormDataError from '@/interceptor/http/interceptorWorker/errors/InvalidFormDataError';
-import InvalidJSONError from '@/interceptor/http/interceptorWorker/errors/InvalidJSONError';
 import LocalHttpRequestHandler from '@/interceptor/http/requestHandler/LocalHttpRequestHandler';
 import RemoteHttpRequestHandler from '@/interceptor/http/requestHandler/RemoteHttpRequestHandler';
 import { JSONValue } from '@/types/json';

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/restrictions.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/restrictions.ts
@@ -1,11 +1,11 @@
 import { beforeEach, describe, expect, expectTypeOf, it } from 'vitest';
 
+import InvalidFormDataError from '@/http/errors/InvalidFormDataError';
 import HttpFormData from '@/http/formData/HttpFormData';
 import HttpHeaders from '@/http/headers/HttpHeaders';
 import HttpSearchParams from '@/http/searchParams/HttpSearchParams';
 import { HTTP_METHODS, HTTP_METHODS_WITH_REQUEST_BODY, HttpSchema } from '@/http/types/schema';
 import { promiseIfRemote } from '@/interceptor/http/interceptorWorker/__tests__/utils/promises';
-import InvalidFormDataError from '@/interceptor/http/interceptorWorker/errors/InvalidFormDataError';
 import LocalHttpRequestHandler from '@/interceptor/http/requestHandler/LocalHttpRequestHandler';
 import RemoteHttpRequestHandler from '@/interceptor/http/requestHandler/RemoteHttpRequestHandler';
 import { AccessControlHeaders, DEFAULT_ACCESS_CONTROL_HEADERS } from '@/interceptor/server/constants';

--- a/packages/zimic/src/interceptor/http/interceptor/errors/UnknownHttpInterceptorPlatformError.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/errors/UnknownHttpInterceptorPlatformError.ts
@@ -4,7 +4,7 @@
  *
  * @see {@link https://github.com/zimicjs/zimic#http-interceptorplatform `interceptor.platform()` API reference}
  */
-class UnknownHttpInterceptorPlatform extends Error {
+class UnknownHttpInterceptorPlatformError extends Error {
   /* istanbul ignore next -- @preserve
    * Ignoring because checking unknown platforms is currently not possible in our Vitest setup. */
   constructor() {
@@ -13,4 +13,4 @@ class UnknownHttpInterceptorPlatform extends Error {
   }
 }
 
-export default UnknownHttpInterceptorPlatform;
+export default UnknownHttpInterceptorPlatformError;

--- a/packages/zimic/src/interceptor/http/interceptorWorker/HttpInterceptorWorker.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/HttpInterceptorWorker.ts
@@ -1,5 +1,7 @@
 import chalk from 'chalk';
 
+import InvalidFormDataError from '@/http/errors/InvalidFormDataError';
+import InvalidJSONError from '@/http/errors/InvalidJSONError';
 import HttpFormData from '@/http/formData/HttpFormData';
 import HttpHeaders from '@/http/headers/HttpHeaders';
 import { HttpHeadersInit, HttpHeadersSchema } from '@/http/headers/types';
@@ -25,8 +27,6 @@ import {
   HttpInterceptorRequest,
   HttpInterceptorResponse,
 } from '../requestHandler/types/requests';
-import InvalidFormDataError from './errors/InvalidFormDataError';
-import InvalidJSONError from './errors/InvalidJSONError';
 import HttpInterceptorWorkerStore from './HttpInterceptorWorkerStore';
 import { HttpResponseFactory } from './types/requests';
 

--- a/packages/zimic/src/interceptor/http/interceptorWorker/LocalHttpInterceptorWorker.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/LocalHttpInterceptorWorker.ts
@@ -11,9 +11,9 @@ import { HttpMethod, HttpServiceSchema } from '@/http/types/schema';
 import { excludeNonPathParams, ensureUniquePathParams, createURL } from '@/utils/urls';
 
 import NotStartedHttpInterceptorError from '../interceptor/errors/NotStartedHttpInterceptorError';
-import UnknownHttpInterceptorPlatform from '../interceptor/errors/UnknownHttpInterceptorPlatform';
+import UnknownHttpInterceptorPlatformError from '../interceptor/errors/UnknownHttpInterceptorPlatformError';
 import HttpInterceptorClient from '../interceptor/HttpInterceptorClient';
-import UnregisteredServiceWorkerError from './errors/UnregisteredServiceWorkerError';
+import UnregisteredBrowserServiceWorkerError from './errors/UnregisteredBrowserServiceWorkerError';
 import HttpInterceptorWorker from './HttpInterceptorWorker';
 import { LocalHttpInterceptorWorkerOptions } from './types/options';
 import { BrowserHttpWorker, HttpResponseFactory, HttpWorker, NodeHttpWorker } from './types/requests';
@@ -60,8 +60,8 @@ class LocalHttpInterceptorWorker extends HttpInterceptorWorker {
     }
 
     /* istanbul ignore next -- @preserve
-     * Ignoring because checking unknown platforms is currently not possible in our Vitest setup. */
-    throw new UnknownHttpInterceptorPlatform();
+     * Ignoring because checking unknown platforms is not configured in our test setup. */
+    throw new UnknownHttpInterceptorPlatformError();
   }
 
   async start() {
@@ -94,8 +94,8 @@ class LocalHttpInterceptorWorker extends HttpInterceptorWorker {
   }
 
   private handleBrowserWorkerStartError(error: unknown) {
-    if (UnregisteredServiceWorkerError.matchesRawError(error)) {
-      throw new UnregisteredServiceWorkerError();
+    if (UnregisteredBrowserServiceWorkerError.matchesRawError(error)) {
+      throw new UnregisteredBrowserServiceWorkerError();
     }
     throw error;
   }

--- a/packages/zimic/src/interceptor/http/interceptorWorker/RemoteHttpInterceptorWorker.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/RemoteHttpInterceptorWorker.ts
@@ -8,7 +8,7 @@ import { WebSocket } from '@/webSocket/types';
 import WebSocketClient from '@/webSocket/WebSocketClient';
 
 import NotStartedHttpInterceptorError from '../interceptor/errors/NotStartedHttpInterceptorError';
-import UnknownHttpInterceptorPlatform from '../interceptor/errors/UnknownHttpInterceptorPlatform';
+import UnknownHttpInterceptorPlatformError from '../interceptor/errors/UnknownHttpInterceptorPlatformError';
 import HttpInterceptorClient, { AnyHttpInterceptorClient } from '../interceptor/HttpInterceptorClient';
 import { HttpInterceptorPlatform } from '../interceptor/types/options';
 import HttpInterceptorWorker from './HttpInterceptorWorker';
@@ -103,8 +103,8 @@ class RemoteHttpInterceptorWorker extends HttpInterceptorWorker {
     }
 
     /* istanbul ignore next -- @preserve
-     * Ignoring because checking unknown platforms is currently not possible in our Vitest setup. */
-    throw new UnknownHttpInterceptorPlatform();
+     * Ignoring because checking unknown platforms is not configured in our test setup. */
+    throw new UnknownHttpInterceptorPlatformError();
   }
 
   async stop() {

--- a/packages/zimic/src/interceptor/http/interceptorWorker/__tests__/HttpinterceptorWorker.browserNoWorker.test.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/__tests__/HttpinterceptorWorker.browserNoWorker.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { HttpInterceptorPlatform } from '../../interceptor/types/options';
-import UnregisteredServiceWorkerError from '../errors/UnregisteredServiceWorkerError';
+import UnregisteredBrowserServiceWorkerError from '../errors/UnregisteredBrowserServiceWorkerError';
 import { createHttpInterceptorWorker } from '../factory';
 import { BrowserHttpWorker } from '../types/requests';
 
@@ -14,7 +14,7 @@ describe('HttpInterceptorWorker (browser, no worker)', () => {
     });
 
     const interceptorStartPromise = interceptorWorker.start();
-    await expect(interceptorStartPromise).rejects.toThrowError(new UnregisteredServiceWorkerError());
+    await expect(interceptorStartPromise).rejects.toThrowError(new UnregisteredBrowserServiceWorkerError());
 
     expect(interceptorWorker.platform()).toBe(platform);
   });

--- a/packages/zimic/src/interceptor/http/interceptorWorker/errors/UnregisteredBrowserServiceWorkerError.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/errors/UnregisteredBrowserServiceWorkerError.ts
@@ -5,7 +5,7 @@ import { SERVICE_WORKER_FILE_NAME } from '@/cli/browser/shared/constants';
  *
  * @see {@link https://github.com/zimicjs/zimic#zimic-browser-init `zimic browser init` API reference}
  */
-class UnregisteredServiceWorkerError extends Error {
+class UnregisteredBrowserServiceWorkerError extends Error {
   constructor() {
     super(
       `Failed to register the browser service worker: ` +
@@ -13,10 +13,10 @@ class UnregisteredServiceWorkerError extends Error {
         'Did you forget to run "npx zimic browser init <public-directory>"?\n\n' +
         'Learn more at https://github.com/zimicjs/zimic#browser-post-install.',
     );
-    this.name = 'UnregisteredServiceWorkerError';
+    this.name = 'UnregisteredBrowserServiceWorkerError';
   }
 
-  static matchesRawError(error: unknown): error is UnregisteredServiceWorkerError {
+  static matchesRawError(error: unknown): error is UnregisteredBrowserServiceWorkerError {
     return (
       error instanceof Error &&
       error.message.toLowerCase().startsWith('[msw] failed to register a service worker for scope')
@@ -24,4 +24,4 @@ class UnregisteredServiceWorkerError extends Error {
   }
 }
 
-export default UnregisteredServiceWorkerError;
+export default UnregisteredBrowserServiceWorkerError;

--- a/packages/zimic/src/interceptor/index.ts
+++ b/packages/zimic/src/interceptor/index.ts
@@ -1,9 +1,15 @@
 import NotStartedHttpInterceptorError from './http/interceptor/errors/NotStartedHttpInterceptorError';
-import UnknownHttpInterceptorPlatform from './http/interceptor/errors/UnknownHttpInterceptorPlatform';
-import UnregisteredServiceWorkerError from './http/interceptorWorker/errors/UnregisteredServiceWorkerError';
+import UnknownHttpInterceptorPlatformError from './http/interceptor/errors/UnknownHttpInterceptorPlatformError';
+import UnknownHttpInterceptorTypeError from './http/interceptor/errors/UnknownHttpInterceptorTypeError';
+import UnregisteredBrowserServiceWorkerError from './http/interceptorWorker/errors/UnregisteredBrowserServiceWorkerError';
 import HttpInterceptorNamespace from './http/namespace/HttpInterceptorNamespace';
 
-export { UnknownHttpInterceptorPlatform, NotStartedHttpInterceptorError, UnregisteredServiceWorkerError };
+export {
+  UnknownHttpInterceptorPlatformError,
+  UnknownHttpInterceptorTypeError,
+  NotStartedHttpInterceptorError,
+  UnregisteredBrowserServiceWorkerError,
+};
 
 export type {
   HttpRequestHandlerResponseDeclaration,


### PR DESCRIPTION
### Refactoring
- [#zimic] Removed an unnecessary constructor of `FormData`.
- [#zimic] Simplified HTTP method declarations.
- [#zimic] Improved the error exports and renamed:
    - `UnknownHttpInterceptorPlatform` from `zimic/interceptor` to `UnknownHttpInterceptorPlatformError`
    - `UnregisteredServiceWorkerError` from `zimic/interceptor` to `UnregisteredBrowserServiceWorkerError`
