### PR TITLE
fix(#zimic): strict empty `HttpHeaders` and `HttpSearchParams` schemas (#211)

### DIFF
--- a/apps/zimic-test-client/tests/v0/interceptor/thirdParty/shared/default.ts
+++ b/apps/zimic-test-client/tests/v0/interceptor/thirdParty/shared/default.ts
@@ -153,7 +153,7 @@ async function declareDefaultClientTests(options: ClientTestOptionsByWorkerType)
         const creationRequests = await creationHandler.requests();
         expect(creationRequests).toHaveLength(1);
 
-        expectTypeOf(creationRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
+        expectTypeOf(creationRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<{}>>();
         expect(creationRequests[0].searchParams.size).toBe(0);
 
         expect(response.headers.get('x-user-id')).toBe(createdUser.id);
@@ -200,7 +200,7 @@ async function declareDefaultClientTests(options: ClientTestOptionsByWorkerType)
         const creationRequests = await creationHandler.requests();
         expect(creationRequests).toHaveLength(1);
 
-        expectTypeOf(creationRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
+        expectTypeOf(creationRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<{}>>();
         expect(creationRequests[0].searchParams.size).toBe(0);
 
         expectTypeOf(creationRequests[0].body).toEqualTypeOf<UserCreationPayload>();
@@ -243,7 +243,7 @@ async function declareDefaultClientTests(options: ClientTestOptionsByWorkerType)
         const creationRequests = await creationHandler.requests();
         expect(creationRequests).toHaveLength(1);
 
-        expectTypeOf(creationRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
+        expectTypeOf(creationRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<{}>>();
         expect(creationRequests[0].searchParams.size).toBe(0);
 
         expectTypeOf(creationRequests[0].body).toEqualTypeOf<UserCreationPayload>();
@@ -452,7 +452,7 @@ async function declareDefaultClientTests(options: ClientTestOptionsByWorkerType)
         expect(getRequests).toHaveLength(1);
         expect(getRequests[0].url).toBe(`${authBaseURL}/users/${user.id}`);
 
-        expectTypeOf(getRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
+        expectTypeOf(getRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<{}>>();
         expect(getRequests[0].searchParams.size).toBe(0);
 
         expectTypeOf(getRequests[0].body).toEqualTypeOf<null>();
@@ -492,7 +492,7 @@ async function declareDefaultClientTests(options: ClientTestOptionsByWorkerType)
         expectTypeOf(getRequests[0].pathParams).toEqualTypeOf<{ id: string }>();
         expect(getRequests[0].pathParams).toEqual({ id: user.id });
 
-        expectTypeOf(getRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
+        expectTypeOf(getRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<{}>>();
         expect(getRequests[0].searchParams.size).toBe(0);
 
         expectTypeOf(getRequests[0].body).toEqualTypeOf<null>();
@@ -534,7 +534,7 @@ async function declareDefaultClientTests(options: ClientTestOptionsByWorkerType)
         expectTypeOf(deleteRequests[0].pathParams).toEqualTypeOf<{ id: string }>();
         expect(deleteRequests[0].pathParams).toEqual({});
 
-        expectTypeOf(deleteRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
+        expectTypeOf(deleteRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<{}>>();
         expect(deleteRequests[0].searchParams.size).toBe(0);
 
         expectTypeOf(deleteRequests[0].body).toEqualTypeOf<null>();
@@ -574,7 +574,7 @@ async function declareDefaultClientTests(options: ClientTestOptionsByWorkerType)
         expectTypeOf(deleteRequests[0].pathParams).toEqualTypeOf<{ id: string }>();
         expect(deleteRequests[0].pathParams).toEqual({ id: user.id });
 
-        expectTypeOf(deleteRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
+        expectTypeOf(deleteRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<{}>>();
         expect(deleteRequests[0].searchParams.size).toBe(0);
 
         expectTypeOf(deleteRequests[0].body).toEqualTypeOf<null>();
@@ -639,7 +639,7 @@ async function declareDefaultClientTests(options: ClientTestOptionsByWorkerType)
         expectTypeOf(listRequests[0].pathParams).toEqualTypeOf<{ userId: string }>();
         expect(listRequests[0].pathParams).toEqual({ userId: notification.userId });
 
-        expectTypeOf(listRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
+        expectTypeOf(listRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<{}>>();
         expect(listRequests[0].searchParams.size).toBe(0);
 
         expectTypeOf(listRequests[0].body).toEqualTypeOf<null>();

--- a/packages/zimic/src/http/headers/__tests__/HttpHeaders.test.ts
+++ b/packages/zimic/src/http/headers/__tests__/HttpHeaders.test.ts
@@ -468,4 +468,28 @@ describe('HttpHeaders', () => {
     otherHeaders.append('accept', '*/*');
     expect(headers.contains(otherHeaders)).toBe(false);
   });
+
+  it('should correctly show type errors if unexpected schemas are used', () => {
+    const defaultSchemaHeaders = new HttpHeaders();
+    defaultSchemaHeaders.set('unknown', 'value');
+    defaultSchemaHeaders.append('unknown', 'value');
+    defaultSchemaHeaders.get('unknown');
+    defaultSchemaHeaders.has('unknown');
+    defaultSchemaHeaders.delete('unknown');
+
+    const emptySchemaHeaders = new HttpHeaders<{}>();
+    // @ts-expect-error
+    emptySchemaHeaders.set('unknown', '*/*');
+    // @ts-expect-error
+    emptySchemaHeaders.append('unknown', '*/*');
+    // @ts-expect-error
+    emptySchemaHeaders.get('unknown');
+    // @ts-expect-error
+    emptySchemaHeaders.has('unknown');
+    // @ts-expect-error
+    emptySchemaHeaders.delete('unknown');
+
+    // @ts-expect-error
+    new HttpHeaders<string>();
+  });
 });

--- a/packages/zimic/src/http/searchParams/__tests__/HttpSearchParams.test.ts
+++ b/packages/zimic/src/http/searchParams/__tests__/HttpSearchParams.test.ts
@@ -452,4 +452,34 @@ describe('HttpSearchParams', () => {
     searchParams.delete('orderBy', 'asc');
     expect(searchParams.contains(otherSearchParams)).toBe(true);
   });
+
+  it('should correctly show type errors if unexpected schemas are used', () => {
+    const defaultSchemaSearchParams = new HttpSearchParams();
+    defaultSchemaSearchParams.set('unknown', 'value');
+    defaultSchemaSearchParams.append('unknown', 'value');
+    defaultSchemaSearchParams.get('unknown');
+    defaultSchemaSearchParams.getAll('unknown');
+    defaultSchemaSearchParams.has('unknown');
+    defaultSchemaSearchParams.has('unknown', 'value');
+    defaultSchemaSearchParams.delete('unknown');
+
+    const emptySchemaSearchParams = new HttpSearchParams<{}>();
+    // @ts-expect-error
+    emptySchemaSearchParams.set('unknown', 'value');
+    // @ts-expect-error
+    emptySchemaSearchParams.append('unknown', 'value');
+    // @ts-expect-error
+    emptySchemaSearchParams.get('unknown');
+    // @ts-expect-error
+    emptySchemaSearchParams.getAll('unknown');
+    // @ts-expect-error
+    emptySchemaSearchParams.has('unknown');
+    // @ts-expect-error
+    emptySchemaSearchParams.has('unknown', 'value');
+    // @ts-expect-error
+    emptySchemaSearchParams.delete('unknown');
+
+    // @ts-expect-error
+    new HttpSearchParams<string>();
+  });
 });

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/bodies.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/bodies.ts
@@ -98,8 +98,16 @@ export async function declareBodyHttpInterceptorTests(options: RuntimeSharedHttp
     describe('JSON', () => {
       it(`should support intercepting ${method} requests having a JSON body`, async () => {
         type MethodSchema = HttpSchema.Method<{
-          request: { body: UserJSONSchema };
-          response: { 200: { body: UserJSONSchema } };
+          request: {
+            headers: { 'content-type': string };
+            body: UserJSONSchema;
+          };
+          response: {
+            200: {
+              headers?: { 'content-type'?: string };
+              body: UserJSONSchema;
+            };
+          };
         }>;
 
         await usingHttpInterceptor<{
@@ -152,8 +160,16 @@ export async function declareBodyHttpInterceptorTests(options: RuntimeSharedHttp
 
       it(`should support intercepting ${method} requests having a number as JSON body`, async () => {
         type MethodSchema = HttpSchema.Method<{
-          request: { body: number };
-          response: { 200: { body: number } };
+          request: {
+            headers: { 'content-type': string };
+            body: number;
+          };
+          response: {
+            200: {
+              headers?: { 'content-type'?: string };
+              body: number;
+            };
+          };
         }>;
 
         await usingHttpInterceptor<{
@@ -206,8 +222,16 @@ export async function declareBodyHttpInterceptorTests(options: RuntimeSharedHttp
 
       it(`should support intercepting ${method} requests having a boolean as JSON body`, async () => {
         type MethodSchema = HttpSchema.Method<{
-          request: { body: boolean };
-          response: { 200: { body: boolean } };
+          request: {
+            headers: { 'content-type': string };
+            body: boolean;
+          };
+          response: {
+            200: {
+              headers?: { 'content-type'?: string };
+              body: boolean;
+            };
+          };
         }>;
 
         await usingHttpInterceptor<{
@@ -664,8 +688,16 @@ export async function declareBodyHttpInterceptorTests(options: RuntimeSharedHttp
     describe('Form data', () => {
       it(`should support intercepting ${method} requests having a form data body`, async () => {
         type MethodSchema = HttpSchema.Method<{
-          request: { body: HttpFormData<UserFormDataSchema> };
-          response: { 200: { body: HttpFormData<UserFormDataSchema> } };
+          request: {
+            headers: { 'content-type': string };
+            body: HttpFormData<UserFormDataSchema>;
+          };
+          response: {
+            200: {
+              headers?: { 'content-type'?: string };
+              body: HttpFormData<UserFormDataSchema>;
+            };
+          };
         }>;
 
         await usingHttpInterceptor<{
@@ -884,8 +916,16 @@ export async function declareBodyHttpInterceptorTests(options: RuntimeSharedHttp
     describe('URL search params', () => {
       it(`should support intercepting ${method} requests having a URL search params body`, async () => {
         type MethodSchema = HttpSchema.Method<{
-          request: { body: HttpSearchParams<UserSearchParamsSchema> };
-          response: { 200: { body: HttpSearchParams<UserSearchParamsSchema> } };
+          request: {
+            headers: { 'content-type': string };
+            body: HttpSearchParams<UserSearchParamsSchema>;
+          };
+          response: {
+            200: {
+              headers?: { 'content-type'?: string };
+              body: HttpSearchParams<UserSearchParamsSchema>;
+            };
+          };
         }>;
 
         await usingHttpInterceptor<{
@@ -1084,8 +1124,16 @@ export async function declareBodyHttpInterceptorTests(options: RuntimeSharedHttp
     describe('Plain text', () => {
       it(`should support intercepting ${method} requests having a plain text body`, async () => {
         type MethodSchema = HttpSchema.Method<{
-          request: { body: string };
-          response: { 200: { body: string } };
+          request: {
+            headers: { 'content-type': string };
+            body: string;
+          };
+          response: {
+            200: {
+              headers?: { 'content-type'?: string };
+              body: string;
+            };
+          };
         }>;
 
         await usingHttpInterceptor<{
@@ -1277,8 +1325,16 @@ export async function declareBodyHttpInterceptorTests(options: RuntimeSharedHttp
         'multipart/mixed',
       ] as const)(`should support intercepting ${method} requests having a binary body: %s`, async (contentType) => {
         type MethodSchema = HttpSchema.Method<{
-          request: { body: Blob };
-          response: { 200: { body: Blob } };
+          request: {
+            headers: { 'content-type': string };
+            body: Blob;
+          };
+          response: {
+            200: {
+              headers?: { 'content-type'?: string };
+              body: Blob;
+            };
+          };
         }>;
 
         await usingHttpInterceptor<{

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/typescript.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/typescript.ts
@@ -91,14 +91,24 @@ export function declareTypeHttpInterceptorTests(options: RuntimeSharedHttpInterc
     await usingHttpInterceptor<{
       '/users': {
         GET: {
-          response: {
-            200: { body: User };
-          };
+          response: { 200: { body: User } };
+        } & {
+          request: {};
+          response: { 200: { body: User } };
+        } & {
+          request: never;
+          response: { 200: { body: User } };
+        } & {
+          request: { searchParams: {} };
+          response: { 200: { body: User } };
+        } & {
+          request: { searchParams: never };
+          response: { 200: { body: User } };
         };
       };
     }>({ type, baseURL }, async (interceptor) => {
       const listHandler = interceptor.get('/users').respond((request) => {
-        expectTypeOf(request.searchParams).toEqualTypeOf<HttpSearchParams<never>>();
+        expectTypeOf(request.searchParams).toEqualTypeOf<HttpSearchParams<{}>>();
 
         return {
           status: 200,
@@ -108,7 +118,7 @@ export function declareTypeHttpInterceptorTests(options: RuntimeSharedHttpInterc
 
       const listRequests = await listHandler.requests();
       type RequestSearchParams = (typeof listRequests)[number]['searchParams'];
-      expectTypeOf<RequestSearchParams>().toEqualTypeOf<HttpSearchParams<never>>();
+      expectTypeOf<RequestSearchParams>().toEqualTypeOf<HttpSearchParams<{}>>();
     });
   });
 
@@ -149,14 +159,24 @@ export function declareTypeHttpInterceptorTests(options: RuntimeSharedHttpInterc
     await usingHttpInterceptor<{
       '/users': {
         GET: {
-          response: {
-            200: { body: User };
-          };
+          response: { 200: { body: User } };
+        } & {
+          request: {};
+          response: { 200: { body: User } };
+        } & {
+          request: never;
+          response: { 200: { body: User } };
+        } & {
+          request: { headers: {} };
+          response: { 200: { body: User } };
+        } & {
+          request: { headers: never };
+          response: { 200: { body: User } };
         };
       };
     }>({ type, baseURL }, async (interceptor) => {
       const listHandler = interceptor.get('/users').respond((request) => {
-        expectTypeOf(request.headers).toEqualTypeOf<HttpHeaders<never>>();
+        expectTypeOf(request.headers).toEqualTypeOf<HttpHeaders<{}>>();
 
         return {
           status: 200,
@@ -166,7 +186,7 @@ export function declareTypeHttpInterceptorTests(options: RuntimeSharedHttpInterc
 
       const listRequests = await listHandler.requests();
       type RequestHeaders = (typeof listRequests)[number]['headers'];
-      expectTypeOf<RequestHeaders>().toEqualTypeOf<HttpHeaders<never>>();
+      expectTypeOf<RequestHeaders>().toEqualTypeOf<HttpHeaders<{}>>();
     });
   });
 

--- a/packages/zimic/src/interceptor/http/requestHandler/types/requests.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/types/requests.ts
@@ -8,7 +8,7 @@ import {
   HttpServiceResponseSchemaStatusCode,
   PathParamsSchemaFromPath,
 } from '@/http/types/schema';
-import { Default, DefaultNoExclude, PossiblePromise, ReplaceBy } from '@/types/utils';
+import { Default, DefaultNoExclude, IfNever, PossiblePromise, ReplaceBy } from '@/types/utils';
 
 export type HttpRequestHandlerResponseBodyAttribute<ResponseSchema extends HttpServiceResponseSchema> =
   undefined extends ResponseSchema['body'] ? { body?: null } : { body: ResponseSchema['body'] };
@@ -42,11 +42,13 @@ export type HttpRequestHandlerResponseDeclarationFactory<
 ) => PossiblePromise<HttpRequestHandlerResponseDeclaration<MethodSchema, StatusCode>>;
 
 export type HttpRequestHeadersSchema<MethodSchema extends HttpServiceMethodSchema> = DefaultNoExclude<
-  Default<MethodSchema['request'], { headers: never }>['headers']
+  Default<MethodSchema['request'], { headers: {} }>['headers'],
+  {}
 >;
 
 export type HttpRequestSearchParamsSchema<MethodSchema extends HttpServiceMethodSchema> = DefaultNoExclude<
-  Default<MethodSchema['request'], { searchParams: never }>['searchParams']
+  Default<MethodSchema['request'], { searchParams: {} }>['searchParams'],
+  {}
 >;
 
 export type HttpRequestBodySchema<MethodSchema extends HttpServiceMethodSchema> = ReplaceBy<
@@ -62,15 +64,15 @@ export type HttpRequestBodySchema<MethodSchema extends HttpServiceMethodSchema> 
 export interface HttpInterceptorRequest<Path extends string, MethodSchema extends HttpServiceMethodSchema>
   extends Omit<HttpRequest, keyof Body | 'headers'> {
   /** The headers of the request. */
-  headers: HttpHeaders<Default<HttpRequestHeadersSchema<MethodSchema>>>;
+  headers: HttpHeaders<IfNever<Default<HttpRequestHeadersSchema<MethodSchema>>, {}>>;
   /** The path parameters of the request. They are parsed from the path string when using dynamic paths. */
   pathParams: PathParamsSchemaFromPath<Path>;
   /** The search parameters of the request. */
-  searchParams: HttpSearchParams<Default<HttpRequestSearchParamsSchema<MethodSchema>>>;
+  searchParams: HttpSearchParams<IfNever<Default<HttpRequestSearchParamsSchema<MethodSchema>>, {}>>;
   /** The body of the request. It is already parsed by default. */
   body: HttpRequestBodySchema<MethodSchema>;
   /** The raw request object. */
-  raw: HttpRequest<Default<Default<MethodSchema['request'], { body: null }>['body'], null>>;
+  raw: HttpRequest<HttpRequestBodySchema<MethodSchema>>;
 }
 
 export type HttpResponseHeadersSchema<

--- a/packages/zimic/src/types/utils.ts
+++ b/packages/zimic/src/types/utils.ts
@@ -4,7 +4,9 @@ export type Default<Type, IfEmpty = never> = [undefined | void] extends [Type]
 
 export type DefaultNoExclude<Type, IfEmpty = never> = [undefined | void] extends Type ? IfEmpty : Type;
 
-export type IfAny<Type, Yes, No> = 0 extends 1 & Type ? Yes : No;
+export type IfAny<Type, Yes, No = Type> = 0 extends 1 & Type ? Yes : No;
+
+export type IfNever<Type, Yes, No = Type> = [Type] extends [never] ? Yes : No;
 
 export type PossiblePromise<Type> = Type | PromiseLike<Type>;
 
@@ -34,7 +36,8 @@ type PickArrayProperties<Type> = {
 
 export type ArrayKey<Type> = keyof PickArrayProperties<Type>;
 
-export type NonArrayKey<Type> = Exclude<keyof Type, ArrayKey<Type>>;
+export type NonArrayKey<Type> =
+  string | number extends ArrayKey<Type> ? keyof Type : Exclude<keyof Type, ArrayKey<Type>>;
 
 export type ReplaceBy<Type, Source, Target> = Type extends Source ? Target : Type;
 


### PR DESCRIPTION
### Fixes
- [#zimic] Changed `HttpHeaders` and `HttpSearchParams` to be strict when a missing or empty schema is used. Now, trying to access properties in `get`, `set`, `append`, for example, will correctly show a type error instead of just returning `never`.

### Refactoring
- [#zimic]  Moved related response tests together.

Closes #211.