### PR TITLE
docs: non-json body code snippets

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     schedule:
       interval: weekly
     commit-message:
-      prefix: chore(deps)
+      prefix: chore
     target-branch: canary
     reviewers:
       - diego-aquino
@@ -39,7 +39,7 @@ updates:
     schedule:
       interval: weekly
     commit-message:
-      prefix: chore(deps)
+      prefix: chore
     target-branch: canary
     reviewers:
       - diego-aquino

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ Visit our [examples](./examples/README.md) to see how to use Zimic with popular 
    });
    ```
 
-    </details></td></tr><tr></tr><tr><td width="900px" valign="top"><details><summary><b>Remote</b></summary>
+    </details></td></tr><tr></tr><tr><td width="900px" valign="top"><details open><summary><b>Remote</b></summary>
 
    ```ts
    import { JSONValue } from 'zimic';
@@ -302,7 +302,7 @@ Visit our [examples](./examples/README.md) to see how to use Zimic with popular 
    console.log(users); // [{ username: 'diego-aquino' }]
    ```
 
-   </details></td></tr><tr></tr><tr><td width="900px" valign="top"><details><summary><b>Remote</b></summary>
+   </details></td></tr><tr></tr><tr><td width="900px" valign="top"><details open><summary><b>Remote</b></summary>
 
    ```ts
    const listHandler = await interceptor.get('/users').respond({

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ Visit our [examples](./examples/README.md) to see how to use Zimic with popular 
    });
    ```
 
-   </details></td><td valign="top"><details open><summary><b>Remote</b></summary>
+    </details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
 
    ```ts
    import { JSONValue } from 'zimic';
@@ -271,7 +271,7 @@ Visit our [examples](./examples/README.md) to see how to use Zimic with popular 
    });
    ```
 
-   </details></td></tr></table>
+    </details></td></tr></table>
 
 In this example, we're [creating an interceptor](#httpcreateinterceptor) for a service supporting `GET` requests to
 `/users`. A successful response contains an array of `User` objects. Learn more about
@@ -302,7 +302,7 @@ In this example, we're [creating an interceptor](#httpcreateinterceptor) for a s
    console.log(users); // [{ username: 'diego-aquino' }]
    ```
 
-   </details></td><td valign="top"><details open><summary><b>Remote</b></summary>
+   </details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
 
    ```ts
    const listHandler = await interceptor.get('/users').respond({
@@ -355,7 +355,7 @@ afterAll(async () => {
 });
 ```
 
-</details></td><td valign="top"><details open><summary><b>Remote</b></summary>
+</details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
 
 ```ts
 // Your interceptors
@@ -1041,13 +1041,12 @@ const interceptor = http.createInterceptor<{
 ##### Declaring HTTP requests
 
 Each method can have a `request`, which defines the schema of the accepted requests. `headers`, `searchParams`, and
-`body` are supported to provide type safety when applying mocks.
-
-[Path parameters](#dynamic-path-parameters) are automatically inferred from dynamic paths, such as `/users/:id`.
+`body` are supported to provide type safety when applying mocks. [Path parameters](#dynamic-path-parameters) are
+automatically inferred from dynamic paths, such as `/users/:id`.
 
 <details open>
   <summary>
-    Declaring a request with <b>search params</b>:
+    Declaring a request type with <b>search params</b>:
   </summary>
 
 ```ts
@@ -1074,7 +1073,7 @@ const interceptor = http.createInterceptor<{
 
 <details open>
   <summary>
-    Declaring a request with <b>JSON</b> body:
+    Declaring a request type with <b>JSON</b> body:
   </summary>
 
 ```ts
@@ -1099,9 +1098,15 @@ const interceptor = http.createInterceptor<{
 
 </details>
 
+> [!IMPORTANT]
+>
+> JSON body types cannot be declared using TypeScript interfaces, because they do not have implicit index signatures as
+> types do. Part of Zimic's JSON validation relies on index signatures. To workaround this, you can declare JSON bodies
+> using `type`. As an extra step to make sure the type is a valid JSON, you can use the utility type `JSONValue`.
+
 <details>
   <summary>
-    Declaring a request with <b>form data</b> body:
+    Declaring a request type with <b>form data</b> body:
   </summary>
 
 ```ts
@@ -1129,11 +1134,10 @@ const interceptor = http.createInterceptor<{
 
 <details>
   <summary>
-    Declaring a request with <b>blob</b> body:
+    Declaring a request type with <b>blob</b> body:
   </summary>
 
 ```ts
-import { HttpSchema } from 'zimic';
 import { http } from 'zimic/interceptor';
 
 const interceptor = http.createInterceptor<{
@@ -1152,11 +1156,10 @@ const interceptor = http.createInterceptor<{
 
 <details>
   <summary>
-    Declaring a request with <b>plain text</b> body:
+    Declaring a request type with <b>plain text</b> body:
   </summary>
 
 ```ts
-import { HttpSchema, JSONValue } from 'zimic';
 import { http } from 'zimic/interceptor';
 
 const interceptor = http.createInterceptor<{
@@ -1175,7 +1178,7 @@ const interceptor = http.createInterceptor<{
 
 <details>
   <summary>
-    Declaring a request with <b>search params</b> (<code>x-www-form-urlencoded</code>) body:
+    Declaring a request type with <b>search params</b> (<code>x-www-form-urlencoded</code>) body:
   </summary>
 
 ```ts
@@ -1204,13 +1207,6 @@ const interceptor = http.createInterceptor<{
 >
 > You only need to include in the schema the properties you want to use in your mocks. Headers, search params, or body
 > fields that are not used do not need to be declared, keeping your type definitions clean and concise.
-
-> [!IMPORTANT]
->
-> JSON body types cannot be declared using the keyword `interface`, because interfaces do not have implicit index
-> signatures as types do. Part of Zimic's JSON validation relies on index signatures. To workaround this, you can
-> declare JSON bodies using `type`. As an extra step to make sure the type is a valid JSON, you can use the utility type
-> `JSONValue`.
 
 <details>
   <summary>
@@ -1254,7 +1250,7 @@ text.
 
 <details open>
   <summary>
-    Declaring a response with <b>JSON</b> body:
+    Declaring a response type with <b>JSON</b> body:
   </summary>
 
 ```ts
@@ -1286,9 +1282,16 @@ const interceptor = http.createInterceptor<{
 
 </details>
 
+> [!IMPORTANT]
+>
+> Also similarly to [declaring HTTP requests](#declaring-http-requests), JSON body types cannot be declared using
+> TypeScript interfaces, because they do not have implicit index signatures as types do. Part of Zimic's JSON validation
+> relies on index signatures. To workaround this, you can declare bodies using `type`. As an extra step to make sure the
+> type is a valid JSON, you can use the utility type `JSONValue`.
+
 <details>
   <summary>
-    Declaring a response with <b>form data</b> body:
+    Declaring a response type with <b>form data</b> body:
   </summary>
 
 ```ts
@@ -1318,11 +1321,10 @@ const interceptor = http.createInterceptor<{
 
 <details>
   <summary>
-    Declaring a response with <b>blob</b> body:
+    Declaring a response type with <b>blob</b> body:
   </summary>
 
 ```ts
-import { HttpSchema } from 'zimic';
 import { http } from 'zimic/interceptor';
 
 const interceptor = http.createInterceptor<{
@@ -1343,11 +1345,10 @@ const interceptor = http.createInterceptor<{
 
 <details>
   <summary>
-    Declaring a response with <b>plain text</b> body:
+    Declaring a response type with <b>plain text</b> body:
   </summary>
 
 ```ts
-import { HttpSchema, JSONValue } from 'zimic';
 import { http } from 'zimic/interceptor';
 
 const interceptor = http.createInterceptor<{
@@ -1368,7 +1369,7 @@ const interceptor = http.createInterceptor<{
 
 <details>
   <summary>
-    Declaring a response with <b>search params</b> (<code>x-www-form-urlencoded</code>) body:
+    Declaring a response type with <b>search params</b> (<code>x-www-form-urlencoded</code>) body:
   </summary>
 
 ```ts
@@ -1400,13 +1401,6 @@ const interceptor = http.createInterceptor<{
 > Similarly to [declaring HTTP requests](#declaring-http-requests), you only need to include in the schema the
 > properties you want to use in your mocks. Headers, search params, or body fields that are not used do not need to be
 > declared, keeping your type definitions clean and concise.
-
-> [!IMPORTANT]
->
-> Also similarly to [declaring HTTP requests](#declaring-http-requests), body types cannot be declared using the keyword
-> `interface`, because interfaces do not have implicit index signatures as types do. Part of Zimic's JSON validation
-> relies on index signatures. To workaround this, you can declare bodies using `type`. As an extra step to make sure the
-> type is a valid JSON, you can use the utility type `JSONValue`.
 
 <details>
   <summary>
@@ -1530,7 +1524,7 @@ const listHandler = interceptor.get('/users').respond({
 });
 ```
 
-</details></td><td valign="top"><details open><summary><b>Remote</b></summary>
+</details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
 
 ```ts
 import { http } from 'zimic/interceptor';
@@ -1603,7 +1597,7 @@ const updateHandler = interceptor.put('/users/:id').respond((request) => {
 await fetch('http://localhost:3000/users/1', { method: 'PUT' });
 ```
 
-</details></td><td valign="top"><details open><summary><b>Remote</b></summary>
+</details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
 
 ```ts
 const updateHandler = await interceptor.put('/users/:id').respond((request) => {
@@ -1634,7 +1628,7 @@ This method is useful to reset the interceptor mocks between tests.
 interceptor.clear();
 ```
 
-</details></td><td valign="top"><details open><summary><b>Remote</b></summary>
+</details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
 
 ```ts
 await interceptor.clear();
@@ -1663,7 +1657,7 @@ const method = handler.method();
 console.log(method); // 'POST'
 ```
 
-</details></td><td valign="top"><details open><summary><b>Remote</b></summary>
+</details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
 
 ```ts
 const handler = await interceptor.post('/users');
@@ -1686,7 +1680,7 @@ const path = handler.path();
 console.log(path); // '/users'
 ```
 
-</details></td><td valign="top"><details open><summary><b>Remote</b></summary>
+</details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
 
 ```ts
 const handler = await interceptor.get('/users');
@@ -1707,187 +1701,43 @@ condition.
 
 <details open>
   <summary>
-    Declaring restrictions over a <b>JSON</b> body:
+    Declaring restrictions for <b>headers</b>:
   </summary>
 
 <table><tr><td valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 const creationHandler = interceptor
-  .post('/users')
+  .get('/users')
   .with({
-    body: { username: 'diego-aquino' },
+    headers: { authorization: 'Bearer <token>' },
   })
   .respond({
-    status: 201,
-    body: { username: 'diego-aquino' },
+    status: 200,
+    body: [{ username: 'diego-aquino' }],
   });
 ```
 
-</details></td><td valign="top"><details open><summary><b>Remote</b></summary>
+</details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
 
 ```ts
 const creationHandler = await interceptor
-  .post('/users')
+  .get('/users')
   .with({
-    body: { username: 'diego-aquino' },
+    headers: { authorization: 'Bearer <token>' },
   })
   .respond({
-    status: 201,
-    body: { username: 'diego-aquino' },
+    status: 200,
+    body: [{ username: 'diego-aquino' }],
   });
 ```
 
 </details></td></tr></table>
-
-> [!IMPORTANT]
->
-> For the body to be correctly parsed, make sure that the intercepted requests have the header
-> `content-type: application/json`.
-
-</details>
-
-<details>
-  <summary>
-    Declaring restrictions over a <b>form data</b> body:
-  </summary>
-
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
-
-```ts
-import { HttpFormData } from 'zimic';
-
-const formData = new HttpFormData<UserCreationData>();
-formData.append('username', 'diego-aquino');
-formData.append('profilePicture', new File(['content'], 'profile.png', { type: 'image/png' }));
-
-const creationHandler = interceptor
-  .post('/users')
-  .with({
-    body: formData,
-  })
-  .respond({
-    status: 201,
-    body: { username: 'diego-aquino' },
-  });
-```
-
-</details></td><td valign="top"><details open><summary><b>Remote</b></summary>
-
-```ts
-import { HttpFormData } from 'zimic';
-
-const formData = new HttpFormData<UserCreationData>();
-formData.append('username', 'diego-aquino');
-formData.append('profilePicture', new File(['content'], 'profile.png', { type: 'image/png' }));
-
-const creationHandler = await interceptor
-  .post('/users')
-  .with({
-    body: formData,
-  })
-  .respond({
-    status: 201,
-    body: { username: 'diego-aquino' },
-  });
-```
-
-</details></td></tr></table>
-
-> [!IMPORTANT]
->
-> For the body to be correctly parsed, make sure that the intercepted requests have the header
-> `content-type: multipart/form-data`.
-
-</details>
-
-<details>
-  <summary>
-    Declaring restrictions over a <b>blob</b> body:
-  </summary>
-
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
-
-```ts
-const creationHandler = interceptor
-  .post('/users')
-  .with({
-    body: new Blob(['content'], { type: 'application/octet-stream' }),
-  })
-  .respond({
-    status: 201,
-    body: { username: 'diego-aquino' },
-  });
-```
-
-</details></td><td valign="top"><details open><summary><b>Remote</b></summary>
-
-```ts
-const creationHandler = await interceptor
-  .post('/users')
-  .with({
-    body: new Blob(['content'], { type: 'application/octet-stream' }),
-  })
-  .respond({
-    status: 201,
-    body: { username: 'diego-aquino' },
-  });
-```
-
-</details></td></tr></table>
-
-> [!IMPORTANT]
->
-> For the body to be correctly parsed, make sure that the intercepted requests have the header `content-type` indicating
-> a binary data, such as `application/octet-stream`, `image/png`, `audio/mpeg`, etc.
-
-</details>
-
-<details>
-  <summary>
-    Declaring restrictions over a <b>plain text</b> body:
-  </summary>
-
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
-
-```ts
-const creationHandler = interceptor
-  .post('/users')
-  .with({
-    body: 'content',
-  })
-  .respond({
-    status: 201,
-    body: { username: 'diego-aquino' },
-  });
-```
-
-</details></td><td valign="top"><details open><summary><b>Remote</b></summary>
-
-```ts
-const creationHandler = await interceptor
-  .post('/users')
-  .with({
-    body: 'content',
-  })
-  .respond({
-    status: 201,
-    body: { username: 'diego-aquino' },
-  });
-```
-
-</details></td></tr></table>
-
-> [!IMPORTANT]
->
-> For the body to be correctly parsed, make sure that the intercepted requests have the header `content-type` indicating
-> a plain text, such as `text/plain`.
-
 </details>
 
 <details open>
   <summary>
-    Declaring restrictions over <b>search params</b>:
+    Declaring restrictions for <b>search params</b>:
   </summary>
 
 <table><tr><td valign="top"><details open><summary><b>Local</b></summary>
@@ -1904,7 +1754,7 @@ const creationHandler = interceptor
   });
 ```
 
-</details></td><td valign="top"><details open><summary><b>Remote</b></summary>
+</details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
 
 ```ts
 const creationHandler = await interceptor
@@ -1923,38 +1773,188 @@ const creationHandler = await interceptor
 
 <details open>
   <summary>
-    Declaring restrictions over <b>headers</b>:
+    Declaring restrictions for a <b>JSON</b> body:
   </summary>
 
 <table><tr><td valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 const creationHandler = interceptor
-  .get('/users')
+  .post('/users')
   .with({
-    headers: { authorization: 'Bearer <token>' },
+    body: { username: 'diego-aquino' },
   })
   .respond({
-    status: 200,
-    body: [{ username: 'diego-aquino' }],
+    status: 201,
+    body: { username: 'diego-aquino' },
   });
 ```
 
-</details></td><td valign="top"><details open><summary><b>Remote</b></summary>
+</details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
 
 ```ts
 const creationHandler = await interceptor
-  .get('/users')
+  .post('/users')
   .with({
-    headers: { authorization: 'Bearer <token>' },
+    body: { username: 'diego-aquino' },
   })
   .respond({
-    status: 200,
-    body: [{ username: 'diego-aquino' }],
+    status: 201,
+    body: { username: 'diego-aquino' },
   });
 ```
 
 </details></td></tr></table>
+
+For JSON bodies to be correctly parsed, make sure that the intercepted requests have the header
+`content-type: application/json`.
+
+</details>
+
+<details>
+  <summary>
+    Declaring restrictions for a <b>form data</b> body:
+  </summary>
+
+<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+
+```ts
+import { HttpFormData } from 'zimic';
+
+const formData = new HttpFormData<UserCreationData>();
+formData.append('username', 'diego-aquino');
+formData.append(
+  'profilePicture',
+  new File(['content'], 'profile.png', {
+    type: 'image/png',
+  }),
+);
+
+const creationHandler = interceptor
+  .post('/users')
+  .with({
+    body: formData,
+  })
+  .respond({
+    status: 201,
+    body: { username: 'diego-aquino' },
+  });
+```
+
+</details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
+
+```ts
+import { HttpFormData } from 'zimic';
+
+const formData = new HttpFormData<UserCreationData>();
+formData.append('username', 'diego-aquino');
+formData.append(
+  'profilePicture',
+  new File(['content'], 'profile.png', {
+    type: 'image/png',
+  }),
+);
+
+const creationHandler = await interceptor
+  .post('/users')
+  .with({
+    body: formData,
+  })
+  .respond({
+    status: 201,
+    body: { username: 'diego-aquino' },
+  });
+```
+
+</details></td></tr></table>
+
+For form data bodies to be correctly parsed, make sure that the intercepted requests have the header
+`content-type: multipart/form-data`.
+
+</details>
+
+<details>
+  <summary>
+    Declaring restrictions for a <b>blob</b> body:
+  </summary>
+
+<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+
+```ts
+const creationHandler = interceptor
+  .post('/users')
+  .with({
+    body: new Blob(['content'], {
+      type: 'application/octet-stream',
+    }),
+  })
+  .respond({
+    status: 201,
+    body: { username: 'diego-aquino' },
+  });
+```
+
+</details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
+
+```ts
+const creationHandler = await interceptor
+  .post('/users')
+  .with({
+    body: new Blob(['content'], {
+      type: 'application/octet-stream',
+    }),
+  })
+  .respond({
+    status: 201,
+    body: { username: 'diego-aquino' },
+  });
+```
+
+</details></td></tr></table>
+
+For blob bodies to be correctly parsed, make sure that the intercepted requests have the header `content-type`
+indicating a binary data, such as `application/octet-stream`, `image/png`, `audio/mpeg`, etc.
+
+</details>
+
+<details>
+  <summary>
+    Declaring restrictions for a <b>plain text</b> body:
+  </summary>
+
+<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+
+```ts
+const creationHandler = interceptor
+  .post('/users')
+  .with({
+    body: 'content',
+  })
+  .respond({
+    status: 201,
+    body: { username: 'diego-aquino' },
+  });
+```
+
+</details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
+
+```ts
+const creationHandler = await interceptor
+  .post('/users')
+  .with({
+    body: 'content',
+  })
+  .respond({
+    status: 201,
+    body: { username: 'diego-aquino' },
+  });
+```
+
+</details></td></tr></table>
+
+For plain text bodies to be correctly parsed, make sure that the intercepted requests have the header `content-type`
+indicating a plain text, such as `text/plain`.
+
 </details>
 
 By default, restrictions use `exact: false`, meaning that any request **containing** the declared restrictions will
@@ -1980,7 +1980,7 @@ const creationHandler = interceptor
   });
 ```
 
-</details></td><td valign="top"><details open><summary><b>Remote</b></summary>
+</details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
 
 ```ts
 const creationHandler = await interceptor
@@ -2018,7 +2018,7 @@ const creationHandler = interceptor
   });
 ```
 
-</details></td><td valign="top"><details open><summary><b>Remote</b></summary>
+</details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
 
 ```ts
 const creationHandler = await interceptor
@@ -2063,7 +2063,7 @@ const listHandler = interceptor.get('/users').respond({
 });
 ```
 
-</details></td><td valign="top"><details open><summary><b>Remote</b></summary>
+</details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
 
 ```ts
 const listHandler = await interceptor.get('/users').respond({
@@ -2087,7 +2087,12 @@ import { HttpFormData } from 'zimic';
 
 const formData = new HttpFormData<UserGetByIdData>();
 formData.append('username', 'diego-aquino');
-formData.append('profilePicture', new File(['content'], 'profile.png', { type: 'image/png' }));
+formData.append(
+  'profilePicture',
+  new File(['content'], 'profile.png', {
+    type: 'image/png',
+  }),
+);
 
 const listHandler = interceptor.get('/users/:id').respond({
   status: 200,
@@ -2095,14 +2100,19 @@ const listHandler = interceptor.get('/users/:id').respond({
 });
 ```
 
-</details></td><td valign="top"><details open><summary><b>Remote</b></summary>
+</details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
 
 ```ts
 import { HttpFormData } from 'zimic';
 
 const formData = new HttpFormData<UserGetByIdData>();
 formData.append('username', 'diego-aquino');
-formData.append('profilePicture', new File(['content'], 'profile.png', { type: 'image/png' }));
+formData.append(
+  'profilePicture',
+  new File(['content'], 'profile.png', {
+    type: 'image/png',
+  }),
+);
 
 const listHandler = await interceptor.get('/users/:id').respond({
   status: 200,
@@ -2123,16 +2133,20 @@ const listHandler = await interceptor.get('/users/:id').respond({
 ```ts
 const listHandler = interceptor.get('/users').respond({
   status: 200,
-  body: new Blob(['content'], { type: 'application/octet-stream' }),
+  body: new Blob(['content'], {
+    type: 'application/octet-stream',
+  }),
 });
 ```
 
-</details></td><td valign="top"><details open><summary><b>Remote</b></summary>
+</details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
 
 ```ts
 const listHandler = await interceptor.get('/users').respond({
   status: 200,
-  body: new Blob(['content'], { type: 'application/octet-stream' }),
+  body: new Blob(['content'], {
+    type: 'application/octet-stream',
+  }),
 });
 ```
 
@@ -2153,7 +2167,7 @@ const listHandler = interceptor.get('/users').respond({
 });
 ```
 
-</details></td><td valign="top"><details open><summary><b>Remote</b></summary>
+</details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
 
 ```ts
 const listHandler = await interceptor.get('/users').respond({
@@ -2170,7 +2184,7 @@ const listHandler = await interceptor.get('/users').respond({
     Declaring responses with <b>search params</b> (<code>x-www-form-urlencoded</code>) body:
   </summary>
 
-<table><tr><td valign="top"><details open><summary><b>Local</b</summary>
+<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 import { HttpSearchParams } from 'zimic';
@@ -2185,7 +2199,7 @@ const listHandler = interceptor.get('/users').respond({
 });
 ```
 
-</details></td><td valign="top"><details open><summary><b>Remote</b</summary>
+</details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
 
 ```ts
 import { HttpSearchParams } from 'zimic';
@@ -2219,7 +2233,7 @@ const listHandler = interceptor.get('/users').respond((request) => {
 });
 ```
 
-</details></td><td valign="top"><details open><summary><b>Remote</b></summary>
+</details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
 
 ```ts
 const listHandler = await interceptor.get('/users').respond((request) => {
@@ -2265,7 +2279,7 @@ otherListHandler.bypass();
 // Now, requests GET /users will match `listHandler` and receive an empty array
 ```
 
-</details></td><td valign="top"><details open><summary><b>Remote</b></summary>
+</details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
 
 ```ts
 const listHandler = await interceptor.get('/users').respond({
@@ -2315,7 +2329,7 @@ otherListHandler.clear();
 otherListHandler.requests(); // Now empty
 ```
 
-</details></td><td valign="top"><details open><summary><b>Remote</b></summary>
+</details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
 
 ```ts
 const listHandler = await interceptor.get('/users').respond({
@@ -2363,7 +2377,7 @@ expect(updateRequests[0].pathParams).toEqual({ id: '1' });
 expect(updateRequests[0].body).toEqual({ username: 'new' });
 ```
 
-</details></td><td valign="top"><details open><summary><b>Remote</b></summary>
+</details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
 
 ```ts
 const updateHandler = await interceptor.put('/users/:id').respond((request) => {
@@ -2407,7 +2421,7 @@ console.log(listRequests[0].raw); // Request{}
 console.log(listRequests[0].response.raw); // Response{}
 ```
 
-</details></td><td valign="top"><details open><summary><b>Remote</b></summary>
+</details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
 
 ```ts
 const listRequests = await listHandler.requests();

--- a/README.md
+++ b/README.md
@@ -168,7 +168,8 @@ Our [Vitest](./examples/README.md#vitest), [Jest](./examples/README.md#jest), an
 
 > [!IMPORTANT]
 >
-> All mocking operations in local interceptor are _synchronous_. There's no need to `await` them before making requests.
+> All mocking operations in local interceptor are **synchronous**. There's no need to `await` them before making
+> requests.
 
 #### Remote HTTP interceptors
 
@@ -191,10 +192,10 @@ remote interceptors.
 
 > [!IMPORTANT]
 >
-> All mocking operations in remote interceptors are _asynchronous_. Make sure to `await` them before making requests.
+> All mocking operations in remote interceptors are **asynchronous**. Make sure to `await` them before making requests.
 >
-> Some code snippets in this `README.md` display a local and a remote interceptor example side by side. Generally, the
-> remote snippets differ only by adding `await` when necessary.
+> Many code snippets in this `README.md` show examples with a local and a remote interceptor. Generally, the remote
+> snippets differ only by adding `await` where necessary.
 >
 > If you are using [`typescript-eslint`](https://typescript-eslint.io), a handy rule is
 > [`@typescript-eslint/no-floating-promises`](https://typescript-eslint.io/rules/no-floating-promises). It checks that

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ Visit our [examples](./examples/README.md) to see how to use Zimic with popular 
    });
    ```
 
-    </details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+    </details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
    ```ts
    import { JSONValue } from 'zimic';
@@ -273,11 +273,11 @@ Visit our [examples](./examples/README.md) to see how to use Zimic with popular 
 
     </details></td></tr></table>
 
-In this example, we're [creating an interceptor](#httpcreateinterceptor) for a service supporting `GET` requests to
-`/users`. A successful response contains an array of `User` objects. Learn more about
-[declaring HTTP service schemas](#declaring-http-service-schemas).
+   In this example, we're [creating an interceptor](#httpcreateinterceptor) for a service supporting `GET` requests to
+   `/users`. A successful response contains an array of `User` objects. Learn more about
+   [declaring HTTP service schemas](#declaring-http-service-schemas).
 
-1. Then, start the interceptor:
+2. Then, start the interceptor:
 
    ```ts
    await interceptor.start();
@@ -287,7 +287,7 @@ In this example, we're [creating an interceptor](#httpcreateinterceptor) for a s
    [interceptor server](#zimic-server-start) before starting it. The base URL of the remote interceptor should point to
    the server, optionally including a path to differentiate from other interceptors.
 
-2. Now, you can intercept requests and return mock responses!
+3. Now, you can intercept requests and return mock responses!
 
    <table><tr><td valign="top"><details open><summary><b>Local</b></summary>
 
@@ -302,7 +302,7 @@ In this example, we're [creating an interceptor](#httpcreateinterceptor) for a s
    console.log(users); // [{ username: 'diego-aquino' }]
    ```
 
-   </details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+   </details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
    ```ts
    const listHandler = await interceptor.get('/users').respond({
@@ -355,7 +355,7 @@ afterAll(async () => {
 });
 ```
 
-</details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+</details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 // Your interceptors
@@ -1524,7 +1524,7 @@ const listHandler = interceptor.get('/users').respond({
 });
 ```
 
-</details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+</details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 import { http } from 'zimic/interceptor';
@@ -1597,7 +1597,7 @@ const updateHandler = interceptor.put('/users/:id').respond((request) => {
 await fetch('http://localhost:3000/users/1', { method: 'PUT' });
 ```
 
-</details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+</details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const updateHandler = await interceptor.put('/users/:id').respond((request) => {
@@ -1628,7 +1628,7 @@ This method is useful to reset the interceptor mocks between tests.
 interceptor.clear();
 ```
 
-</details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+</details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 await interceptor.clear();
@@ -1657,7 +1657,7 @@ const method = handler.method();
 console.log(method); // 'POST'
 ```
 
-</details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+</details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const handler = await interceptor.post('/users');
@@ -1680,7 +1680,7 @@ const path = handler.path();
 console.log(path); // '/users'
 ```
 
-</details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+</details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const handler = await interceptor.get('/users');
@@ -1718,7 +1718,7 @@ const creationHandler = interceptor
   });
 ```
 
-</details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+</details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const creationHandler = await interceptor
@@ -1754,7 +1754,7 @@ const creationHandler = interceptor
   });
 ```
 
-</details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+</details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const creationHandler = await interceptor
@@ -1790,7 +1790,7 @@ const creationHandler = interceptor
   });
 ```
 
-</details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+</details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const creationHandler = await interceptor
@@ -1841,7 +1841,7 @@ const creationHandler = interceptor
   });
 ```
 
-</details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+</details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 import { HttpFormData } from 'zimic';
@@ -1894,7 +1894,7 @@ const creationHandler = interceptor
   });
 ```
 
-</details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+</details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const creationHandler = await interceptor
@@ -1936,7 +1936,7 @@ const creationHandler = interceptor
   });
 ```
 
-</details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+</details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const creationHandler = await interceptor
@@ -1980,7 +1980,7 @@ const creationHandler = interceptor
   });
 ```
 
-</details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+</details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const creationHandler = await interceptor
@@ -2018,7 +2018,7 @@ const creationHandler = interceptor
   });
 ```
 
-</details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+</details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const creationHandler = await interceptor
@@ -2063,7 +2063,7 @@ const listHandler = interceptor.get('/users').respond({
 });
 ```
 
-</details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+</details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const listHandler = await interceptor.get('/users').respond({
@@ -2100,7 +2100,7 @@ const listHandler = interceptor.get('/users/:id').respond({
 });
 ```
 
-</details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+</details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 import { HttpFormData } from 'zimic';
@@ -2139,7 +2139,7 @@ const listHandler = interceptor.get('/users').respond({
 });
 ```
 
-</details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+</details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const listHandler = await interceptor.get('/users').respond({
@@ -2167,7 +2167,7 @@ const listHandler = interceptor.get('/users').respond({
 });
 ```
 
-</details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+</details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const listHandler = await interceptor.get('/users').respond({
@@ -2199,7 +2199,7 @@ const listHandler = interceptor.get('/users').respond({
 });
 ```
 
-</details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+</details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 import { HttpSearchParams } from 'zimic';
@@ -2233,7 +2233,7 @@ const listHandler = interceptor.get('/users').respond((request) => {
 });
 ```
 
-</details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+</details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const listHandler = await interceptor.get('/users').respond((request) => {
@@ -2279,7 +2279,7 @@ otherListHandler.bypass();
 // Now, requests GET /users will match `listHandler` and receive an empty array
 ```
 
-</details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+</details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const listHandler = await interceptor.get('/users').respond({
@@ -2329,7 +2329,7 @@ otherListHandler.clear();
 otherListHandler.requests(); // Now empty
 ```
 
-</details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+</details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const listHandler = await interceptor.get('/users').respond({
@@ -2377,7 +2377,7 @@ expect(updateRequests[0].pathParams).toEqual({ id: '1' });
 expect(updateRequests[0].body).toEqual({ username: 'new' });
 ```
 
-</details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+</details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const updateHandler = await interceptor.put('/users/:id').respond((request) => {
@@ -2421,7 +2421,7 @@ console.log(listRequests[0].raw); // Request{}
 console.log(listRequests[0].response.raw); // Response{}
 ```
 
-</details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+</details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const listRequests = await listHandler.requests();

--- a/README.md
+++ b/README.md
@@ -1047,7 +1047,7 @@ Each method can have a `request`, which defines the schema of the accepted reque
 
 <details open>
   <summary>
-    Declaring a request with search params:
+    Declaring a request with <b>search params</b>:
   </summary>
 
 ```ts
@@ -1074,7 +1074,7 @@ const interceptor = http.createInterceptor<{
 
 <details open>
   <summary>
-    Declaring a request with a JSON body using <code>JSONValue</code>:
+    Declaring a request with a <b>JSON body</b> using <code>JSONValue</code>:
   </summary>
 
 ```ts
@@ -1101,7 +1101,7 @@ const interceptor = http.createInterceptor<{
 
 <details>
   <summary>
-    Declaring a request with a form data body using <a href='#httpformdata'><code>HttpFormData</code></a>:
+    Declaring a request with a <b>form data body</b> using <a href='#httpformdata'><code>HttpFormData</code></a>:
   </summary>
 
 ```ts
@@ -1133,7 +1133,7 @@ const interceptor = http.createInterceptor<{
 
 <details>
   <summary>
-    Declaring a request with a blob body:
+    Declaring a request with a <b>blob body</b>:
   </summary>
 
 ```ts
@@ -1156,7 +1156,7 @@ const interceptor = http.createInterceptor<{
 
 <details>
   <summary>
-    Declaring a request with plain text body:
+    Declaring a request with <b>plain text body</b>:
   </summary>
 
 ```ts
@@ -1179,7 +1179,7 @@ const interceptor = http.createInterceptor<{
 
 <details>
   <summary>
-    Declaring a request with a search params body (<code>x-www-form-urlencoded</code>) using <a href='#httpsearchparams'><code>HttpSearchParams</code></a>:
+    Declaring a request with a <b>search params body</b> (<code>x-www-form-urlencoded</code>) using <a href='#httpsearchparams'><code>HttpSearchParams</code></a>:
   </summary>
 
 ```ts
@@ -1258,7 +1258,7 @@ text.
 
 <details open>
   <summary>
-    Declaring a response with a JSON body using <code>JSONValue</code>:
+    Declaring a response with a <b>JSON body</b> using <code>JSONValue</code>:
   </summary>
 
 ```ts
@@ -1292,7 +1292,7 @@ const interceptor = http.createInterceptor<{
 
 <details>
   <summary>
-    Declaring a response with a form data body using <a href='#httpformdata'><code>HttpFormData</code></a>:
+    Declaring a response with a <b>form data body</b> using <a href='#httpformdata'><code>HttpFormData</code></a>:
   </summary>
 
 ```ts
@@ -1322,7 +1322,7 @@ const interceptor = http.createInterceptor<{
 
 <details>
   <summary>
-    Declaring a response with a blob body:
+    Declaring a response with a <b>blob body</b>:
   </summary>
 
 ```ts
@@ -1347,7 +1347,7 @@ const interceptor = http.createInterceptor<{
 
 <details>
   <summary>
-    Declaring a response with plain text body:
+    Declaring a response with <b>plain text body</b>:
   </summary>
 
 ```ts
@@ -1372,7 +1372,7 @@ const interceptor = http.createInterceptor<{
 
 <details>
   <summary>
-    Declaring a response with a search params body (<code>x-www-form-urlencoded</code>) using <a href='#httpsearchparams'><code>HttpSearchParams</code></a>:
+    Declaring a response with a <b>search params body</b> (<code>x-www-form-urlencoded</code>) using <a href='#httpsearchparams'><code>HttpSearchParams</code></a>:
   </summary>
 
 ```ts
@@ -1711,7 +1711,7 @@ condition.
 
 <details open>
   <summary>
-    Declaring restrictions over a JSON body:
+    Declaring restrictions over a <b>JSON body</b>:
   </summary>
 
 <table><tr><td valign="top"><details open><summary><b>Local</b></summary>
@@ -1753,7 +1753,7 @@ const creationHandler = await interceptor
 
 <details>
   <summary>
-    Declaring restrictions over a form data body:
+    Declaring restrictions over a <b>form data body</b>:
   </summary>
 
 <table><tr><td valign="top"><details open><summary><b>Local</b></summary>
@@ -1807,7 +1807,7 @@ const creationHandler = await interceptor
 
 <details>
   <summary>
-    Declaring restrictions over a blob body:
+    Declaring restrictions over a <b>blob body</b>:
   </summary>
 
 <table><tr><td valign="top"><details open><summary><b>Local</b></summary>
@@ -1849,7 +1849,7 @@ const creationHandler = await interceptor
 
 <details>
   <summary>
-    Declaring restrictions over a plain text body:
+    Declaring restrictions over a <b>plain text body</b>:
   </summary>
 
 <table><tr><td valign="top"><details open><summary><b>Local</b></summary>
@@ -1891,7 +1891,7 @@ const creationHandler = await interceptor
 
 <details open>
   <summary>
-    Declaring restrictions over search params:
+    Declaring restrictions over <b>search params</b>:
   </summary>
 
 <table><tr><td valign="top"><details open><summary><b>Local</b></summary>
@@ -1927,7 +1927,7 @@ const creationHandler = await interceptor
 
 <details open>
   <summary>
-    Declaring restrictions over headers:
+    Declaring restrictions over <b>headers</b>:
   </summary>
 
 <table><tr><td valign="top"><details open><summary><b>Local</b></summary>
@@ -2055,7 +2055,7 @@ validated against the schema of the interceptor.
 
 <details open>
   <summary>
-    Declaring responses with a JSON body:
+    Declaring responses with a <b>JSON body</b>:
   </summary>
 
 <table><tr><td valign="top"><details open><summary><b>Local</b></summary>
@@ -2081,7 +2081,7 @@ const listHandler = await interceptor.get('/users').respond({
 
 <details>
   <summary>
-    Declaring responses with a form data body using <a href='#httpformdata'><code>HttpFormData</code></a>:
+    Declaring responses with a <b>form data body</b> using <a href='#httpformdata'><code>HttpFormData</code></a>:
   </summary>
 
 <table><tr><td valign="top"><details open><summary><b>Local</b></summary>
@@ -2119,7 +2119,7 @@ const listHandler = await interceptor.get('/users/:id').respond({
 
 <details>
   <summary>
-    Declaring responses with a blob body:
+    Declaring responses with a <b>blob body</b>:
   </summary>
 
 <table><tr><td valign="top"><details open><summary><b>Local</b></summary>
@@ -2145,7 +2145,7 @@ const listHandler = await interceptor.get('/users').respond({
 
 <details>
   <summary>
-    Declaring responses with plain text body:
+    Declaring responses with <b>plain text body</b>:
   </summary>
 
 <table><tr><td valign="top"><details open><summary><b>Local</b></summary>
@@ -2171,7 +2171,7 @@ const listHandler = await interceptor.get('/users').respond({
 
 <details>
   <summary>
-    Declaring responses with a search params body (<code>x-www-form-urlencoded</code>) using <a href='#httpsearchparams'><code>HttpSearchParams</code></a>:
+    Declaring responses with a <b>search params body</b> (<code>x-www-form-urlencoded</code>) using <a href='#httpsearchparams'><code>HttpSearchParams</code></a>:
   </summary>
 
 <table><tr><td valign="top"><details open><summary><b>Local</b</summary>

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Visit our [examples](./examples/README.md) to see how to use Zimic with popular 
 
 1. To start using Zimic, create your first [HTTP interceptor](#httpinterceptor):
 
-   <ul><li><details open><summary><b>Local</b></summary>
+   <table><tr><td valign="top"><details open><summary><b>Local</b></summary>
 
    ```ts
    import { JSONValue } from 'zimic';
@@ -246,7 +246,7 @@ Visit our [examples](./examples/README.md) to see how to use Zimic with popular 
    });
    ```
 
-   </details></li><li><details><summary><b>Remote</b></summary>
+    </details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
    ```ts
    import { JSONValue } from 'zimic';
@@ -271,13 +271,13 @@ Visit our [examples](./examples/README.md) to see how to use Zimic with popular 
    });
    ```
 
-   </details></li></ul>
+    </details></td></tr></table>
 
-   In this example, we're [creating an interceptor](#httpcreateinterceptor) for a service supporting `GET` requests to
-   `/users`. A successful response contains an array of `User` objects. Learn more about
-   [declaring HTTP service schemas](#declaring-http-service-schemas).
+In this example, we're [creating an interceptor](#httpcreateinterceptor) for a service supporting `GET` requests to
+`/users`. A successful response contains an array of `User` objects. Learn more about
+[declaring HTTP service schemas](#declaring-http-service-schemas).
 
-2. Then, start the interceptor:
+1. Then, start the interceptor:
 
    ```ts
    await interceptor.start();
@@ -287,9 +287,9 @@ Visit our [examples](./examples/README.md) to see how to use Zimic with popular 
    [interceptor server](#zimic-server-start) before starting it. The base URL of the remote interceptor should point to
    the server, optionally including a path to differentiate from other interceptors.
 
-3. Now, you can intercept requests and return mock responses!
+2. Now, you can intercept requests and return mock responses!
 
-   <ul><li><details open><summary><b>Local</b></summary>
+   <table><tr><td valign="top"><details open><summary><b>Local</b></summary>
 
    ```ts
    const listHandler = interceptor.get('/users').respond({
@@ -302,7 +302,7 @@ Visit our [examples](./examples/README.md) to see how to use Zimic with popular 
    console.log(users); // [{ username: 'diego-aquino' }]
    ```
 
-   </details></li><li><details><summary><b>Remote</b></summary>
+   </details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
    ```ts
    const listHandler = await interceptor.get('/users').respond({
@@ -315,7 +315,7 @@ Visit our [examples](./examples/README.md) to see how to use Zimic with popular 
    console.log(users); // [{ username: 'diego-aquino' }]
    ```
 
-   </details></li></ul>
+   </details></td></tr></table>
 
 More usage examples and recommendations are available in our [examples](#examples) and the
 [`zimic/interceptor` API reference](#zimicinterceptor-api-reference).
@@ -327,7 +327,7 @@ test setup file. An example using a Jest/Vitest API:
 
 `tests/setup.ts`
 
-<ul><li><details open><summary><b>Local</b></summary>
+<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 // Your interceptors
@@ -355,7 +355,7 @@ afterAll(async () => {
 });
 ```
 
-</details></li><li><details><summary><b>Remote</b></summary>
+</details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 // Your interceptors
@@ -383,7 +383,7 @@ afterAll(async () => {
 });
 ```
 
-</details></li></ul>
+</details></td></tr></table>
 
 When using [remote interceptors](#remote-http-interceptors), a common strategy is to load your mocks to the
 [interceptor server](#zimic-server) before starting your application. See
@@ -1500,7 +1500,7 @@ The supported methods are: `get`, `post`, `put`, `patch`, `delete`, `head`, and 
 When using a [remote interceptor](#remote-http-interceptors), creating a handler is an asynchronous operation, so you
 need to `await` it. You can also chain any number of operations and apply them by awaiting the handler.
 
-<ul><li><details open><summary><b>Local</b></summary>
+<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 import { http } from 'zimic/interceptor';
@@ -1524,7 +1524,7 @@ const listHandler = interceptor.get('/users').respond({
 });
 ```
 
-</details></li><li><details><summary><b>Remote</b></summary>
+</details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 import { http } from 'zimic/interceptor';
@@ -1548,7 +1548,7 @@ const listHandler = await interceptor.get('/users').respond({
 });
 ```
 
-</details></li></ul>
+</details></td></tr></table>
 
 ##### Dynamic path parameters
 
@@ -1582,7 +1582,7 @@ interceptor.get(`/users/${1}`); // Only matches id 1
 the path string. For example, the path `/users/:userId` will result in a `request.pathParams` of type
 `{ userId: string }`.
 
-<ul><li><details open><summary><b>Local</b></summary>
+<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 const updateHandler = interceptor.put('/users/:id').respond((request) => {
@@ -1597,7 +1597,7 @@ const updateHandler = interceptor.put('/users/:id').respond((request) => {
 await fetch('http://localhost:3000/users/1', { method: 'PUT' });
 ```
 
-</details></li><li><details><summary><b>Remote</b></summary>
+</details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const updateHandler = await interceptor.put('/users/:id').respond((request) => {
@@ -1612,7 +1612,7 @@ const updateHandler = await interceptor.put('/users/:id').respond((request) => {
 await fetch('http://localhost:3000/users/1', { method: 'PUT' });
 ```
 
-</details></li></ul>
+</details></td></tr></table>
 
 #### HTTP `interceptor.clear()`
 
@@ -1622,19 +1622,19 @@ requests until new mock responses are registered.
 
 This method is useful to reset the interceptor mocks between tests.
 
-<ul><li><details open><summary><b>Local</b></summary>
+<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 interceptor.clear();
 ```
 
-</details></li><li><details><summary><b>Remote</b></summary>
+</details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 await interceptor.clear();
 ```
 
-</details></li></ul>
+</details></td></tr></table>
 
 ### `HttpRequestHandler`
 
@@ -1649,7 +1649,7 @@ When multiple handlers match the same method and path, the _last_ created with
 
 Returns the method that matches a handler.
 
-<ul><li><details open><summary><b>Local</b></summary>
+<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 const handler = interceptor.post('/users');
@@ -1657,7 +1657,7 @@ const method = handler.method();
 console.log(method); // 'POST'
 ```
 
-</details></li><li><details><summary><b>Remote</b></summary>
+</details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const handler = await interceptor.post('/users');
@@ -1665,14 +1665,14 @@ const method = handler.method();
 console.log(method); // 'POST'
 ```
 
-</details></li></ul>
+</details></td></tr></table>
 
 #### HTTP `handler.path()`
 
 Returns the path that matches a handler. The base URL of the interceptor is not included, but it is used when matching
 requests.
 
-<ul><li><details open><summary><b>Local</b></summary>
+<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 const handler = interceptor.get('/users');
@@ -1680,7 +1680,7 @@ const path = handler.path();
 console.log(path); // '/users'
 ```
 
-</details></li><li><details><summary><b>Remote</b></summary>
+</details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const handler = await interceptor.get('/users');
@@ -1688,7 +1688,7 @@ const path = handler.path();
 console.log(path); // '/users'
 ```
 
-</details></li></ul>
+</details></td></tr></table>
 
 #### HTTP `handler.with(restriction)`
 
@@ -1704,7 +1704,7 @@ condition.
     Declaring restrictions for <b>headers</b>:
   </summary>
 
-<ul><li><details open><summary><b>Local</b></summary>
+<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 const creationHandler = interceptor
@@ -1718,7 +1718,7 @@ const creationHandler = interceptor
   });
 ```
 
-</details></li><li><details><summary><b>Remote</b></summary>
+</details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const creationHandler = await interceptor
@@ -1732,7 +1732,7 @@ const creationHandler = await interceptor
   });
 ```
 
-</details></li></ul>
+</details></td></tr></table>
 </details>
 
 <details open>
@@ -1740,7 +1740,7 @@ const creationHandler = await interceptor
     Declaring restrictions for <b>search params</b>:
   </summary>
 
-<ul><li><details open><summary><b>Local</b></summary>
+<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 const creationHandler = interceptor
@@ -1754,7 +1754,7 @@ const creationHandler = interceptor
   });
 ```
 
-</details></li><li><details><summary><b>Remote</b></summary>
+</details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const creationHandler = await interceptor
@@ -1768,7 +1768,7 @@ const creationHandler = await interceptor
   });
 ```
 
-</details></li></ul>
+</details></td></tr></table>
 </details>
 
 <details open>
@@ -1776,7 +1776,7 @@ const creationHandler = await interceptor
     Declaring restrictions for a <b>JSON</b> body:
   </summary>
 
-<ul><li><details open><summary><b>Local</b></summary>
+<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 const creationHandler = interceptor
@@ -1790,7 +1790,7 @@ const creationHandler = interceptor
   });
 ```
 
-</details></li><li><details><summary><b>Remote</b></summary>
+</details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const creationHandler = await interceptor
@@ -1804,7 +1804,7 @@ const creationHandler = await interceptor
   });
 ```
 
-</details></li></ul>
+</details></td></tr></table>
 
 For JSON bodies to be correctly parsed, make sure that the intercepted requests have the header
 `content-type: application/json`.
@@ -1816,7 +1816,7 @@ For JSON bodies to be correctly parsed, make sure that the intercepted requests 
     Declaring restrictions for a <b>form data</b> body:
   </summary>
 
-<ul><li><details open><summary><b>Local</b></summary>
+<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 import { HttpFormData } from 'zimic';
@@ -1841,7 +1841,7 @@ const creationHandler = interceptor
   });
 ```
 
-</details></li><li><details><summary><b>Remote</b></summary>
+</details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 import { HttpFormData } from 'zimic';
@@ -1866,7 +1866,7 @@ const creationHandler = await interceptor
   });
 ```
 
-</details></li></ul>
+</details></td></tr></table>
 
 For form data bodies to be correctly parsed, make sure that the intercepted requests have the header
 `content-type: multipart/form-data`.
@@ -1878,7 +1878,7 @@ For form data bodies to be correctly parsed, make sure that the intercepted requ
     Declaring restrictions for a <b>blob</b> body:
   </summary>
 
-<ul><li><details open><summary><b>Local</b></summary>
+<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 const creationHandler = interceptor
@@ -1894,7 +1894,7 @@ const creationHandler = interceptor
   });
 ```
 
-</details></li><li><details><summary><b>Remote</b></summary>
+</details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const creationHandler = await interceptor
@@ -1910,7 +1910,7 @@ const creationHandler = await interceptor
   });
 ```
 
-</details></li></ul>
+</details></td></tr></table>
 
 For blob bodies to be correctly parsed, make sure that the intercepted requests have the header `content-type`
 indicating a binary data, such as `application/octet-stream`, `image/png`, `audio/mpeg`, etc.
@@ -1922,7 +1922,7 @@ indicating a binary data, such as `application/octet-stream`, `image/png`, `audi
     Declaring restrictions for a <b>plain text</b> body:
   </summary>
 
-<ul><li><details open><summary><b>Local</b></summary>
+<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 const creationHandler = interceptor
@@ -1936,7 +1936,7 @@ const creationHandler = interceptor
   });
 ```
 
-</details></li><li><details><summary><b>Remote</b></summary>
+</details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const creationHandler = await interceptor
@@ -1950,7 +1950,7 @@ const creationHandler = await interceptor
   });
 ```
 
-</details></li></ul>
+</details></td></tr></table>
 
 For plain text bodies to be correctly parsed, make sure that the intercepted requests have the header `content-type`
 indicating a plain text, such as `text/plain`.
@@ -1963,7 +1963,7 @@ in the headers, search params, or body would still match the restrictions.
 
 If you want to match only requests with the exact values declared, you can use `exact: true`:
 
-<ul><li><details open><summary><b>Local</b></summary>
+<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 const creationHandler = interceptor
@@ -1980,7 +1980,7 @@ const creationHandler = interceptor
   });
 ```
 
-</details></li><li><details><summary><b>Remote</b></summary>
+</details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const creationHandler = await interceptor
@@ -1997,13 +1997,13 @@ const creationHandler = await interceptor
   });
 ```
 
-</details></li></ul>
+</details></td></tr></table>
 
 ##### Computed restrictions
 
 A function is also supported to declare restrictions in case they are dynamic.
 
-<ul><li><details open><summary><b>Local</b></summary>
+<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 const creationHandler = interceptor
@@ -2018,7 +2018,7 @@ const creationHandler = interceptor
   });
 ```
 
-</details></li><li><details><summary><b>Remote</b></summary>
+</details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const creationHandler = await interceptor
@@ -2033,7 +2033,7 @@ const creationHandler = await interceptor
   });
 ```
 
-</details></li></ul>
+</details></td></tr></table>
 
 The `request` parameter represents the intercepted request, containing useful properties such as `request.body`,
 `request.headers`, `request.pathParams`, and `request.searchParams`, which are typed based on the interceptor schema.
@@ -2054,7 +2054,7 @@ validated against the schema of the interceptor.
     Declaring responses with <b>JSON</b> body:
   </summary>
 
-<ul><li><details open><summary><b>Local</b></summary>
+<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 const listHandler = interceptor.get('/users').respond({
@@ -2063,7 +2063,7 @@ const listHandler = interceptor.get('/users').respond({
 });
 ```
 
-   </details></li><li><details><summary><b>Remote</b></summary>
+</details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const listHandler = await interceptor.get('/users').respond({
@@ -2072,7 +2072,7 @@ const listHandler = await interceptor.get('/users').respond({
 });
 ```
 
-</details></li></ul>
+</details></td></tr></table>
 </details>
 
 <details>
@@ -2080,7 +2080,7 @@ const listHandler = await interceptor.get('/users').respond({
     Declaring responses with <b>form data</b> body:
   </summary>
 
-<ul><li><details open><summary><b>Local</b></summary>
+<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 import { HttpFormData } from 'zimic';
@@ -2100,7 +2100,7 @@ const listHandler = interceptor.get('/users/:id').respond({
 });
 ```
 
-</details></li><li><details><summary><b>Remote</b></summary>
+</details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 import { HttpFormData } from 'zimic';
@@ -2120,7 +2120,7 @@ const listHandler = await interceptor.get('/users/:id').respond({
 });
 ```
 
-</details></li></ul>
+</details></td></tr></table>
 </details>
 
 <details>
@@ -2128,7 +2128,7 @@ const listHandler = await interceptor.get('/users/:id').respond({
     Declaring responses with <b>blob</b> body:
   </summary>
 
-<ul><li><details open><summary><b>Local</b></summary>
+<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 const listHandler = interceptor.get('/users').respond({
@@ -2139,7 +2139,7 @@ const listHandler = interceptor.get('/users').respond({
 });
 ```
 
-</details></li><li><details><summary><b>Remote</b></summary>
+</details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const listHandler = await interceptor.get('/users').respond({
@@ -2150,7 +2150,7 @@ const listHandler = await interceptor.get('/users').respond({
 });
 ```
 
-</details></li></ul>
+</details></td></tr></table>
 </details>
 
 <details>
@@ -2158,7 +2158,7 @@ const listHandler = await interceptor.get('/users').respond({
     Declaring responses with <b>plain text</b> body:
   </summary>
 
-<ul><li><details open><summary><b>Local</b></summary>
+<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 const listHandler = interceptor.get('/users').respond({
@@ -2167,7 +2167,7 @@ const listHandler = interceptor.get('/users').respond({
 });
 ```
 
-</details></li><li><details><summary><b>Remote</b></summary>
+</details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const listHandler = await interceptor.get('/users').respond({
@@ -2176,7 +2176,7 @@ const listHandler = await interceptor.get('/users').respond({
 });
 ```
 
-</details></li></ul>
+</details></td></tr></table>
 </details>
 
 <details>
@@ -2184,7 +2184,7 @@ const listHandler = await interceptor.get('/users').respond({
     Declaring responses with <b>search params</b> (<code>x-www-form-urlencoded</code>) body:
   </summary>
 
-<ul><li><details open><summary><b>Local</b></summary>
+<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 import { HttpSearchParams } from 'zimic';
@@ -2199,7 +2199,7 @@ const listHandler = interceptor.get('/users').respond({
 });
 ```
 
-</details></li><li><details><summary><b>Remote</b></summary>
+</details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 import { HttpSearchParams } from 'zimic';
@@ -2214,14 +2214,14 @@ const listHandler = await interceptor.get('/users').respond({
 });
 ```
 
-</details></li></ul>
+</details></td></tr></table>
 </details>
 
 ##### Computed responses
 
 A function is also supported to declare a response in case it is dynamic:
 
-<ul><li><details open><summary><b>Local</b></summary>
+<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 const listHandler = interceptor.get('/users').respond((request) => {
@@ -2233,7 +2233,7 @@ const listHandler = interceptor.get('/users').respond((request) => {
 });
 ```
 
-</details></li><li><details><summary><b>Remote</b></summary>
+</details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const listHandler = await interceptor.get('/users').respond((request) => {
@@ -2245,7 +2245,7 @@ const listHandler = await interceptor.get('/users').respond((request) => {
 });
 ```
 
-</details></li></ul>
+</details></td></tr></table>
 
 The `request` parameter represents the intercepted request, containing useful properties such as `request.body`,
 `request.headers`, `request.pathParams`, and `request.searchParams`, which are typed based on the interceptor schema.
@@ -2262,7 +2262,7 @@ To make the handler match requests again, register a new response with
 This method is useful to skip a handler. It is more gentle than [`handler.clear()`](#http-handlerclear), as it only
 removed the response, keeping restrictions and intercepted requests.
 
-<ul><li><details open><summary><b>Local</b></summary>
+<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 const listHandler = interceptor.get('/users').respond({
@@ -2279,7 +2279,7 @@ otherListHandler.bypass();
 // Now, requests GET /users will match `listHandler` and receive an empty array
 ```
 
-</details></li><li><details><summary><b>Remote</b></summary>
+</details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const listHandler = await interceptor.get('/users').respond({
@@ -2296,7 +2296,7 @@ await otherListHandler.bypass();
 // Now, requests GET /users will match `listHandler` and receive an empty array
 ```
 
-</details></li></ul>
+</details></td></tr></table>
 
 #### HTTP `handler.clear()`
 
@@ -2310,7 +2310,7 @@ To make the handler match requests again, register a new response with `handler.
 This method is useful to reset handlers to a clean state between tests. It is more aggressive than
 [`handler.bypass()`](#http-handlerbypass), as it also clears restrictions and intercepted requests.
 
-<ul><li><details open><summary><b>Local</b></summary>
+<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 const listHandler = interceptor.get('/users').respond({
@@ -2329,7 +2329,7 @@ otherListHandler.clear();
 otherListHandler.requests(); // Now empty
 ```
 
-</details></li><li><details><summary><b>Remote</b></summary>
+</details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const listHandler = await interceptor.get('/users').respond({
@@ -2348,14 +2348,14 @@ await otherListHandler.clear();
 await otherListHandler.requests(); // Now empty
 ```
 
-</details></li></ul>
+</details></td></tr></table>
 
 #### HTTP `handler.requests()`
 
 Returns the intercepted requests that matched this handler, along with the responses returned to each of them. This is
 useful for testing that the correct requests were made by your application.
 
-<ul><li><details open><summary><b>Local</b></summary>
+<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 const updateHandler = interceptor.put('/users/:id').respond((request) => {
@@ -2377,7 +2377,7 @@ expect(updateRequests[0].pathParams).toEqual({ id: '1' });
 expect(updateRequests[0].body).toEqual({ username: 'new' });
 ```
 
-</details></li><li><details><summary><b>Remote</b></summary>
+</details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const updateHandler = await interceptor.put('/users/:id').respond((request) => {
@@ -2399,7 +2399,7 @@ expect(updateRequests[0].pathParams).toEqual({ id: '1' });
 expect(updateRequests[0].body).toEqual({ username: 'new' });
 ```
 
-</details></li></ul>
+</details></td></tr></table>
 
 The return by `requests` are simplified objects based on the
 [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) and
@@ -2413,7 +2413,7 @@ and falls back to plain text if it fails.
 
 If you need access to the original `Request` and `Response` objects, you can use the `request.raw` property:
 
-<ul><li><details open><summary><b>Local</b></summary>
+<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 const listRequests = listHandler.requests();
@@ -2421,7 +2421,7 @@ console.log(listRequests[0].raw); // Request{}
 console.log(listRequests[0].response.raw); // Response{}
 ```
 
-</details></li><li><details><summary><b>Remote</b></summary>
+</details></td></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const listRequests = await listHandler.requests();
@@ -2429,7 +2429,7 @@ console.log(listRequests[0].raw); // Request{}
 console.log(listRequests[0].response.raw); // Response{}
 ```
 
-</details></li></ul>
+</details></td></tr></table>
 
 ## CLI
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ When to use `local`:
 Our [Vitest](./examples/README.md#vitest), [Jest](./examples/README.md#jest), and
 [Next.js Pages Router](./examples/README.md#nextjs) examples use local interceptors.
 
-> [!NOTE]
+> [!IMPORTANT]
 >
 > All mocking operations in local interceptor are _synchronous_. There's no need to `await` them before making requests.
 
@@ -189,7 +189,7 @@ When to use `remote`:
 Our [Playwright](./examples/README.md#playwright) and [Next.js App Router](./examples/README.md#nextjs) examples use
 remote interceptors.
 
-> [!NOTE]
+> [!IMPORTANT]
 >
 > All mocking operations in remote interceptors are _asynchronous_. Make sure to `await` them before making requests.
 >

--- a/README.md
+++ b/README.md
@@ -385,9 +385,8 @@ afterAll(async () => {
 
 </details></td></tr></table>
 
-When using [remote interceptors](#remote-http-interceptors), a common strategy is to load your mocks to the
-[interceptor server](#zimic-server) before starting your application. See
-[Next.js App Router - Loading mocks](./examples/with-next-js-app/README.md#loading-mocks) and
+When using [remote interceptors](#remote-http-interceptors), a common strategy is to apply your mocks before starting
+the application. See [Next.js App Router - Loading mocks](./examples/with-next-js-app/README.md#loading-mocks) and
 [Playwright - Loading mocks](./examples/with-playwright/README.md#loading-mocks) for examples.
 
 ---

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Visit our [examples](./examples/README.md) to see how to use Zimic with popular 
 
 1. To start using Zimic, create your first [HTTP interceptor](#httpinterceptor):
 
-   <table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+   <table><tr><td width="900px" valign="top"><details open><summary><b>Local</b></summary>
 
    ```ts
    import { JSONValue } from 'zimic';
@@ -246,7 +246,7 @@ Visit our [examples](./examples/README.md) to see how to use Zimic with popular 
    });
    ```
 
-    </details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+    </details></td></tr><tr></tr><tr><td width="900px" valign="top"><details><summary><b>Remote</b></summary>
 
    ```ts
    import { JSONValue } from 'zimic';
@@ -289,7 +289,7 @@ Visit our [examples](./examples/README.md) to see how to use Zimic with popular 
 
 3. Now, you can intercept requests and return mock responses!
 
-   <table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+   <table><tr><td width="900px" valign="top"><details open><summary><b>Local</b></summary>
 
    ```ts
    const listHandler = interceptor.get('/users').respond({
@@ -302,7 +302,7 @@ Visit our [examples](./examples/README.md) to see how to use Zimic with popular 
    console.log(users); // [{ username: 'diego-aquino' }]
    ```
 
-   </details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+   </details></td></tr><tr></tr><tr><td width="900px" valign="top"><details><summary><b>Remote</b></summary>
 
    ```ts
    const listHandler = await interceptor.get('/users').respond({
@@ -327,7 +327,7 @@ test setup file. An example using a Jest/Vitest API:
 
 `tests/setup.ts`
 
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+<table><tr><td width="900px" valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 // Your interceptors
@@ -355,7 +355,7 @@ afterAll(async () => {
 });
 ```
 
-</details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+</details></td></tr><tr></tr><tr><td width="900px" valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 // Your interceptors
@@ -1500,7 +1500,7 @@ The supported methods are: `get`, `post`, `put`, `patch`, `delete`, `head`, and 
 When using a [remote interceptor](#remote-http-interceptors), creating a handler is an asynchronous operation, so you
 need to `await` it. You can also chain any number of operations and apply them by awaiting the handler.
 
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+<table><tr><td width="900px" valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 import { http } from 'zimic/interceptor';
@@ -1524,7 +1524,7 @@ const listHandler = interceptor.get('/users').respond({
 });
 ```
 
-</details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+</details></td></tr><tr></tr><tr><td width="900px" valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 import { http } from 'zimic/interceptor';
@@ -1582,7 +1582,7 @@ interceptor.get(`/users/${1}`); // Only matches id 1
 the path string. For example, the path `/users/:userId` will result in a `request.pathParams` of type
 `{ userId: string }`.
 
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+<table><tr><td width="900px" valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 const updateHandler = interceptor.put('/users/:id').respond((request) => {
@@ -1597,7 +1597,7 @@ const updateHandler = interceptor.put('/users/:id').respond((request) => {
 await fetch('http://localhost:3000/users/1', { method: 'PUT' });
 ```
 
-</details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+</details></td></tr><tr></tr><tr><td width="900px" valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const updateHandler = await interceptor.put('/users/:id').respond((request) => {
@@ -1622,13 +1622,13 @@ requests until new mock responses are registered.
 
 This method is useful to reset the interceptor mocks between tests.
 
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+<table><tr><td width="900px" valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 interceptor.clear();
 ```
 
-</details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+</details></td></tr><tr></tr><tr><td width="900px" valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 await interceptor.clear();
@@ -1649,7 +1649,7 @@ When multiple handlers match the same method and path, the _last_ created with
 
 Returns the method that matches a handler.
 
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+<table><tr><td width="900px" valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 const handler = interceptor.post('/users');
@@ -1657,7 +1657,7 @@ const method = handler.method();
 console.log(method); // 'POST'
 ```
 
-</details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+</details></td></tr><tr></tr><tr><td width="900px" valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const handler = await interceptor.post('/users');
@@ -1672,7 +1672,7 @@ console.log(method); // 'POST'
 Returns the path that matches a handler. The base URL of the interceptor is not included, but it is used when matching
 requests.
 
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+<table><tr><td width="900px" valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 const handler = interceptor.get('/users');
@@ -1680,7 +1680,7 @@ const path = handler.path();
 console.log(path); // '/users'
 ```
 
-</details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+</details></td></tr><tr></tr><tr><td width="900px" valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const handler = await interceptor.get('/users');
@@ -1704,7 +1704,7 @@ condition.
     Declaring restrictions for <b>headers</b>:
   </summary>
 
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+<table><tr><td width="900px" valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 const creationHandler = interceptor
@@ -1718,7 +1718,7 @@ const creationHandler = interceptor
   });
 ```
 
-</details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+</details></td></tr><tr></tr><tr><td width="900px" valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const creationHandler = await interceptor
@@ -1740,7 +1740,7 @@ const creationHandler = await interceptor
     Declaring restrictions for <b>search params</b>:
   </summary>
 
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+<table><tr><td width="900px" valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 const creationHandler = interceptor
@@ -1754,7 +1754,7 @@ const creationHandler = interceptor
   });
 ```
 
-</details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+</details></td></tr><tr></tr><tr><td width="900px" valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const creationHandler = await interceptor
@@ -1776,7 +1776,7 @@ const creationHandler = await interceptor
     Declaring restrictions for a <b>JSON</b> body:
   </summary>
 
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+<table><tr><td width="900px" valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 const creationHandler = interceptor
@@ -1790,7 +1790,7 @@ const creationHandler = interceptor
   });
 ```
 
-</details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+</details></td></tr><tr></tr><tr><td width="900px" valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const creationHandler = await interceptor
@@ -1816,7 +1816,7 @@ For JSON bodies to be correctly parsed, make sure that the intercepted requests 
     Declaring restrictions for a <b>form data</b> body:
   </summary>
 
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+<table><tr><td width="900px" valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 import { HttpFormData } from 'zimic';
@@ -1841,7 +1841,7 @@ const creationHandler = interceptor
   });
 ```
 
-</details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+</details></td></tr><tr></tr><tr><td width="900px" valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 import { HttpFormData } from 'zimic';
@@ -1878,7 +1878,7 @@ For form data bodies to be correctly parsed, make sure that the intercepted requ
     Declaring restrictions for a <b>blob</b> body:
   </summary>
 
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+<table><tr><td width="900px" valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 const creationHandler = interceptor
@@ -1894,7 +1894,7 @@ const creationHandler = interceptor
   });
 ```
 
-</details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+</details></td></tr><tr></tr><tr><td width="900px" valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const creationHandler = await interceptor
@@ -1922,7 +1922,7 @@ indicating a binary data, such as `application/octet-stream`, `image/png`, `audi
     Declaring restrictions for a <b>plain text</b> body:
   </summary>
 
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+<table><tr><td width="900px" valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 const creationHandler = interceptor
@@ -1936,7 +1936,7 @@ const creationHandler = interceptor
   });
 ```
 
-</details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+</details></td></tr><tr></tr><tr><td width="900px" valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const creationHandler = await interceptor
@@ -1963,7 +1963,7 @@ in the headers, search params, or body would still match the restrictions.
 
 If you want to match only requests with the exact values declared, you can use `exact: true`:
 
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+<table><tr><td width="900px" valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 const creationHandler = interceptor
@@ -1980,7 +1980,7 @@ const creationHandler = interceptor
   });
 ```
 
-</details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+</details></td></tr><tr></tr><tr><td width="900px" valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const creationHandler = await interceptor
@@ -2003,7 +2003,7 @@ const creationHandler = await interceptor
 
 A function is also supported to declare restrictions in case they are dynamic.
 
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+<table><tr><td width="900px" valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 const creationHandler = interceptor
@@ -2018,7 +2018,7 @@ const creationHandler = interceptor
   });
 ```
 
-</details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+</details></td></tr><tr></tr><tr><td width="900px" valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const creationHandler = await interceptor
@@ -2054,7 +2054,7 @@ validated against the schema of the interceptor.
     Declaring responses with <b>JSON</b> body:
   </summary>
 
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+<table><tr><td width="900px" valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 const listHandler = interceptor.get('/users').respond({
@@ -2063,7 +2063,7 @@ const listHandler = interceptor.get('/users').respond({
 });
 ```
 
-</details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+</details></td></tr><tr></tr><tr><td width="900px" valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const listHandler = await interceptor.get('/users').respond({
@@ -2080,7 +2080,7 @@ const listHandler = await interceptor.get('/users').respond({
     Declaring responses with <b>form data</b> body:
   </summary>
 
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+<table><tr><td width="900px" valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 import { HttpFormData } from 'zimic';
@@ -2100,7 +2100,7 @@ const listHandler = interceptor.get('/users/:id').respond({
 });
 ```
 
-</details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+</details></td></tr><tr></tr><tr><td width="900px" valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 import { HttpFormData } from 'zimic';
@@ -2128,7 +2128,7 @@ const listHandler = await interceptor.get('/users/:id').respond({
     Declaring responses with <b>blob</b> body:
   </summary>
 
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+<table><tr><td width="900px" valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 const listHandler = interceptor.get('/users').respond({
@@ -2139,7 +2139,7 @@ const listHandler = interceptor.get('/users').respond({
 });
 ```
 
-</details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+</details></td></tr><tr></tr><tr><td width="900px" valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const listHandler = await interceptor.get('/users').respond({
@@ -2158,7 +2158,7 @@ const listHandler = await interceptor.get('/users').respond({
     Declaring responses with <b>plain text</b> body:
   </summary>
 
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+<table><tr><td width="900px" valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 const listHandler = interceptor.get('/users').respond({
@@ -2167,7 +2167,7 @@ const listHandler = interceptor.get('/users').respond({
 });
 ```
 
-</details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+</details></td></tr><tr></tr><tr><td width="900px" valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const listHandler = await interceptor.get('/users').respond({
@@ -2184,7 +2184,7 @@ const listHandler = await interceptor.get('/users').respond({
     Declaring responses with <b>search params</b> (<code>x-www-form-urlencoded</code>) body:
   </summary>
 
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+<table><tr><td width="900px" valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 import { HttpSearchParams } from 'zimic';
@@ -2199,7 +2199,7 @@ const listHandler = interceptor.get('/users').respond({
 });
 ```
 
-</details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+</details></td></tr><tr></tr><tr><td width="900px" valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 import { HttpSearchParams } from 'zimic';
@@ -2221,7 +2221,7 @@ const listHandler = await interceptor.get('/users').respond({
 
 A function is also supported to declare a response in case it is dynamic:
 
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+<table><tr><td width="900px" valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 const listHandler = interceptor.get('/users').respond((request) => {
@@ -2233,7 +2233,7 @@ const listHandler = interceptor.get('/users').respond((request) => {
 });
 ```
 
-</details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+</details></td></tr><tr></tr><tr><td width="900px" valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const listHandler = await interceptor.get('/users').respond((request) => {
@@ -2262,7 +2262,7 @@ To make the handler match requests again, register a new response with
 This method is useful to skip a handler. It is more gentle than [`handler.clear()`](#http-handlerclear), as it only
 removed the response, keeping restrictions and intercepted requests.
 
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+<table><tr><td width="900px" valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 const listHandler = interceptor.get('/users').respond({
@@ -2279,7 +2279,7 @@ otherListHandler.bypass();
 // Now, requests GET /users will match `listHandler` and receive an empty array
 ```
 
-</details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+</details></td></tr><tr></tr><tr><td width="900px" valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const listHandler = await interceptor.get('/users').respond({
@@ -2310,7 +2310,7 @@ To make the handler match requests again, register a new response with `handler.
 This method is useful to reset handlers to a clean state between tests. It is more aggressive than
 [`handler.bypass()`](#http-handlerbypass), as it also clears restrictions and intercepted requests.
 
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+<table><tr><td width="900px" valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 const listHandler = interceptor.get('/users').respond({
@@ -2329,7 +2329,7 @@ otherListHandler.clear();
 otherListHandler.requests(); // Now empty
 ```
 
-</details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+</details></td></tr><tr></tr><tr><td width="900px" valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const listHandler = await interceptor.get('/users').respond({
@@ -2355,7 +2355,7 @@ await otherListHandler.requests(); // Now empty
 Returns the intercepted requests that matched this handler, along with the responses returned to each of them. This is
 useful for testing that the correct requests were made by your application.
 
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+<table><tr><td width="900px" valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 const updateHandler = interceptor.put('/users/:id').respond((request) => {
@@ -2377,7 +2377,7 @@ expect(updateRequests[0].pathParams).toEqual({ id: '1' });
 expect(updateRequests[0].body).toEqual({ username: 'new' });
 ```
 
-</details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+</details></td></tr><tr></tr><tr><td width="900px" valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const updateHandler = await interceptor.put('/users/:id').respond((request) => {
@@ -2413,7 +2413,7 @@ and falls back to plain text if it fails.
 
 If you need access to the original `Request` and `Response` objects, you can use the `request.raw` property:
 
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+<table><tr><td width="900px" valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 const listRequests = listHandler.requests();
@@ -2421,7 +2421,7 @@ console.log(listRequests[0].raw); // Request{}
 console.log(listRequests[0].response.raw); // Response{}
 ```
 
-</details></td></tr><tr></tr><tr><td valign="top"><details><summary><b>Remote</b></summary>
+</details></td></tr><tr></tr><tr><td width="900px" valign="top"><details><summary><b>Remote</b></summary>
 
 ```ts
 const listRequests = await listHandler.requests();

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Visit our [examples](./examples/README.md) to see how to use Zimic with popular 
 
 1. To start using Zimic, create your first [HTTP interceptor](#httpinterceptor):
 
-   <table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+   <li><details open><summary><b>Local</b></summary>
 
    ```ts
    import { JSONValue } from 'zimic';
@@ -246,7 +246,7 @@ Visit our [examples](./examples/README.md) to see how to use Zimic with popular 
    });
    ```
 
-    </details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
+   </details></li><li><details open><summary><b>Remote</b></summary>
 
    ```ts
    import { JSONValue } from 'zimic';
@@ -271,7 +271,7 @@ Visit our [examples](./examples/README.md) to see how to use Zimic with popular 
    });
    ```
 
-    </details></td></tr></table>
+   </details></li>
 
 In this example, we're [creating an interceptor](#httpcreateinterceptor) for a service supporting `GET` requests to
 `/users`. A successful response contains an array of `User` objects. Learn more about
@@ -289,7 +289,7 @@ In this example, we're [creating an interceptor](#httpcreateinterceptor) for a s
 
 2. Now, you can intercept requests and return mock responses!
 
-   <table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+   <li><details open><summary><b>Local</b></summary>
 
    ```ts
    const listHandler = interceptor.get('/users').respond({
@@ -302,7 +302,7 @@ In this example, we're [creating an interceptor](#httpcreateinterceptor) for a s
    console.log(users); // [{ username: 'diego-aquino' }]
    ```
 
-   </details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
+   </details></li><li><details open><summary><b>Remote</b></summary>
 
    ```ts
    const listHandler = await interceptor.get('/users').respond({
@@ -315,7 +315,7 @@ In this example, we're [creating an interceptor](#httpcreateinterceptor) for a s
    console.log(users); // [{ username: 'diego-aquino' }]
    ```
 
-   </details></td></tr></table>
+   </details></li>
 
 More usage examples and recommendations are available in our [examples](#examples) and the
 [`zimic/interceptor` API reference](#zimicinterceptor-api-reference).
@@ -327,7 +327,7 @@ test setup file. An example using a Jest/Vitest API:
 
 `tests/setup.ts`
 
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+<li><details open><summary><b>Local</b></summary>
 
 ```ts
 // Your interceptors
@@ -355,7 +355,7 @@ afterAll(async () => {
 });
 ```
 
-</details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
+</details></li><li><details open><summary><b>Remote</b></summary>
 
 ```ts
 // Your interceptors
@@ -383,7 +383,7 @@ afterAll(async () => {
 });
 ```
 
-</details></td></tr></table>
+</details></li>
 
 When using [remote interceptors](#remote-http-interceptors), a common strategy is to load your mocks to the
 [interceptor server](#zimic-server) before starting your application. See
@@ -1500,7 +1500,7 @@ The supported methods are: `get`, `post`, `put`, `patch`, `delete`, `head`, and 
 When using a [remote interceptor](#remote-http-interceptors), creating a handler is an asynchronous operation, so you
 need to `await` it. You can also chain any number of operations and apply them by awaiting the handler.
 
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+<li><details open><summary><b>Local</b></summary>
 
 ```ts
 import { http } from 'zimic/interceptor';
@@ -1524,7 +1524,7 @@ const listHandler = interceptor.get('/users').respond({
 });
 ```
 
-</details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
+</details></li><li><details open><summary><b>Remote</b></summary>
 
 ```ts
 import { http } from 'zimic/interceptor';
@@ -1548,7 +1548,7 @@ const listHandler = await interceptor.get('/users').respond({
 });
 ```
 
-</details></td></tr></table>
+</details></li>
 
 ##### Dynamic path parameters
 
@@ -1582,7 +1582,7 @@ interceptor.get(`/users/${1}`); // Only matches id 1
 the path string. For example, the path `/users/:userId` will result in a `request.pathParams` of type
 `{ userId: string }`.
 
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+<li><details open><summary><b>Local</b></summary>
 
 ```ts
 const updateHandler = interceptor.put('/users/:id').respond((request) => {
@@ -1597,7 +1597,7 @@ const updateHandler = interceptor.put('/users/:id').respond((request) => {
 await fetch('http://localhost:3000/users/1', { method: 'PUT' });
 ```
 
-</details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
+</details></li><li><details open><summary><b>Remote</b></summary>
 
 ```ts
 const updateHandler = await interceptor.put('/users/:id').respond((request) => {
@@ -1612,7 +1612,7 @@ const updateHandler = await interceptor.put('/users/:id').respond((request) => {
 await fetch('http://localhost:3000/users/1', { method: 'PUT' });
 ```
 
-</details></td></tr></table>
+</details></li>
 
 #### HTTP `interceptor.clear()`
 
@@ -1622,19 +1622,19 @@ requests until new mock responses are registered.
 
 This method is useful to reset the interceptor mocks between tests.
 
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+<li><details open><summary><b>Local</b></summary>
 
 ```ts
 interceptor.clear();
 ```
 
-</details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
+</details></li><li><details open><summary><b>Remote</b></summary>
 
 ```ts
 await interceptor.clear();
 ```
 
-</details></td></tr></table>
+</details></li>
 
 ### `HttpRequestHandler`
 
@@ -1649,7 +1649,7 @@ When multiple handlers match the same method and path, the _last_ created with
 
 Returns the method that matches a handler.
 
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+<li><details open><summary><b>Local</b></summary>
 
 ```ts
 const handler = interceptor.post('/users');
@@ -1657,7 +1657,7 @@ const method = handler.method();
 console.log(method); // 'POST'
 ```
 
-</details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
+</details></li><li><details open><summary><b>Remote</b></summary>
 
 ```ts
 const handler = await interceptor.post('/users');
@@ -1665,14 +1665,14 @@ const method = handler.method();
 console.log(method); // 'POST'
 ```
 
-</details></td></tr></table>
+</details></li>
 
 #### HTTP `handler.path()`
 
 Returns the path that matches a handler. The base URL of the interceptor is not included, but it is used when matching
 requests.
 
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+<li><details open><summary><b>Local</b></summary>
 
 ```ts
 const handler = interceptor.get('/users');
@@ -1680,7 +1680,7 @@ const path = handler.path();
 console.log(path); // '/users'
 ```
 
-</details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
+</details></li><li><details open><summary><b>Remote</b></summary>
 
 ```ts
 const handler = await interceptor.get('/users');
@@ -1688,7 +1688,7 @@ const path = handler.path();
 console.log(path); // '/users'
 ```
 
-</details></td></tr></table>
+</details></li>
 
 #### HTTP `handler.with(restriction)`
 
@@ -1704,7 +1704,7 @@ condition.
     Declaring restrictions for <b>headers</b>:
   </summary>
 
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+<li><details open><summary><b>Local</b></summary>
 
 ```ts
 const creationHandler = interceptor
@@ -1718,7 +1718,7 @@ const creationHandler = interceptor
   });
 ```
 
-</details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
+</details></li><li><details open><summary><b>Remote</b></summary>
 
 ```ts
 const creationHandler = await interceptor
@@ -1732,7 +1732,7 @@ const creationHandler = await interceptor
   });
 ```
 
-</details></td></tr></table>
+</details></li>
 </details>
 
 <details open>
@@ -1740,7 +1740,7 @@ const creationHandler = await interceptor
     Declaring restrictions for <b>search params</b>:
   </summary>
 
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+<li><details open><summary><b>Local</b></summary>
 
 ```ts
 const creationHandler = interceptor
@@ -1754,7 +1754,7 @@ const creationHandler = interceptor
   });
 ```
 
-</details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
+</details></li><li><details open><summary><b>Remote</b></summary>
 
 ```ts
 const creationHandler = await interceptor
@@ -1768,7 +1768,7 @@ const creationHandler = await interceptor
   });
 ```
 
-</details></td></tr></table>
+</details></li>
 </details>
 
 <details open>
@@ -1776,7 +1776,7 @@ const creationHandler = await interceptor
     Declaring restrictions for a <b>JSON</b> body:
   </summary>
 
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+<li><details open><summary><b>Local</b></summary>
 
 ```ts
 const creationHandler = interceptor
@@ -1790,7 +1790,7 @@ const creationHandler = interceptor
   });
 ```
 
-</details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
+</details></li><li><details open><summary><b>Remote</b></summary>
 
 ```ts
 const creationHandler = await interceptor
@@ -1804,7 +1804,7 @@ const creationHandler = await interceptor
   });
 ```
 
-</details></td></tr></table>
+</details></li>
 
 For JSON bodies to be correctly parsed, make sure that the intercepted requests have the header
 `content-type: application/json`.
@@ -1816,7 +1816,7 @@ For JSON bodies to be correctly parsed, make sure that the intercepted requests 
     Declaring restrictions for a <b>form data</b> body:
   </summary>
 
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+<li><details open><summary><b>Local</b></summary>
 
 ```ts
 import { HttpFormData } from 'zimic';
@@ -1841,7 +1841,7 @@ const creationHandler = interceptor
   });
 ```
 
-</details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
+</details></li><li><details open><summary><b>Remote</b></summary>
 
 ```ts
 import { HttpFormData } from 'zimic';
@@ -1866,7 +1866,7 @@ const creationHandler = await interceptor
   });
 ```
 
-</details></td></tr></table>
+</details></li>
 
 For form data bodies to be correctly parsed, make sure that the intercepted requests have the header
 `content-type: multipart/form-data`.
@@ -1878,7 +1878,7 @@ For form data bodies to be correctly parsed, make sure that the intercepted requ
     Declaring restrictions for a <b>blob</b> body:
   </summary>
 
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+<li><details open><summary><b>Local</b></summary>
 
 ```ts
 const creationHandler = interceptor
@@ -1894,7 +1894,7 @@ const creationHandler = interceptor
   });
 ```
 
-</details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
+</details></li><li><details open><summary><b>Remote</b></summary>
 
 ```ts
 const creationHandler = await interceptor
@@ -1910,7 +1910,7 @@ const creationHandler = await interceptor
   });
 ```
 
-</details></td></tr></table>
+</details></li>
 
 For blob bodies to be correctly parsed, make sure that the intercepted requests have the header `content-type`
 indicating a binary data, such as `application/octet-stream`, `image/png`, `audio/mpeg`, etc.
@@ -1922,7 +1922,7 @@ indicating a binary data, such as `application/octet-stream`, `image/png`, `audi
     Declaring restrictions for a <b>plain text</b> body:
   </summary>
 
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+<li><details open><summary><b>Local</b></summary>
 
 ```ts
 const creationHandler = interceptor
@@ -1936,7 +1936,7 @@ const creationHandler = interceptor
   });
 ```
 
-</details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
+</details></li><li><details open><summary><b>Remote</b></summary>
 
 ```ts
 const creationHandler = await interceptor
@@ -1950,7 +1950,7 @@ const creationHandler = await interceptor
   });
 ```
 
-</details></td></tr></table>
+</details></li>
 
 For plain text bodies to be correctly parsed, make sure that the intercepted requests have the header `content-type`
 indicating a plain text, such as `text/plain`.
@@ -1963,7 +1963,7 @@ in the headers, search params, or body would still match the restrictions.
 
 If you want to match only requests with the exact values declared, you can use `exact: true`:
 
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+<li><details open><summary><b>Local</b></summary>
 
 ```ts
 const creationHandler = interceptor
@@ -1980,7 +1980,7 @@ const creationHandler = interceptor
   });
 ```
 
-</details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
+</details></li><li><details open><summary><b>Remote</b></summary>
 
 ```ts
 const creationHandler = await interceptor
@@ -1997,13 +1997,13 @@ const creationHandler = await interceptor
   });
 ```
 
-</details></td></tr></table>
+</details></li>
 
 ##### Computed restrictions
 
 A function is also supported to declare restrictions in case they are dynamic.
 
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+<li><details open><summary><b>Local</b></summary>
 
 ```ts
 const creationHandler = interceptor
@@ -2018,7 +2018,7 @@ const creationHandler = interceptor
   });
 ```
 
-</details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
+</details></li><li><details open><summary><b>Remote</b></summary>
 
 ```ts
 const creationHandler = await interceptor
@@ -2033,7 +2033,7 @@ const creationHandler = await interceptor
   });
 ```
 
-</details></td></tr></table>
+</details></li>
 
 The `request` parameter represents the intercepted request, containing useful properties such as `request.body`,
 `request.headers`, `request.pathParams`, and `request.searchParams`, which are typed based on the interceptor schema.
@@ -2054,7 +2054,7 @@ validated against the schema of the interceptor.
     Declaring responses with <b>JSON</b> body:
   </summary>
 
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+<li><details open><summary><b>Local</b></summary>
 
 ```ts
 const listHandler = interceptor.get('/users').respond({
@@ -2063,7 +2063,7 @@ const listHandler = interceptor.get('/users').respond({
 });
 ```
 
-</details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
+   </details></li><li><details open><summary><b>Remote</b></summary>
 
 ```ts
 const listHandler = await interceptor.get('/users').respond({
@@ -2072,7 +2072,7 @@ const listHandler = await interceptor.get('/users').respond({
 });
 ```
 
-</details></td></tr></table>
+</details></li>
 </details>
 
 <details>
@@ -2080,7 +2080,7 @@ const listHandler = await interceptor.get('/users').respond({
     Declaring responses with <b>form data</b> body:
   </summary>
 
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+<li><details open><summary><b>Local</b></summary>
 
 ```ts
 import { HttpFormData } from 'zimic';
@@ -2100,7 +2100,7 @@ const listHandler = interceptor.get('/users/:id').respond({
 });
 ```
 
-</details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
+</details></li><li><details open><summary><b>Remote</b></summary>
 
 ```ts
 import { HttpFormData } from 'zimic';
@@ -2120,7 +2120,7 @@ const listHandler = await interceptor.get('/users/:id').respond({
 });
 ```
 
-</details></td></tr></table>
+</details></li>
 </details>
 
 <details>
@@ -2128,7 +2128,7 @@ const listHandler = await interceptor.get('/users/:id').respond({
     Declaring responses with <b>blob</b> body:
   </summary>
 
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+<li><details open><summary><b>Local</b></summary>
 
 ```ts
 const listHandler = interceptor.get('/users').respond({
@@ -2139,7 +2139,7 @@ const listHandler = interceptor.get('/users').respond({
 });
 ```
 
-</details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
+</details></li><li><details open><summary><b>Remote</b></summary>
 
 ```ts
 const listHandler = await interceptor.get('/users').respond({
@@ -2150,7 +2150,7 @@ const listHandler = await interceptor.get('/users').respond({
 });
 ```
 
-</details></td></tr></table>
+</details></li>
 </details>
 
 <details>
@@ -2158,7 +2158,7 @@ const listHandler = await interceptor.get('/users').respond({
     Declaring responses with <b>plain text</b> body:
   </summary>
 
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+<li><details open><summary><b>Local</b></summary>
 
 ```ts
 const listHandler = interceptor.get('/users').respond({
@@ -2167,7 +2167,7 @@ const listHandler = interceptor.get('/users').respond({
 });
 ```
 
-</details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
+</details></li><li><details open><summary><b>Remote</b></summary>
 
 ```ts
 const listHandler = await interceptor.get('/users').respond({
@@ -2176,7 +2176,7 @@ const listHandler = await interceptor.get('/users').respond({
 });
 ```
 
-</details></td></tr></table>
+</details></li>
 </details>
 
 <details>
@@ -2184,7 +2184,7 @@ const listHandler = await interceptor.get('/users').respond({
     Declaring responses with <b>search params</b> (<code>x-www-form-urlencoded</code>) body:
   </summary>
 
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+<li><details open><summary><b>Local</b></summary>
 
 ```ts
 import { HttpSearchParams } from 'zimic';
@@ -2199,7 +2199,7 @@ const listHandler = interceptor.get('/users').respond({
 });
 ```
 
-</details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
+</details></li><li><details open><summary><b>Remote</b></summary>
 
 ```ts
 import { HttpSearchParams } from 'zimic';
@@ -2214,14 +2214,14 @@ const listHandler = await interceptor.get('/users').respond({
 });
 ```
 
-</details></td></tr></table>
+</details></li>
 </details>
 
 ##### Computed responses
 
 A function is also supported to declare a response in case it is dynamic:
 
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+<li><details open><summary><b>Local</b></summary>
 
 ```ts
 const listHandler = interceptor.get('/users').respond((request) => {
@@ -2233,7 +2233,7 @@ const listHandler = interceptor.get('/users').respond((request) => {
 });
 ```
 
-</details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
+</details></li><li><details open><summary><b>Remote</b></summary>
 
 ```ts
 const listHandler = await interceptor.get('/users').respond((request) => {
@@ -2245,7 +2245,7 @@ const listHandler = await interceptor.get('/users').respond((request) => {
 });
 ```
 
-</details></td></tr></table>
+</details></li>
 
 The `request` parameter represents the intercepted request, containing useful properties such as `request.body`,
 `request.headers`, `request.pathParams`, and `request.searchParams`, which are typed based on the interceptor schema.
@@ -2262,7 +2262,7 @@ To make the handler match requests again, register a new response with
 This method is useful to skip a handler. It is more gentle than [`handler.clear()`](#http-handlerclear), as it only
 removed the response, keeping restrictions and intercepted requests.
 
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+<li><details open><summary><b>Local</b></summary>
 
 ```ts
 const listHandler = interceptor.get('/users').respond({
@@ -2279,7 +2279,7 @@ otherListHandler.bypass();
 // Now, requests GET /users will match `listHandler` and receive an empty array
 ```
 
-</details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
+</details></li><li><details open><summary><b>Remote</b></summary>
 
 ```ts
 const listHandler = await interceptor.get('/users').respond({
@@ -2296,7 +2296,7 @@ await otherListHandler.bypass();
 // Now, requests GET /users will match `listHandler` and receive an empty array
 ```
 
-</details></td></tr></table>
+</details></li>
 
 #### HTTP `handler.clear()`
 
@@ -2310,7 +2310,7 @@ To make the handler match requests again, register a new response with `handler.
 This method is useful to reset handlers to a clean state between tests. It is more aggressive than
 [`handler.bypass()`](#http-handlerbypass), as it also clears restrictions and intercepted requests.
 
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+<li><details open><summary><b>Local</b></summary>
 
 ```ts
 const listHandler = interceptor.get('/users').respond({
@@ -2329,7 +2329,7 @@ otherListHandler.clear();
 otherListHandler.requests(); // Now empty
 ```
 
-</details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
+</details></li><li><details open><summary><b>Remote</b></summary>
 
 ```ts
 const listHandler = await interceptor.get('/users').respond({
@@ -2348,14 +2348,14 @@ await otherListHandler.clear();
 await otherListHandler.requests(); // Now empty
 ```
 
-</details></td></tr></table>
+</details></li>
 
 #### HTTP `handler.requests()`
 
 Returns the intercepted requests that matched this handler, along with the responses returned to each of them. This is
 useful for testing that the correct requests were made by your application.
 
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+<li><details open><summary><b>Local</b></summary>
 
 ```ts
 const updateHandler = interceptor.put('/users/:id').respond((request) => {
@@ -2377,7 +2377,7 @@ expect(updateRequests[0].pathParams).toEqual({ id: '1' });
 expect(updateRequests[0].body).toEqual({ username: 'new' });
 ```
 
-</details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
+</details></li><li><details open><summary><b>Remote</b></summary>
 
 ```ts
 const updateHandler = await interceptor.put('/users/:id').respond((request) => {
@@ -2399,7 +2399,7 @@ expect(updateRequests[0].pathParams).toEqual({ id: '1' });
 expect(updateRequests[0].body).toEqual({ username: 'new' });
 ```
 
-</details></td></tr></table>
+</details></li>
 
 The return by `requests` are simplified objects based on the
 [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) and
@@ -2413,7 +2413,7 @@ and falls back to plain text if it fails.
 
 If you need access to the original `Request` and `Response` objects, you can use the `request.raw` property:
 
-<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+<li><details open><summary><b>Local</b></summary>
 
 ```ts
 const listRequests = listHandler.requests();
@@ -2421,7 +2421,7 @@ console.log(listRequests[0].raw); // Request{}
 console.log(listRequests[0].response.raw); // Response{}
 ```
 
-</details></td></tr><tr><td valign="top"><details open><summary><b>Remote</b></summary>
+</details></li><li><details open><summary><b>Remote</b></summary>
 
 ```ts
 const listRequests = await listHandler.requests();
@@ -2429,7 +2429,7 @@ console.log(listRequests[0].raw); // Request{}
 console.log(listRequests[0].response.raw); // Response{}
 ```
 
-</details></td></tr></table>
+</details></li>
 
 ## CLI
 

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Visit our [examples](./examples/README.md) to see how to use Zimic with popular 
 
 1. To start using Zimic, create your first [HTTP interceptor](#httpinterceptor):
 
-   <li><details open><summary><b>Local</b></summary>
+   <ul><li><details open><summary><b>Local</b></summary>
 
    ```ts
    import { JSONValue } from 'zimic';
@@ -246,7 +246,7 @@ Visit our [examples](./examples/README.md) to see how to use Zimic with popular 
    });
    ```
 
-   </details></li><li><details open><summary><b>Remote</b></summary>
+   </details></li><li><details><summary><b>Remote</b></summary>
 
    ```ts
    import { JSONValue } from 'zimic';
@@ -271,13 +271,13 @@ Visit our [examples](./examples/README.md) to see how to use Zimic with popular 
    });
    ```
 
-   </details></li>
+   </details></li></ul>
 
-In this example, we're [creating an interceptor](#httpcreateinterceptor) for a service supporting `GET` requests to
-`/users`. A successful response contains an array of `User` objects. Learn more about
-[declaring HTTP service schemas](#declaring-http-service-schemas).
+   In this example, we're [creating an interceptor](#httpcreateinterceptor) for a service supporting `GET` requests to
+   `/users`. A successful response contains an array of `User` objects. Learn more about
+   [declaring HTTP service schemas](#declaring-http-service-schemas).
 
-1. Then, start the interceptor:
+2. Then, start the interceptor:
 
    ```ts
    await interceptor.start();
@@ -287,9 +287,9 @@ In this example, we're [creating an interceptor](#httpcreateinterceptor) for a s
    [interceptor server](#zimic-server-start) before starting it. The base URL of the remote interceptor should point to
    the server, optionally including a path to differentiate from other interceptors.
 
-2. Now, you can intercept requests and return mock responses!
+3. Now, you can intercept requests and return mock responses!
 
-   <li><details open><summary><b>Local</b></summary>
+   <ul><li><details open><summary><b>Local</b></summary>
 
    ```ts
    const listHandler = interceptor.get('/users').respond({
@@ -302,7 +302,7 @@ In this example, we're [creating an interceptor](#httpcreateinterceptor) for a s
    console.log(users); // [{ username: 'diego-aquino' }]
    ```
 
-   </details></li><li><details open><summary><b>Remote</b></summary>
+   </details></li><li><details><summary><b>Remote</b></summary>
 
    ```ts
    const listHandler = await interceptor.get('/users').respond({
@@ -315,7 +315,7 @@ In this example, we're [creating an interceptor](#httpcreateinterceptor) for a s
    console.log(users); // [{ username: 'diego-aquino' }]
    ```
 
-   </details></li>
+   </details></li></ul>
 
 More usage examples and recommendations are available in our [examples](#examples) and the
 [`zimic/interceptor` API reference](#zimicinterceptor-api-reference).
@@ -327,7 +327,7 @@ test setup file. An example using a Jest/Vitest API:
 
 `tests/setup.ts`
 
-<li><details open><summary><b>Local</b></summary>
+<ul><li><details open><summary><b>Local</b></summary>
 
 ```ts
 // Your interceptors
@@ -355,7 +355,7 @@ afterAll(async () => {
 });
 ```
 
-</details></li><li><details open><summary><b>Remote</b></summary>
+</details></li><li><details><summary><b>Remote</b></summary>
 
 ```ts
 // Your interceptors
@@ -383,7 +383,7 @@ afterAll(async () => {
 });
 ```
 
-</details></li>
+</details></li></ul>
 
 When using [remote interceptors](#remote-http-interceptors), a common strategy is to load your mocks to the
 [interceptor server](#zimic-server) before starting your application. See
@@ -1500,7 +1500,7 @@ The supported methods are: `get`, `post`, `put`, `patch`, `delete`, `head`, and 
 When using a [remote interceptor](#remote-http-interceptors), creating a handler is an asynchronous operation, so you
 need to `await` it. You can also chain any number of operations and apply them by awaiting the handler.
 
-<li><details open><summary><b>Local</b></summary>
+<ul><li><details open><summary><b>Local</b></summary>
 
 ```ts
 import { http } from 'zimic/interceptor';
@@ -1524,7 +1524,7 @@ const listHandler = interceptor.get('/users').respond({
 });
 ```
 
-</details></li><li><details open><summary><b>Remote</b></summary>
+</details></li><li><details><summary><b>Remote</b></summary>
 
 ```ts
 import { http } from 'zimic/interceptor';
@@ -1548,7 +1548,7 @@ const listHandler = await interceptor.get('/users').respond({
 });
 ```
 
-</details></li>
+</details></li></ul>
 
 ##### Dynamic path parameters
 
@@ -1582,7 +1582,7 @@ interceptor.get(`/users/${1}`); // Only matches id 1
 the path string. For example, the path `/users/:userId` will result in a `request.pathParams` of type
 `{ userId: string }`.
 
-<li><details open><summary><b>Local</b></summary>
+<ul><li><details open><summary><b>Local</b></summary>
 
 ```ts
 const updateHandler = interceptor.put('/users/:id').respond((request) => {
@@ -1597,7 +1597,7 @@ const updateHandler = interceptor.put('/users/:id').respond((request) => {
 await fetch('http://localhost:3000/users/1', { method: 'PUT' });
 ```
 
-</details></li><li><details open><summary><b>Remote</b></summary>
+</details></li><li><details><summary><b>Remote</b></summary>
 
 ```ts
 const updateHandler = await interceptor.put('/users/:id').respond((request) => {
@@ -1612,7 +1612,7 @@ const updateHandler = await interceptor.put('/users/:id').respond((request) => {
 await fetch('http://localhost:3000/users/1', { method: 'PUT' });
 ```
 
-</details></li>
+</details></li></ul>
 
 #### HTTP `interceptor.clear()`
 
@@ -1622,19 +1622,19 @@ requests until new mock responses are registered.
 
 This method is useful to reset the interceptor mocks between tests.
 
-<li><details open><summary><b>Local</b></summary>
+<ul><li><details open><summary><b>Local</b></summary>
 
 ```ts
 interceptor.clear();
 ```
 
-</details></li><li><details open><summary><b>Remote</b></summary>
+</details></li><li><details><summary><b>Remote</b></summary>
 
 ```ts
 await interceptor.clear();
 ```
 
-</details></li>
+</details></li></ul>
 
 ### `HttpRequestHandler`
 
@@ -1649,7 +1649,7 @@ When multiple handlers match the same method and path, the _last_ created with
 
 Returns the method that matches a handler.
 
-<li><details open><summary><b>Local</b></summary>
+<ul><li><details open><summary><b>Local</b></summary>
 
 ```ts
 const handler = interceptor.post('/users');
@@ -1657,7 +1657,7 @@ const method = handler.method();
 console.log(method); // 'POST'
 ```
 
-</details></li><li><details open><summary><b>Remote</b></summary>
+</details></li><li><details><summary><b>Remote</b></summary>
 
 ```ts
 const handler = await interceptor.post('/users');
@@ -1665,14 +1665,14 @@ const method = handler.method();
 console.log(method); // 'POST'
 ```
 
-</details></li>
+</details></li></ul>
 
 #### HTTP `handler.path()`
 
 Returns the path that matches a handler. The base URL of the interceptor is not included, but it is used when matching
 requests.
 
-<li><details open><summary><b>Local</b></summary>
+<ul><li><details open><summary><b>Local</b></summary>
 
 ```ts
 const handler = interceptor.get('/users');
@@ -1680,7 +1680,7 @@ const path = handler.path();
 console.log(path); // '/users'
 ```
 
-</details></li><li><details open><summary><b>Remote</b></summary>
+</details></li><li><details><summary><b>Remote</b></summary>
 
 ```ts
 const handler = await interceptor.get('/users');
@@ -1688,7 +1688,7 @@ const path = handler.path();
 console.log(path); // '/users'
 ```
 
-</details></li>
+</details></li></ul>
 
 #### HTTP `handler.with(restriction)`
 
@@ -1704,7 +1704,7 @@ condition.
     Declaring restrictions for <b>headers</b>:
   </summary>
 
-<li><details open><summary><b>Local</b></summary>
+<ul><li><details open><summary><b>Local</b></summary>
 
 ```ts
 const creationHandler = interceptor
@@ -1718,7 +1718,7 @@ const creationHandler = interceptor
   });
 ```
 
-</details></li><li><details open><summary><b>Remote</b></summary>
+</details></li><li><details><summary><b>Remote</b></summary>
 
 ```ts
 const creationHandler = await interceptor
@@ -1732,7 +1732,7 @@ const creationHandler = await interceptor
   });
 ```
 
-</details></li>
+</details></li></ul>
 </details>
 
 <details open>
@@ -1740,7 +1740,7 @@ const creationHandler = await interceptor
     Declaring restrictions for <b>search params</b>:
   </summary>
 
-<li><details open><summary><b>Local</b></summary>
+<ul><li><details open><summary><b>Local</b></summary>
 
 ```ts
 const creationHandler = interceptor
@@ -1754,7 +1754,7 @@ const creationHandler = interceptor
   });
 ```
 
-</details></li><li><details open><summary><b>Remote</b></summary>
+</details></li><li><details><summary><b>Remote</b></summary>
 
 ```ts
 const creationHandler = await interceptor
@@ -1768,7 +1768,7 @@ const creationHandler = await interceptor
   });
 ```
 
-</details></li>
+</details></li></ul>
 </details>
 
 <details open>
@@ -1776,7 +1776,7 @@ const creationHandler = await interceptor
     Declaring restrictions for a <b>JSON</b> body:
   </summary>
 
-<li><details open><summary><b>Local</b></summary>
+<ul><li><details open><summary><b>Local</b></summary>
 
 ```ts
 const creationHandler = interceptor
@@ -1790,7 +1790,7 @@ const creationHandler = interceptor
   });
 ```
 
-</details></li><li><details open><summary><b>Remote</b></summary>
+</details></li><li><details><summary><b>Remote</b></summary>
 
 ```ts
 const creationHandler = await interceptor
@@ -1804,7 +1804,7 @@ const creationHandler = await interceptor
   });
 ```
 
-</details></li>
+</details></li></ul>
 
 For JSON bodies to be correctly parsed, make sure that the intercepted requests have the header
 `content-type: application/json`.
@@ -1816,7 +1816,7 @@ For JSON bodies to be correctly parsed, make sure that the intercepted requests 
     Declaring restrictions for a <b>form data</b> body:
   </summary>
 
-<li><details open><summary><b>Local</b></summary>
+<ul><li><details open><summary><b>Local</b></summary>
 
 ```ts
 import { HttpFormData } from 'zimic';
@@ -1841,7 +1841,7 @@ const creationHandler = interceptor
   });
 ```
 
-</details></li><li><details open><summary><b>Remote</b></summary>
+</details></li><li><details><summary><b>Remote</b></summary>
 
 ```ts
 import { HttpFormData } from 'zimic';
@@ -1866,7 +1866,7 @@ const creationHandler = await interceptor
   });
 ```
 
-</details></li>
+</details></li></ul>
 
 For form data bodies to be correctly parsed, make sure that the intercepted requests have the header
 `content-type: multipart/form-data`.
@@ -1878,7 +1878,7 @@ For form data bodies to be correctly parsed, make sure that the intercepted requ
     Declaring restrictions for a <b>blob</b> body:
   </summary>
 
-<li><details open><summary><b>Local</b></summary>
+<ul><li><details open><summary><b>Local</b></summary>
 
 ```ts
 const creationHandler = interceptor
@@ -1894,7 +1894,7 @@ const creationHandler = interceptor
   });
 ```
 
-</details></li><li><details open><summary><b>Remote</b></summary>
+</details></li><li><details><summary><b>Remote</b></summary>
 
 ```ts
 const creationHandler = await interceptor
@@ -1910,7 +1910,7 @@ const creationHandler = await interceptor
   });
 ```
 
-</details></li>
+</details></li></ul>
 
 For blob bodies to be correctly parsed, make sure that the intercepted requests have the header `content-type`
 indicating a binary data, such as `application/octet-stream`, `image/png`, `audio/mpeg`, etc.
@@ -1922,7 +1922,7 @@ indicating a binary data, such as `application/octet-stream`, `image/png`, `audi
     Declaring restrictions for a <b>plain text</b> body:
   </summary>
 
-<li><details open><summary><b>Local</b></summary>
+<ul><li><details open><summary><b>Local</b></summary>
 
 ```ts
 const creationHandler = interceptor
@@ -1936,7 +1936,7 @@ const creationHandler = interceptor
   });
 ```
 
-</details></li><li><details open><summary><b>Remote</b></summary>
+</details></li><li><details><summary><b>Remote</b></summary>
 
 ```ts
 const creationHandler = await interceptor
@@ -1950,7 +1950,7 @@ const creationHandler = await interceptor
   });
 ```
 
-</details></li>
+</details></li></ul>
 
 For plain text bodies to be correctly parsed, make sure that the intercepted requests have the header `content-type`
 indicating a plain text, such as `text/plain`.
@@ -1963,7 +1963,7 @@ in the headers, search params, or body would still match the restrictions.
 
 If you want to match only requests with the exact values declared, you can use `exact: true`:
 
-<li><details open><summary><b>Local</b></summary>
+<ul><li><details open><summary><b>Local</b></summary>
 
 ```ts
 const creationHandler = interceptor
@@ -1980,7 +1980,7 @@ const creationHandler = interceptor
   });
 ```
 
-</details></li><li><details open><summary><b>Remote</b></summary>
+</details></li><li><details><summary><b>Remote</b></summary>
 
 ```ts
 const creationHandler = await interceptor
@@ -1997,13 +1997,13 @@ const creationHandler = await interceptor
   });
 ```
 
-</details></li>
+</details></li></ul>
 
 ##### Computed restrictions
 
 A function is also supported to declare restrictions in case they are dynamic.
 
-<li><details open><summary><b>Local</b></summary>
+<ul><li><details open><summary><b>Local</b></summary>
 
 ```ts
 const creationHandler = interceptor
@@ -2018,7 +2018,7 @@ const creationHandler = interceptor
   });
 ```
 
-</details></li><li><details open><summary><b>Remote</b></summary>
+</details></li><li><details><summary><b>Remote</b></summary>
 
 ```ts
 const creationHandler = await interceptor
@@ -2033,7 +2033,7 @@ const creationHandler = await interceptor
   });
 ```
 
-</details></li>
+</details></li></ul>
 
 The `request` parameter represents the intercepted request, containing useful properties such as `request.body`,
 `request.headers`, `request.pathParams`, and `request.searchParams`, which are typed based on the interceptor schema.
@@ -2054,7 +2054,7 @@ validated against the schema of the interceptor.
     Declaring responses with <b>JSON</b> body:
   </summary>
 
-<li><details open><summary><b>Local</b></summary>
+<ul><li><details open><summary><b>Local</b></summary>
 
 ```ts
 const listHandler = interceptor.get('/users').respond({
@@ -2063,7 +2063,7 @@ const listHandler = interceptor.get('/users').respond({
 });
 ```
 
-   </details></li><li><details open><summary><b>Remote</b></summary>
+   </details></li><li><details><summary><b>Remote</b></summary>
 
 ```ts
 const listHandler = await interceptor.get('/users').respond({
@@ -2072,7 +2072,7 @@ const listHandler = await interceptor.get('/users').respond({
 });
 ```
 
-</details></li>
+</details></li></ul>
 </details>
 
 <details>
@@ -2080,7 +2080,7 @@ const listHandler = await interceptor.get('/users').respond({
     Declaring responses with <b>form data</b> body:
   </summary>
 
-<li><details open><summary><b>Local</b></summary>
+<ul><li><details open><summary><b>Local</b></summary>
 
 ```ts
 import { HttpFormData } from 'zimic';
@@ -2100,7 +2100,7 @@ const listHandler = interceptor.get('/users/:id').respond({
 });
 ```
 
-</details></li><li><details open><summary><b>Remote</b></summary>
+</details></li><li><details><summary><b>Remote</b></summary>
 
 ```ts
 import { HttpFormData } from 'zimic';
@@ -2120,7 +2120,7 @@ const listHandler = await interceptor.get('/users/:id').respond({
 });
 ```
 
-</details></li>
+</details></li></ul>
 </details>
 
 <details>
@@ -2128,7 +2128,7 @@ const listHandler = await interceptor.get('/users/:id').respond({
     Declaring responses with <b>blob</b> body:
   </summary>
 
-<li><details open><summary><b>Local</b></summary>
+<ul><li><details open><summary><b>Local</b></summary>
 
 ```ts
 const listHandler = interceptor.get('/users').respond({
@@ -2139,7 +2139,7 @@ const listHandler = interceptor.get('/users').respond({
 });
 ```
 
-</details></li><li><details open><summary><b>Remote</b></summary>
+</details></li><li><details><summary><b>Remote</b></summary>
 
 ```ts
 const listHandler = await interceptor.get('/users').respond({
@@ -2150,7 +2150,7 @@ const listHandler = await interceptor.get('/users').respond({
 });
 ```
 
-</details></li>
+</details></li></ul>
 </details>
 
 <details>
@@ -2158,7 +2158,7 @@ const listHandler = await interceptor.get('/users').respond({
     Declaring responses with <b>plain text</b> body:
   </summary>
 
-<li><details open><summary><b>Local</b></summary>
+<ul><li><details open><summary><b>Local</b></summary>
 
 ```ts
 const listHandler = interceptor.get('/users').respond({
@@ -2167,7 +2167,7 @@ const listHandler = interceptor.get('/users').respond({
 });
 ```
 
-</details></li><li><details open><summary><b>Remote</b></summary>
+</details></li><li><details><summary><b>Remote</b></summary>
 
 ```ts
 const listHandler = await interceptor.get('/users').respond({
@@ -2176,7 +2176,7 @@ const listHandler = await interceptor.get('/users').respond({
 });
 ```
 
-</details></li>
+</details></li></ul>
 </details>
 
 <details>
@@ -2184,7 +2184,7 @@ const listHandler = await interceptor.get('/users').respond({
     Declaring responses with <b>search params</b> (<code>x-www-form-urlencoded</code>) body:
   </summary>
 
-<li><details open><summary><b>Local</b></summary>
+<ul><li><details open><summary><b>Local</b></summary>
 
 ```ts
 import { HttpSearchParams } from 'zimic';
@@ -2199,7 +2199,7 @@ const listHandler = interceptor.get('/users').respond({
 });
 ```
 
-</details></li><li><details open><summary><b>Remote</b></summary>
+</details></li><li><details><summary><b>Remote</b></summary>
 
 ```ts
 import { HttpSearchParams } from 'zimic';
@@ -2214,14 +2214,14 @@ const listHandler = await interceptor.get('/users').respond({
 });
 ```
 
-</details></li>
+</details></li></ul>
 </details>
 
 ##### Computed responses
 
 A function is also supported to declare a response in case it is dynamic:
 
-<li><details open><summary><b>Local</b></summary>
+<ul><li><details open><summary><b>Local</b></summary>
 
 ```ts
 const listHandler = interceptor.get('/users').respond((request) => {
@@ -2233,7 +2233,7 @@ const listHandler = interceptor.get('/users').respond((request) => {
 });
 ```
 
-</details></li><li><details open><summary><b>Remote</b></summary>
+</details></li><li><details><summary><b>Remote</b></summary>
 
 ```ts
 const listHandler = await interceptor.get('/users').respond((request) => {
@@ -2245,7 +2245,7 @@ const listHandler = await interceptor.get('/users').respond((request) => {
 });
 ```
 
-</details></li>
+</details></li></ul>
 
 The `request` parameter represents the intercepted request, containing useful properties such as `request.body`,
 `request.headers`, `request.pathParams`, and `request.searchParams`, which are typed based on the interceptor schema.
@@ -2262,7 +2262,7 @@ To make the handler match requests again, register a new response with
 This method is useful to skip a handler. It is more gentle than [`handler.clear()`](#http-handlerclear), as it only
 removed the response, keeping restrictions and intercepted requests.
 
-<li><details open><summary><b>Local</b></summary>
+<ul><li><details open><summary><b>Local</b></summary>
 
 ```ts
 const listHandler = interceptor.get('/users').respond({
@@ -2279,7 +2279,7 @@ otherListHandler.bypass();
 // Now, requests GET /users will match `listHandler` and receive an empty array
 ```
 
-</details></li><li><details open><summary><b>Remote</b></summary>
+</details></li><li><details><summary><b>Remote</b></summary>
 
 ```ts
 const listHandler = await interceptor.get('/users').respond({
@@ -2296,7 +2296,7 @@ await otherListHandler.bypass();
 // Now, requests GET /users will match `listHandler` and receive an empty array
 ```
 
-</details></li>
+</details></li></ul>
 
 #### HTTP `handler.clear()`
 
@@ -2310,7 +2310,7 @@ To make the handler match requests again, register a new response with `handler.
 This method is useful to reset handlers to a clean state between tests. It is more aggressive than
 [`handler.bypass()`](#http-handlerbypass), as it also clears restrictions and intercepted requests.
 
-<li><details open><summary><b>Local</b></summary>
+<ul><li><details open><summary><b>Local</b></summary>
 
 ```ts
 const listHandler = interceptor.get('/users').respond({
@@ -2329,7 +2329,7 @@ otherListHandler.clear();
 otherListHandler.requests(); // Now empty
 ```
 
-</details></li><li><details open><summary><b>Remote</b></summary>
+</details></li><li><details><summary><b>Remote</b></summary>
 
 ```ts
 const listHandler = await interceptor.get('/users').respond({
@@ -2348,14 +2348,14 @@ await otherListHandler.clear();
 await otherListHandler.requests(); // Now empty
 ```
 
-</details></li>
+</details></li></ul>
 
 #### HTTP `handler.requests()`
 
 Returns the intercepted requests that matched this handler, along with the responses returned to each of them. This is
 useful for testing that the correct requests were made by your application.
 
-<li><details open><summary><b>Local</b></summary>
+<ul><li><details open><summary><b>Local</b></summary>
 
 ```ts
 const updateHandler = interceptor.put('/users/:id').respond((request) => {
@@ -2377,7 +2377,7 @@ expect(updateRequests[0].pathParams).toEqual({ id: '1' });
 expect(updateRequests[0].body).toEqual({ username: 'new' });
 ```
 
-</details></li><li><details open><summary><b>Remote</b></summary>
+</details></li><li><details><summary><b>Remote</b></summary>
 
 ```ts
 const updateHandler = await interceptor.put('/users/:id').respond((request) => {
@@ -2399,7 +2399,7 @@ expect(updateRequests[0].pathParams).toEqual({ id: '1' });
 expect(updateRequests[0].body).toEqual({ username: 'new' });
 ```
 
-</details></li>
+</details></li></ul>
 
 The return by `requests` are simplified objects based on the
 [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) and
@@ -2413,7 +2413,7 @@ and falls back to plain text if it fails.
 
 If you need access to the original `Request` and `Response` objects, you can use the `request.raw` property:
 
-<li><details open><summary><b>Local</b></summary>
+<ul><li><details open><summary><b>Local</b></summary>
 
 ```ts
 const listRequests = listHandler.requests();
@@ -2421,7 +2421,7 @@ console.log(listRequests[0].raw); // Request{}
 console.log(listRequests[0].response.raw); // Response{}
 ```
 
-</details></li><li><details open><summary><b>Remote</b></summary>
+</details></li><li><details><summary><b>Remote</b></summary>
 
 ```ts
 const listRequests = await listHandler.requests();
@@ -2429,7 +2429,7 @@ console.log(listRequests[0].raw); // Request{}
 console.log(listRequests[0].response.raw); // Response{}
 ```
 
-</details></li>
+</details></li></ul>
 
 ## CLI
 

--- a/README.md
+++ b/README.md
@@ -1074,7 +1074,7 @@ const interceptor = http.createInterceptor<{
 
 <details open>
   <summary>
-    Declaring a request with a <b>JSON body</b> using <code>JSONValue</code>:
+    Declaring a request with <b>JSON</b> body:
   </summary>
 
 ```ts
@@ -1101,7 +1101,7 @@ const interceptor = http.createInterceptor<{
 
 <details>
   <summary>
-    Declaring a request with a <b>form data body</b> using <a href='#httpformdata'><code>HttpFormData</code></a>:
+    Declaring a request with <b>form data</b> body:
   </summary>
 
 ```ts
@@ -1111,10 +1111,6 @@ import { http } from 'zimic/interceptor';
 type FileUploadData = HttpSchema.FormData<{
   files: File[];
   description?: string;
-}>;
-
-type UserListSearchParams = HttpSchema.SearchParams<{
-  username?: string;
 }>;
 
 const interceptor = http.createInterceptor<{
@@ -1133,7 +1129,7 @@ const interceptor = http.createInterceptor<{
 
 <details>
   <summary>
-    Declaring a request with a <b>blob body</b>:
+    Declaring a request with <b>blob</b> body:
   </summary>
 
 ```ts
@@ -1156,7 +1152,7 @@ const interceptor = http.createInterceptor<{
 
 <details>
   <summary>
-    Declaring a request with <b>plain text body</b>:
+    Declaring a request with <b>plain text</b> body:
   </summary>
 
 ```ts
@@ -1179,7 +1175,7 @@ const interceptor = http.createInterceptor<{
 
 <details>
   <summary>
-    Declaring a request with a <b>search params body</b> (<code>x-www-form-urlencoded</code>) using <a href='#httpsearchparams'><code>HttpSearchParams</code></a>:
+    Declaring a request with <b>search params</b> (<code>x-www-form-urlencoded</code>) body:
   </summary>
 
 ```ts
@@ -1258,7 +1254,7 @@ text.
 
 <details open>
   <summary>
-    Declaring a response with a <b>JSON body</b> using <code>JSONValue</code>:
+    Declaring a response with <b>JSON</b> body:
   </summary>
 
 ```ts
@@ -1292,7 +1288,7 @@ const interceptor = http.createInterceptor<{
 
 <details>
   <summary>
-    Declaring a response with a <b>form data body</b> using <a href='#httpformdata'><code>HttpFormData</code></a>:
+    Declaring a response with <b>form data</b> body:
   </summary>
 
 ```ts
@@ -1322,7 +1318,7 @@ const interceptor = http.createInterceptor<{
 
 <details>
   <summary>
-    Declaring a response with a <b>blob body</b>:
+    Declaring a response with <b>blob</b> body:
   </summary>
 
 ```ts
@@ -1347,7 +1343,7 @@ const interceptor = http.createInterceptor<{
 
 <details>
   <summary>
-    Declaring a response with <b>plain text body</b>:
+    Declaring a response with <b>plain text</b> body:
   </summary>
 
 ```ts
@@ -1372,7 +1368,7 @@ const interceptor = http.createInterceptor<{
 
 <details>
   <summary>
-    Declaring a response with a <b>search params body</b> (<code>x-www-form-urlencoded</code>) using <a href='#httpsearchparams'><code>HttpSearchParams</code></a>:
+    Declaring a response with <b>search params</b> (<code>x-www-form-urlencoded</code>) body:
   </summary>
 
 ```ts
@@ -1711,7 +1707,7 @@ condition.
 
 <details open>
   <summary>
-    Declaring restrictions over a <b>JSON body</b>:
+    Declaring restrictions over a <b>JSON</b> body:
   </summary>
 
 <table><tr><td valign="top"><details open><summary><b>Local</b></summary>
@@ -1753,7 +1749,7 @@ const creationHandler = await interceptor
 
 <details>
   <summary>
-    Declaring restrictions over a <b>form data body</b>:
+    Declaring restrictions over a <b>form data</b> body:
   </summary>
 
 <table><tr><td valign="top"><details open><summary><b>Local</b></summary>
@@ -1807,7 +1803,7 @@ const creationHandler = await interceptor
 
 <details>
   <summary>
-    Declaring restrictions over a <b>blob body</b>:
+    Declaring restrictions over a <b>blob</b> body:
   </summary>
 
 <table><tr><td valign="top"><details open><summary><b>Local</b></summary>
@@ -1849,7 +1845,7 @@ const creationHandler = await interceptor
 
 <details>
   <summary>
-    Declaring restrictions over a <b>plain text body</b>:
+    Declaring restrictions over a <b>plain text</b> body:
   </summary>
 
 <table><tr><td valign="top"><details open><summary><b>Local</b></summary>
@@ -2055,7 +2051,7 @@ validated against the schema of the interceptor.
 
 <details open>
   <summary>
-    Declaring responses with a <b>JSON body</b>:
+    Declaring responses with <b>JSON</b> body:
   </summary>
 
 <table><tr><td valign="top"><details open><summary><b>Local</b></summary>
@@ -2081,7 +2077,7 @@ const listHandler = await interceptor.get('/users').respond({
 
 <details>
   <summary>
-    Declaring responses with a <b>form data body</b> using <a href='#httpformdata'><code>HttpFormData</code></a>:
+    Declaring responses with <b>form data</b> body:
   </summary>
 
 <table><tr><td valign="top"><details open><summary><b>Local</b></summary>
@@ -2119,7 +2115,7 @@ const listHandler = await interceptor.get('/users/:id').respond({
 
 <details>
   <summary>
-    Declaring responses with a <b>blob body</b>:
+    Declaring responses with <b>blob</b> body:
   </summary>
 
 <table><tr><td valign="top"><details open><summary><b>Local</b></summary>
@@ -2145,7 +2141,7 @@ const listHandler = await interceptor.get('/users').respond({
 
 <details>
   <summary>
-    Declaring responses with <b>plain text body</b>:
+    Declaring responses with <b>plain text</b> body:
   </summary>
 
 <table><tr><td valign="top"><details open><summary><b>Local</b></summary>
@@ -2171,7 +2167,7 @@ const listHandler = await interceptor.get('/users').respond({
 
 <details>
   <summary>
-    Declaring responses with a <b>search params body</b> (<code>x-www-form-urlencoded</code>) using <a href='#httpsearchparams'><code>HttpSearchParams</code></a>:
+    Declaring responses with <b>search params</b> (<code>x-www-form-urlencoded</code>) body:
   </summary>
 
 <table><tr><td valign="top"><details open><summary><b>Local</b</summary>

--- a/README.md
+++ b/README.md
@@ -1043,8 +1043,39 @@ const interceptor = http.createInterceptor<{
 Each method can have a `request`, which defines the schema of the accepted requests. `headers`, `searchParams`, and
 `body` are supported to provide type safety when applying mocks.
 
-[Path parameters](#dynamic-path-parameters) are automatically inferred from dynamic paths, such as `/users/:id`. Bodies
-can be a JSON object, [`HttpFormData`](#httpformdata), [`HttpSearchParams`](#httpsearchparams), `Blob`, or plain text.
+[Path parameters](#dynamic-path-parameters) are automatically inferred from dynamic paths, such as `/users/:id`.
+
+<details open>
+  <summary>
+    Declaring a request with search params:
+  </summary>
+
+```ts
+import { HttpSchema, JSONValue } from 'zimic';
+import { http } from 'zimic/interceptor';
+
+type UserListSearchParams = HttpSchema.SearchParams<{
+  username?: string;
+}>;
+
+const interceptor = http.createInterceptor<{
+  '/users': {
+    GET: {
+      request: { searchParams: UserListSearchParams };
+    };
+  };
+}>({
+  type: 'local',
+  baseURL: 'http://localhost:3000',
+});
+```
+
+</details>
+
+<details open>
+  <summary>
+    Declaring a request with a JSON body using <code>JSONValue</code>:
+  </summary>
 
 ```ts
 import { HttpSchema, JSONValue } from 'zimic';
@@ -1054,6 +1085,107 @@ type UserCreationBody = JSONValue<{
   username: string;
 }>;
 
+const interceptor = http.createInterceptor<{
+  '/users': {
+    POST: {
+      request: { body: UserCreationBody };
+    };
+  };
+}>({
+  type: 'local',
+  baseURL: 'http://localhost:3000',
+});
+```
+
+</details>
+
+<details>
+  <summary>
+    Declaring a request with a form data body using <a href='#httpformdata'><code>HttpFormData</code></a>:
+  </summary>
+
+```ts
+import { HttpSchema, HttpFormData } from 'zimic';
+import { http } from 'zimic/interceptor';
+
+type FileUploadData = HttpSchema.FormData<{
+  files: File[];
+  description?: string;
+}>;
+
+type UserListSearchParams = HttpSchema.SearchParams<{
+  username?: string;
+}>;
+
+const interceptor = http.createInterceptor<{
+  '/files': {
+    POST: {
+      request: { body: HttpFormData<FileUploadData> };
+    };
+  };
+}>({
+  type: 'local',
+  baseURL: 'http://localhost:3000',
+});
+```
+
+</details>
+
+<details>
+  <summary>
+    Declaring a request with a blob body:
+  </summary>
+
+```ts
+import { HttpSchema } from 'zimic';
+import { http } from 'zimic/interceptor';
+
+const interceptor = http.createInterceptor<{
+  '/users': {
+    POST: {
+      request: { body: Blob };
+    };
+  };
+}>({
+  type: 'local',
+  baseURL: 'http://localhost:3000',
+});
+```
+
+</details>
+
+<details>
+  <summary>
+    Declaring a request with plain text body:
+  </summary>
+
+```ts
+import { HttpSchema, JSONValue } from 'zimic';
+import { http } from 'zimic/interceptor';
+
+const interceptor = http.createInterceptor<{
+  '/users': {
+    POST: {
+      request: { body: string };
+    };
+  };
+}>({
+  type: 'local',
+  baseURL: 'http://localhost:3000',
+});
+```
+
+</details>
+
+<details>
+  <summary>
+    Declaring a request with a search params body (<code>x-www-form-urlencoded</code>) using <a href='#httpsearchparams'><code>HttpSearchParams</code></a>:
+  </summary>
+
+```ts
+import { HttpSchema, HttpSearchParams } from 'zimic';
+import { http } from 'zimic/interceptor';
+
 type UserListSearchParams = HttpSchema.SearchParams<{
   username?: string;
 }>;
@@ -1061,26 +1193,16 @@ type UserListSearchParams = HttpSchema.SearchParams<{
 const interceptor = http.createInterceptor<{
   '/users': {
     POST: {
-      request: {
-        body: UserCreationBody;
-      };
-      // ...
+      request: { body: HttpSearchParams<UserListSearchParams> };
     };
-
-    GET: {
-      request: {
-        searchParams: UserListSearchParams;
-      };
-      // ...
-    };
-    // Other methods
   };
-  // Other paths
 }>({
   type: 'local',
   baseURL: 'http://localhost:3000',
 });
 ```
+
+</details>
 
 > [!TIP]
 >
@@ -1089,9 +1211,10 @@ const interceptor = http.createInterceptor<{
 
 > [!IMPORTANT]
 >
-> Body types cannot be declared using the keyword `interface`, because interfaces do not have implicit index signatures
-> as types do. Part of Zimic's JSON validation relies on index signatures. To workaround this, you can declare bodies
-> using `type`. As an extra step to make sure the type is a valid JSON, you can use the utility type `JSONValue`.
+> JSON body types cannot be declared using the keyword `interface`, because interfaces do not have implicit index
+> signatures as types do. Part of Zimic's JSON validation relies on index signatures. To workaround this, you can
+> declare JSON bodies using `type`. As an extra step to make sure the type is a valid JSON, you can use the utility type
+> `JSONValue`.
 
 <details>
   <summary>
@@ -1133,6 +1256,11 @@ keys. `headers` and `body` are supported to provide type safety when applying mo
 Bodies can be a JSON object, [`HttpFormData`](#httpformdata), [`HttpSearchParams`](#httpsearchparams), `Blob`, or plain
 text.
 
+<details open>
+  <summary>
+    Declaring a response with a JSON body using <code>JSONValue</code>:
+  </summary>
+
 ```ts
 import { JSONValue } from 'zimic';
 import { http } from 'zimic/interceptor';
@@ -1148,20 +1276,128 @@ type NotFoundError = JSONValue<{
 const interceptor = http.createInterceptor<{
   '/users/:id': {
     GET: {
-      // ...
       response: {
         200: { body: User };
         404: { body: NotFoundError };
       };
     };
-    // Other methods
   };
-  // Other paths
 }>({
   type: 'local',
   baseURL: 'http://localhost:3000',
 });
 ```
+
+</details>
+
+<details>
+  <summary>
+    Declaring a response with a form data body using <a href='#httpformdata'><code>HttpFormData</code></a>:
+  </summary>
+
+```ts
+import { HttpSchema, HttpFormData } from 'zimic';
+import { http } from 'zimic/interceptor';
+
+type FileUploadData = HttpSchema.FormData<{
+  files: File[];
+  description?: string;
+}>;
+
+const interceptor = http.createInterceptor<{
+  '/files': {
+    POST: {
+      response: {
+        200: { body: HttpFormData<FileUploadData> };
+      };
+    };
+  };
+}>({
+  type: 'local',
+  baseURL: 'http://localhost:3000',
+});
+```
+
+</details>
+
+<details>
+  <summary>
+    Declaring a response with a blob body:
+  </summary>
+
+```ts
+import { HttpSchema } from 'zimic';
+import { http } from 'zimic/interceptor';
+
+const interceptor = http.createInterceptor<{
+  '/users': {
+    POST: {
+      response: {
+        200: { body: Blob };
+      };
+    };
+  };
+}>({
+  type: 'local',
+  baseURL: 'http://localhost:3000',
+});
+```
+
+</details>
+
+<details>
+  <summary>
+    Declaring a response with plain text body:
+  </summary>
+
+```ts
+import { HttpSchema, JSONValue } from 'zimic';
+import { http } from 'zimic/interceptor';
+
+const interceptor = http.createInterceptor<{
+  '/users': {
+    POST: {
+      response: {
+        200: { body: string };
+      };
+    };
+  };
+}>({
+  type: 'local',
+  baseURL: 'http://localhost:3000',
+});
+```
+
+</details>
+
+<details>
+  <summary>
+    Declaring a response with a search params body (<code>x-www-form-urlencoded</code>) using <a href='#httpsearchparams'><code>HttpSearchParams</code></a>:
+  </summary>
+
+```ts
+import { HttpSchema, HttpSearchParams } from 'zimic';
+import { http } from 'zimic/interceptor';
+
+type UserListSearchParams = HttpSchema.SearchParams<{
+  username?: string;
+}>;
+
+const interceptor = http.createInterceptor<{
+  '/users': {
+    POST: {
+      response: {
+        200: { body: HttpSearchParams<UserListSearchParams> };
+      };
+    };
+  };
+}>({
+  type: 'local',
+  baseURL: 'http://localhost:3000',
+});
+```
+
+</details>
 
 > [!TIP]
 >
@@ -1473,14 +1709,198 @@ condition.
 
 ##### Static restrictions
 
+<details open>
+  <summary>
+    Declaring restrictions over a JSON body:
+  </summary>
+
 <table><tr><td valign="top"><details open><summary><b>Local</b></summary>
 
 ```ts
 const creationHandler = interceptor
   .post('/users')
   .with({
-    headers: { 'content-type': 'application/json' },
-    body: creationPayload,
+    body: { username: 'diego-aquino' },
+  })
+  .respond({
+    status: 201,
+    body: { username: 'diego-aquino' },
+  });
+```
+
+</details></td><td valign="top"><details open><summary><b>Remote</b></summary>
+
+```ts
+const creationHandler = await interceptor
+  .post('/users')
+  .with({
+    body: { username: 'diego-aquino' },
+  })
+  .respond({
+    status: 201,
+    body: { username: 'diego-aquino' },
+  });
+```
+
+</details></td></tr></table>
+
+> [!IMPORTANT]
+>
+> For the body to be correctly parsed, make sure that the intercepted requests have the header
+> `content-type: application/json`.
+
+</details>
+
+<details>
+  <summary>
+    Declaring restrictions over a form data body:
+  </summary>
+
+<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+
+```ts
+import { HttpFormData } from 'zimic';
+
+const formData = new HttpFormData<UserCreationData>();
+formData.append('username', 'diego-aquino');
+formData.append('profilePicture', new File(['content'], 'profile.png', { type: 'image/png' }));
+
+const creationHandler = interceptor
+  .post('/users')
+  .with({
+    body: formData,
+  })
+  .respond({
+    status: 201,
+    body: { username: 'diego-aquino' },
+  });
+```
+
+</details></td><td valign="top"><details open><summary><b>Remote</b></summary>
+
+```ts
+import { HttpFormData } from 'zimic';
+
+const formData = new HttpFormData<UserCreationData>();
+formData.append('username', 'diego-aquino');
+formData.append('profilePicture', new File(['content'], 'profile.png', { type: 'image/png' }));
+
+const creationHandler = await interceptor
+  .post('/users')
+  .with({
+    body: formData,
+  })
+  .respond({
+    status: 201,
+    body: { username: 'diego-aquino' },
+  });
+```
+
+</details></td></tr></table>
+
+> [!IMPORTANT]
+>
+> For the body to be correctly parsed, make sure that the intercepted requests have the header
+> `content-type: multipart/form-data`.
+
+</details>
+
+<details>
+  <summary>
+    Declaring restrictions over a blob body:
+  </summary>
+
+<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+
+```ts
+const creationHandler = interceptor
+  .post('/users')
+  .with({
+    body: new Blob(['content'], { type: 'application/octet-stream' }),
+  })
+  .respond({
+    status: 201,
+    body: { username: 'diego-aquino' },
+  });
+```
+
+</details></td><td valign="top"><details open><summary><b>Remote</b></summary>
+
+```ts
+const creationHandler = await interceptor
+  .post('/users')
+  .with({
+    body: new Blob(['content'], { type: 'application/octet-stream' }),
+  })
+  .respond({
+    status: 201,
+    body: { username: 'diego-aquino' },
+  });
+```
+
+</details></td></tr></table>
+
+> [!IMPORTANT]
+>
+> For the body to be correctly parsed, make sure that the intercepted requests have the header `content-type` indicating
+> a binary data, such as `application/octet-stream`, `image/png`, `audio/mpeg`, etc.
+
+</details>
+
+<details>
+  <summary>
+    Declaring restrictions over a plain text body:
+  </summary>
+
+<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+
+```ts
+const creationHandler = interceptor
+  .post('/users')
+  .with({
+    body: 'content',
+  })
+  .respond({
+    status: 201,
+    body: { username: 'diego-aquino' },
+  });
+```
+
+</details></td><td valign="top"><details open><summary><b>Remote</b></summary>
+
+```ts
+const creationHandler = await interceptor
+  .post('/users')
+  .with({
+    body: 'content',
+  })
+  .respond({
+    status: 201,
+    body: { username: 'diego-aquino' },
+  });
+```
+
+</details></td></tr></table>
+
+> [!IMPORTANT]
+>
+> For the body to be correctly parsed, make sure that the intercepted requests have the header `content-type` indicating
+> a plain text, such as `text/plain`.
+
+</details>
+
+<details open>
+  <summary>
+    Declaring restrictions over search params:
+  </summary>
+
+<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+
+```ts
+const creationHandler = interceptor
+  .get('/users')
+  .with({
+    searchParams: { username: 'diego-aquino' },
   })
   .respond({
     status: 200,
@@ -1492,10 +1912,9 @@ const creationHandler = interceptor
 
 ```ts
 const creationHandler = await interceptor
-  .post('/users')
+  .get('/users')
   .with({
-    headers: { 'content-type': 'application/json' },
-    body: creationPayload,
+    searchParams: { username: 'diego-aquino' },
   })
   .respond({
     status: 200,
@@ -1504,10 +1923,47 @@ const creationHandler = await interceptor
 ```
 
 </details></td></tr></table>
+</details>
+
+<details open>
+  <summary>
+    Declaring restrictions over headers:
+  </summary>
+
+<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+
+```ts
+const creationHandler = interceptor
+  .get('/users')
+  .with({
+    headers: { authorization: 'Bearer <token>' },
+  })
+  .respond({
+    status: 200,
+    body: [{ username: 'diego-aquino' }],
+  });
+```
+
+</details></td><td valign="top"><details open><summary><b>Remote</b></summary>
+
+```ts
+const creationHandler = await interceptor
+  .get('/users')
+  .with({
+    headers: { authorization: 'Bearer <token>' },
+  })
+  .respond({
+    status: 200,
+    body: [{ username: 'diego-aquino' }],
+  });
+```
+
+</details></td></tr></table>
+</details>
 
 By default, restrictions use `exact: false`, meaning that any request **containing** the declared restrictions will
-match the handler, regardless of having more properties or values. In the example above, requests with more headers than
-`content-type: application/json` will still match the handler. The same applies to search params and body restrictions.
+match the handler, regardless of having more properties or values. In the examples above, requests with more properties
+in the headers, search params, or body would still match the restrictions.
 
 If you want to match only requests with the exact values declared, you can use `exact: true`:
 
@@ -1518,13 +1974,13 @@ const creationHandler = interceptor
   .post('/users')
   .with({
     headers: { 'content-type': 'application/json' },
-    body: creationPayload,
+    body: { username: 'diego-aquino' },
     // Only requests with these exact headers and body will match
     exact: true,
   })
   .respond({
-    status: 200,
-    body: [{ username: 'diego-aquino' }],
+    status: 201,
+    body: { username: 'diego-aquino' },
   });
 ```
 
@@ -1535,13 +1991,13 @@ const creationHandler = await interceptor
   .post('/users')
   .with({
     headers: { 'content-type': 'application/json' },
-    body: creationPayload,
+    body: { username: 'diego-aquino' },
     // Only requests with these exact headers and body will match
     exact: true,
   })
   .respond({
-    status: 200,
-    body: [{ username: 'diego-aquino' }],
+    status: 201,
+    body: { username: 'diego-aquino' },
   });
 ```
 
@@ -1549,7 +2005,7 @@ const creationHandler = await interceptor
 
 ##### Computed restrictions
 
-A function is also supported to declare restrictions, in case they are dynamic.
+A function is also supported to declare restrictions in case they are dynamic.
 
 <table><tr><td valign="top"><details open><summary><b>Local</b></summary>
 
@@ -1561,7 +2017,7 @@ const creationHandler = interceptor
     return accept !== null && accept.startsWith('application');
   })
   .respond({
-    status: 200,
+    status: 201,
     body: [{ username: 'diego-aquino' }],
   });
 ```
@@ -1576,7 +2032,7 @@ const creationHandler = await interceptor
     return accept !== null && accept.startsWith('application');
   })
   .respond({
-    status: 200,
+    status: 201,
     body: [{ username: 'diego-aquino' }],
   });
 ```
@@ -1586,7 +2042,7 @@ const creationHandler = await interceptor
 The `request` parameter represents the intercepted request, containing useful properties such as `request.body`,
 `request.headers`, `request.pathParams`, and `request.searchParams`, which are typed based on the interceptor schema.
 The function should return a boolean: `true` if the request matches the handler and should receive the mock response;
-`false` otherwise and the request should bypass the handler.
+`false` otherwise.
 
 #### HTTP `handler.respond(declaration)`
 
@@ -1596,6 +2052,11 @@ When the handler matches a request, it will respond with the given declaration. 
 validated against the schema of the interceptor.
 
 ##### Static responses
+
+<details open>
+  <summary>
+    Declaring responses with a JSON body:
+  </summary>
 
 <table><tr><td valign="top"><details open><summary><b>Local</b></summary>
 
@@ -1616,10 +2077,139 @@ const listHandler = await interceptor.get('/users').respond({
 ```
 
 </details></td></tr></table>
+</details>
+
+<details>
+  <summary>
+    Declaring responses with a form data body using <a href='#httpformdata'><code>HttpFormData</code></a>:
+  </summary>
+
+<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+
+```ts
+import { HttpFormData } from 'zimic';
+
+const formData = new HttpFormData<UserGetByIdData>();
+formData.append('username', 'diego-aquino');
+formData.append('profilePicture', new File(['content'], 'profile.png', { type: 'image/png' }));
+
+const listHandler = interceptor.get('/users/:id').respond({
+  status: 200,
+  body: formData,
+});
+```
+
+</details></td><td valign="top"><details open><summary><b>Remote</b></summary>
+
+```ts
+import { HttpFormData } from 'zimic';
+
+const formData = new HttpFormData<UserGetByIdData>();
+formData.append('username', 'diego-aquino');
+formData.append('profilePicture', new File(['content'], 'profile.png', { type: 'image/png' }));
+
+const listHandler = await interceptor.get('/users/:id').respond({
+  status: 200,
+  body: formData,
+});
+```
+
+</details></td></tr></table>
+</details>
+
+<details>
+  <summary>
+    Declaring responses with a blob body:
+  </summary>
+
+<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+
+```ts
+const listHandler = interceptor.get('/users').respond({
+  status: 200,
+  body: new Blob(['content'], { type: 'application/octet-stream' }),
+});
+```
+
+</details></td><td valign="top"><details open><summary><b>Remote</b></summary>
+
+```ts
+const listHandler = await interceptor.get('/users').respond({
+  status: 200,
+  body: new Blob(['content'], { type: 'application/octet-stream' }),
+});
+```
+
+</details></td></tr></table>
+</details>
+
+<details>
+  <summary>
+    Declaring responses with plain text body:
+  </summary>
+
+<table><tr><td valign="top"><details open><summary><b>Local</b></summary>
+
+```ts
+const listHandler = interceptor.get('/users').respond({
+  status: 200,
+  body: 'content',
+});
+```
+
+</details></td><td valign="top"><details open><summary><b>Remote</b></summary>
+
+```ts
+const listHandler = await interceptor.get('/users').respond({
+  status: 200,
+  body: 'content',
+});
+```
+
+</details></td></tr></table>
+</details>
+
+<details>
+  <summary>
+    Declaring responses with a search params body (<code>x-www-form-urlencoded</code>) using <a href='#httpsearchparams'><code>HttpSearchParams</code></a>:
+  </summary>
+
+<table><tr><td valign="top"><details open><summary><b>Local</b</summary>
+
+```ts
+import { HttpSearchParams } from 'zimic';
+
+const searchParams = new HttpSearchParams<UserGetByIdSearchParams>({
+  username: 'diego-aquino',
+});
+
+const listHandler = interceptor.get('/users').respond({
+  status: 200,
+  body: searchParams,
+});
+```
+
+</details></td><td valign="top"><details open><summary><b>Remote</b</summary>
+
+```ts
+import { HttpSearchParams } from 'zimic';
+
+const searchParams = new HttpSearchParams<UserGetByIdSearchParams>({
+  username: 'diego-aquino',
+});
+
+const listHandler = await interceptor.get('/users').respond({
+  status: 200,
+  body: searchParams,
+});
+```
+
+</details></td></tr></table>
+</details>
 
 ##### Computed responses
 
-A function is also supported to declare a response, in case it is dynamic:
+A function is also supported to declare a response in case it is dynamic:
 
 <table><tr><td valign="top"><details open><summary><b>Local</b></summary>
 


### PR DESCRIPTION
### Documentation
- [#zimic] Added more snippets about using form data, search params, blobs and plain text as bodies.
- [#zimic] Improved the structure of local vs remote code snippets.

### Chore
- [ci] Removed the scope `deps` from dependabot automated dependency upgrades.