### PR TITLE
fix(#zimic): partial restriction types

### DIFF
--- a/packages/zimic/src/http/types/requests.ts
+++ b/packages/zimic/src/http/types/requests.ts
@@ -47,7 +47,8 @@ export interface HttpRequest<
   StrictHeadersSchema extends HttpHeadersSchema = HttpHeadersSchema,
 > extends Request {
   headers: StrictHeaders<StrictHeadersSchema>;
-  json: () => Promise<StrictBody>;
+  json: () => Promise<StrictBody extends JSONValue ? StrictBody : never>;
+  formData: () => Promise<StrictBody extends HttpFormData<infer _Schema> ? StrictBody : FormData>;
 }
 
 /**
@@ -61,5 +62,6 @@ export interface HttpResponse<
 > extends Response {
   status: StatusCode;
   headers: StrictHeaders<StrictHeadersSchema>;
-  json: () => Promise<StrictBody>;
+  json: () => Promise<StrictBody extends JSONValue ? StrictBody : never>;
+  formData: () => Promise<StrictBody extends HttpFormData<infer _Schema> ? StrictBody : FormData>;
 }

--- a/packages/zimic/src/http/types/requests.ts
+++ b/packages/zimic/src/http/types/requests.ts
@@ -9,7 +9,7 @@ import { HttpSearchParamsSchema } from '../searchParams/types';
 
 /** The default body type for HTTP requests and responses. */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type HttpBody = JSONValue | HttpFormData<any> | HttpSearchParams<any> | Blob | ArrayBuffer | ReadableStream;
+export type HttpBody = JSONValue | HttpFormData<any> | HttpSearchParams<any> | Blob | ArrayBuffer;
 
 /**
  * An HTTP headers object with a strictly-typed schema. Fully compatible with the built-in
@@ -47,8 +47,8 @@ export interface HttpRequest<
   StrictHeadersSchema extends HttpHeadersSchema = HttpHeadersSchema,
 > extends Request {
   headers: StrictHeaders<StrictHeadersSchema>;
-  json: () => Promise<StrictBody extends JSONValue ? StrictBody : never>;
-  formData: () => Promise<StrictBody extends HttpFormData<infer _Schema> ? StrictBody : FormData>;
+  json: () => Promise<StrictBody extends Exclude<JSONValue, string> ? StrictBody : never>;
+  formData: () => Promise<StrictBody extends HttpFormData<infer _HttpFormDataSchema> ? StrictBody : FormData>;
 }
 
 /**
@@ -62,6 +62,6 @@ export interface HttpResponse<
 > extends Response {
   status: StatusCode;
   headers: StrictHeaders<StrictHeadersSchema>;
-  json: () => Promise<StrictBody extends JSONValue ? StrictBody : never>;
-  formData: () => Promise<StrictBody extends HttpFormData<infer _Schema> ? StrictBody : FormData>;
+  json: () => Promise<StrictBody extends Exclude<JSONValue, string> ? StrictBody : never>;
+  formData: () => Promise<StrictBody extends HttpFormData<infer _HttpFormDataSchema> ? StrictBody : FormData>;
 }

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/bodies.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/bodies.ts
@@ -4,6 +4,7 @@ import InvalidFormDataError from '@/http/errors/InvalidFormDataError';
 import InvalidJSONError from '@/http/errors/InvalidJSONError';
 import HttpFormData from '@/http/formData/HttpFormData';
 import HttpSearchParams from '@/http/searchParams/HttpSearchParams';
+import { HttpRequest, HttpResponse } from '@/http/types/requests';
 import { HTTP_METHODS_WITH_REQUEST_BODY, HttpSchema } from '@/http/types/schema';
 import { promiseIfRemote } from '@/interceptor/http/interceptorWorker/__tests__/utils/promises';
 import LocalHttpRequestHandler from '@/interceptor/http/requestHandler/LocalHttpRequestHandler';
@@ -76,7 +77,7 @@ export async function declareBodyHttpInterceptorTests(options: RuntimeSharedHttp
   });
 
   describe.each(HTTP_METHODS_WITH_REQUEST_BODY)('Method: %s', (method) => {
-    const lowerMethod = method.toLowerCase<typeof method>();
+    const lowerMethod = method.toLowerCase<'POST'>();
 
     const invalidRequestJSONString = '<invalid-request-json>';
     const invalidResponseJSONString = '<invalid-response-json>';
@@ -155,6 +156,28 @@ export async function declareBodyHttpInterceptorTests(options: RuntimeSharedHttp
           expect(request.response.headers.get('content-type')).toBe('application/json');
           expectTypeOf(request.response.body).toEqualTypeOf<UserJSONSchema>();
           expect(request.response.body).toEqual(users[0]);
+
+          expectTypeOf(request.raw).toEqualTypeOf<HttpRequest<UserJSONSchema>>();
+          expect(request.raw).toBeInstanceOf(Request);
+          expect(request.raw.url).toBe(request.url);
+          expect(request.raw.method).toBe(method);
+          expect(Object.fromEntries(request.headers)).toEqual(
+            expect.objectContaining(Object.fromEntries(request.raw.headers)),
+          );
+          expectTypeOf(request.raw.json).toEqualTypeOf<() => Promise<UserJSONSchema>>();
+          expect(await request.raw.json()).toEqual<UserJSONSchema>(users[0]);
+          expectTypeOf(request.raw.formData).toEqualTypeOf<() => Promise<FormData>>();
+
+          expectTypeOf(request.response.raw).toEqualTypeOf<HttpResponse<UserJSONSchema, 200>>();
+          expect(request.response.raw).toBeInstanceOf(Response);
+          expectTypeOf(request.response.raw.status).toEqualTypeOf<200>();
+          expect(request.response.raw.status).toBe(200);
+          expect(Object.fromEntries(response.headers)).toEqual(
+            expect.objectContaining(Object.fromEntries(request.response.raw.headers)),
+          );
+          expectTypeOf(request.response.raw.json).toEqualTypeOf<() => Promise<UserJSONSchema>>();
+          expect(await request.response.raw.json()).toEqual<UserJSONSchema>(users[0]);
+          expectTypeOf(request.response.raw.formData).toEqualTypeOf<() => Promise<FormData>>();
         });
       });
 
@@ -217,6 +240,28 @@ export async function declareBodyHttpInterceptorTests(options: RuntimeSharedHttp
           expect(request.response.headers.get('content-type')).toBe('application/json');
           expectTypeOf(request.response.body).toEqualTypeOf<number>();
           expect(request.response.body).toBe(2);
+
+          expectTypeOf(request.raw).toEqualTypeOf<HttpRequest<number>>();
+          expect(request.raw).toBeInstanceOf(Request);
+          expect(request.raw.url).toBe(request.url);
+          expect(request.raw.method).toBe(method);
+          expect(Object.fromEntries(request.headers)).toEqual(
+            expect.objectContaining(Object.fromEntries(request.raw.headers)),
+          );
+          expectTypeOf(request.raw.json).toEqualTypeOf<() => Promise<number>>();
+          expect(await request.raw.json()).toEqual<number>(1);
+          expectTypeOf(request.raw.formData).toEqualTypeOf<() => Promise<FormData>>();
+
+          expectTypeOf(request.response.raw).toEqualTypeOf<HttpResponse<number, 200>>();
+          expect(request.response.raw).toBeInstanceOf(Response);
+          expectTypeOf(request.response.raw.status).toEqualTypeOf<200>();
+          expect(request.response.raw.status).toBe(200);
+          expect(Object.fromEntries(response.headers)).toEqual(
+            expect.objectContaining(Object.fromEntries(request.response.raw.headers)),
+          );
+          expectTypeOf(request.response.raw.json).toEqualTypeOf<() => Promise<number>>();
+          expect(await request.response.raw.json()).toEqual<number>(2);
+          expectTypeOf(request.response.raw.formData).toEqualTypeOf<() => Promise<FormData>>();
         });
       });
 
@@ -279,6 +324,28 @@ export async function declareBodyHttpInterceptorTests(options: RuntimeSharedHttp
           expect(request.response.headers.get('content-type')).toBe('application/json');
           expectTypeOf(request.response.body).toEqualTypeOf<boolean>();
           expect(request.response.body).toBe(false);
+
+          expectTypeOf(request.raw).toEqualTypeOf<HttpRequest<boolean>>();
+          expect(request.raw).toBeInstanceOf(Request);
+          expect(request.raw.url).toBe(request.url);
+          expect(request.raw.method).toBe(method);
+          expect(Object.fromEntries(request.headers)).toEqual(
+            expect.objectContaining(Object.fromEntries(request.raw.headers)),
+          );
+          expectTypeOf(request.raw.json).toEqualTypeOf<() => Promise<boolean>>();
+          expect(await request.raw.json()).toEqual<boolean>(true);
+          expectTypeOf(request.raw.formData).toEqualTypeOf<() => Promise<FormData>>();
+
+          expectTypeOf(request.response.raw).toEqualTypeOf<HttpResponse<boolean, 200>>();
+          expect(request.response.raw).toBeInstanceOf(Response);
+          expectTypeOf(request.response.raw.status).toEqualTypeOf<200>();
+          expect(request.response.raw.status).toBe(200);
+          expect(Object.fromEntries(response.headers)).toEqual(
+            expect.objectContaining(Object.fromEntries(request.response.raw.headers)),
+          );
+          expectTypeOf(request.response.raw.json).toEqualTypeOf<() => Promise<boolean>>();
+          expect(await request.response.raw.json()).toEqual<boolean>(false);
+          expectTypeOf(request.response.raw.formData).toEqualTypeOf<() => Promise<FormData>>();
         });
       });
 
@@ -774,6 +841,30 @@ export async function declareBodyHttpInterceptorTests(options: RuntimeSharedHttp
           expect(interceptedResponseTagFile.size).toBe(responseTagFile.size);
           expect(interceptedResponseTagFile.type).toBe(responseTagFile.type);
           expect(await interceptedResponseTagFile.text()).toEqual(await responseTagFile.text());
+
+          expectTypeOf(request.raw).toEqualTypeOf<HttpRequest<HttpFormData<UserFormDataSchema>>>();
+          expect(request.raw).toBeInstanceOf(Request);
+          expect(request.raw.url).toBe(request.url);
+          expect(request.raw.method).toBe(method);
+          expect(Object.fromEntries(request.headers)).toEqual(
+            expect.objectContaining(Object.fromEntries(request.raw.headers)),
+          );
+          expectTypeOf(request.raw.json).toEqualTypeOf<() => Promise<never>>();
+          expectTypeOf(request.raw.formData).toEqualTypeOf<() => Promise<HttpFormData<UserFormDataSchema>>>();
+          expect(Object.fromEntries(await request.raw.formData())).toEqual(Object.fromEntries(formData));
+
+          expectTypeOf(request.response.raw).toEqualTypeOf<HttpResponse<HttpFormData<UserFormDataSchema>, 200>>();
+          expect(request.response.raw).toBeInstanceOf(Response);
+          expectTypeOf(request.response.raw.status).toEqualTypeOf<200>();
+          expect(request.response.raw.status).toBe(200);
+          expect(Object.fromEntries(response.headers)).toEqual(
+            expect.objectContaining(Object.fromEntries(request.response.raw.headers)),
+          );
+          expectTypeOf(request.response.raw.json).toEqualTypeOf<() => Promise<never>>();
+          expectTypeOf(request.response.raw.formData).toEqualTypeOf<() => Promise<HttpFormData<UserFormDataSchema>>>();
+          expect(Object.fromEntries(await request.response.raw.formData())).toEqual(
+            Object.fromEntries(responseFormData),
+          );
         });
       });
 
@@ -983,6 +1074,28 @@ export async function declareBodyHttpInterceptorTests(options: RuntimeSharedHttp
           expectTypeOf(request.response.body).toEqualTypeOf<HttpSearchParams<UserSearchParamsSchema>>();
           expect(request.response.body).toBeInstanceOf(HttpSearchParams);
           expect(request.response.body).toEqual(responseSearchParams);
+
+          expectTypeOf(request.raw).toEqualTypeOf<HttpRequest<HttpSearchParams<UserSearchParamsSchema>>>();
+          expect(request.raw).toBeInstanceOf(Request);
+          expect(request.raw.url).toBe(request.url);
+          expect(request.raw.method).toBe(method);
+          expect(Object.fromEntries(request.headers)).toEqual(
+            expect.objectContaining(Object.fromEntries(request.raw.headers)),
+          );
+          expectTypeOf(request.raw.json).toEqualTypeOf<() => Promise<never>>();
+          expectTypeOf(request.raw.formData).toEqualTypeOf<() => Promise<FormData>>();
+
+          expectTypeOf(request.response.raw).toEqualTypeOf<
+            HttpResponse<HttpSearchParams<UserSearchParamsSchema>, 200>
+          >();
+          expect(request.response.raw).toBeInstanceOf(Response);
+          expectTypeOf(request.response.raw.status).toEqualTypeOf<200>();
+          expect(request.response.raw.status).toBe(200);
+          expect(Object.fromEntries(response.headers)).toEqual(
+            expect.objectContaining(Object.fromEntries(request.response.raw.headers)),
+          );
+          expectTypeOf(request.response.raw.json).toEqualTypeOf<() => Promise<never>>();
+          expectTypeOf(request.response.raw.formData).toEqualTypeOf<() => Promise<FormData>>();
         });
       });
 
@@ -1180,6 +1293,26 @@ export async function declareBodyHttpInterceptorTests(options: RuntimeSharedHttp
           expect(request.response.headers.get('content-type')).toBe('text/plain;charset=UTF-8');
           expectTypeOf(request.response.body).toEqualTypeOf<string>();
           expect(request.response.body).toBe('content-response');
+
+          expectTypeOf(request.raw).toEqualTypeOf<HttpRequest<string>>();
+          expect(request.raw).toBeInstanceOf(Request);
+          expect(request.raw.url).toBe(request.url);
+          expect(request.raw.method).toBe(method);
+          expect(Object.fromEntries(request.headers)).toEqual(
+            expect.objectContaining(Object.fromEntries(request.raw.headers)),
+          );
+          expectTypeOf(request.raw.json).toEqualTypeOf<() => Promise<never>>();
+          expectTypeOf(request.raw.formData).toEqualTypeOf<() => Promise<FormData>>();
+
+          expectTypeOf(request.response.raw).toEqualTypeOf<HttpResponse<string, 200>>();
+          expect(request.response.raw).toBeInstanceOf(Response);
+          expectTypeOf(request.response.raw.status).toEqualTypeOf<200>();
+          expect(request.response.raw.status).toBe(200);
+          expect(Object.fromEntries(response.headers)).toEqual(
+            expect.objectContaining(Object.fromEntries(request.response.raw.headers)),
+          );
+          expectTypeOf(request.response.raw.json).toEqualTypeOf<() => Promise<never>>();
+          expectTypeOf(request.response.raw.formData).toEqualTypeOf<() => Promise<FormData>>();
         });
       });
 
@@ -1395,6 +1528,26 @@ export async function declareBodyHttpInterceptorTests(options: RuntimeSharedHttp
           expect(request.response.body.type).toBe(responseFile.type);
           expect(request.response.body.size).toBe(responseFile.size);
           expect(await request.response.body.text()).toEqual(await responseFile.text());
+
+          expectTypeOf(request.raw).toEqualTypeOf<HttpRequest<Blob>>();
+          expect(request.raw).toBeInstanceOf(Request);
+          expect(request.raw.url).toBe(request.url);
+          expect(request.raw.method).toBe(method);
+          expect(Object.fromEntries(request.headers)).toEqual(
+            expect.objectContaining(Object.fromEntries(request.raw.headers)),
+          );
+          expectTypeOf(request.raw.json).toEqualTypeOf<() => Promise<never>>();
+          expectTypeOf(request.raw.formData).toEqualTypeOf<() => Promise<FormData>>();
+
+          expectTypeOf(request.response.raw).toEqualTypeOf<HttpResponse<Blob, 200>>();
+          expect(request.response.raw).toBeInstanceOf(Response);
+          expectTypeOf(request.response.raw.status).toEqualTypeOf<200>();
+          expect(request.response.raw.status).toBe(200);
+          expect(Object.fromEntries(response.headers)).toEqual(
+            expect.objectContaining(Object.fromEntries(request.response.raw.headers)),
+          );
+          expectTypeOf(request.response.raw.json).toEqualTypeOf<() => Promise<never>>();
+          expectTypeOf(request.response.raw.formData).toEqualTypeOf<() => Promise<FormData>>();
         });
       });
 
@@ -1463,6 +1616,111 @@ export async function declareBodyHttpInterceptorTests(options: RuntimeSharedHttp
           expectTypeOf(request.response.body).toEqualTypeOf<Blob | null>();
           expect(request.response.body).toBeInstanceOf(Blob);
           expect(request.response.body!.size).toBe(0);
+        });
+      });
+
+      it(`should consider array buffer ${method} request bodies as blob`, async () => {
+        type MethodSchema = HttpSchema.Method<{
+          request: {
+            headers: { 'content-type': string };
+            body: ArrayBuffer;
+          };
+          response: {
+            200: {
+              headers: { 'content-type'?: string };
+              body: ArrayBuffer;
+            };
+          };
+        }>;
+
+        await usingHttpInterceptor<{
+          '/users/:id': {
+            POST: MethodSchema;
+            PUT: MethodSchema;
+            PATCH: MethodSchema;
+            DELETE: MethodSchema;
+          };
+        }>(interceptorOptions, async (interceptor) => {
+          const responseBuffer = new ArrayBuffer(2);
+          const responseView = new Uint8Array(responseBuffer);
+          responseView[0] = 0x00;
+          responseView[1] = 0xff;
+
+          const handler = await promiseIfRemote(
+            interceptor[lowerMethod]('/users/:id').respond((request) => {
+              expectTypeOf(request.body).toEqualTypeOf<Blob>();
+              expect(request.body).toBeInstanceOf(Blob);
+
+              return {
+                status: 200,
+                headers: { 'content-type': 'application/octet-stream' },
+                body: responseBuffer,
+              };
+            }),
+            interceptor,
+          );
+          expect(handler).toBeInstanceOf(Handler);
+
+          let requests = await promiseIfRemote(handler.requests(), interceptor);
+          expect(requests).toHaveLength(0);
+
+          const requestBuffer = new ArrayBuffer(2);
+          const requestView = new Uint8Array(requestBuffer);
+          requestView[0] = 0xff;
+          requestView[1] = 0x00;
+
+          const response = await fetch(joinURL(baseURL, `/users/${users[0].id}`), {
+            method,
+            headers: { 'content-type': 'application/octet-stream' },
+            body: requestBuffer,
+          });
+          expect(response.status).toBe(200);
+
+          const fetchedFile = await response.blob();
+          expect(fetchedFile).toBeInstanceOf(Blob);
+          expect(fetchedFile.type).toBe('application/octet-stream');
+          expect(fetchedFile.size).toBe(2);
+          expect(await fetchedFile.arrayBuffer()).toEqual(responseBuffer);
+
+          requests = await promiseIfRemote(handler.requests(), interceptor);
+          expect(requests).toHaveLength(1);
+          const [request] = requests;
+
+          expect(request).toBeInstanceOf(Request);
+          expect(request.headers.get('content-type')).toBe('application/octet-stream');
+          expectTypeOf(request.body).toEqualTypeOf<Blob>();
+          expect(request.body).toBeInstanceOf(Blob);
+          expect(request.body.type).toBe('application/octet-stream');
+          expect(request.body.size).toBe(2);
+          expect(await request.body.arrayBuffer()).toEqual(requestBuffer);
+
+          expect(request.response).toBeInstanceOf(Response);
+          expect(request.response.headers.get('content-type')).toBe('application/octet-stream');
+          expectTypeOf(request.response.body).toEqualTypeOf<Blob>();
+          expect(request.response.body).toBeInstanceOf(Blob);
+          expect(request.response.body.type).toBe('application/octet-stream');
+          expect(request.response.body.size).toBe(2);
+          expect(await request.response.body.arrayBuffer()).toEqual(responseBuffer);
+
+          expectTypeOf(request.raw).toEqualTypeOf<HttpRequest<Blob>>();
+          expect(request.raw).toBeInstanceOf(Request);
+          expect(request.raw.url).toBe(request.url);
+          expect(request.raw.method).toBe(method);
+          expect(Object.fromEntries(request.headers)).toEqual(
+            expect.objectContaining(Object.fromEntries(request.raw.headers)),
+          );
+          expectTypeOf(request.raw.json).toEqualTypeOf<() => Promise<never>>();
+          expectTypeOf(request.raw.formData).toEqualTypeOf<() => Promise<FormData>>();
+
+          expectTypeOf(request.response.raw).toEqualTypeOf<HttpResponse<Blob, 200>>();
+          expect(request.response.raw).toBeInstanceOf(Response);
+          expectTypeOf(request.response.raw.status).toEqualTypeOf<200>();
+          expect(request.response.raw.status).toBe(200);
+          expect(Object.fromEntries(response.headers)).toEqual(
+            expect.objectContaining(Object.fromEntries(request.response.raw.headers)),
+          );
+          expectTypeOf(request.response.raw.json).toEqualTypeOf<() => Promise<never>>();
+          expectTypeOf(request.response.raw.formData).toEqualTypeOf<() => Promise<FormData>>();
         });
       });
     });

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/bypass.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/bypass.ts
@@ -34,7 +34,7 @@ export function declareBypassHttpInterceptorTests(options: RuntimeSharedHttpInte
       type,
     });
 
-    const lowerMethod = method.toLowerCase<typeof method>();
+    const lowerMethod = method.toLowerCase<'POST'>();
 
     type MethodSchema = HttpSchema.Method<{
       response: {

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/clear.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/clear.ts
@@ -34,7 +34,7 @@ export function declareClearHttpInterceptorTests(options: RuntimeSharedHttpInter
       type,
     });
 
-    const lowerMethod = method.toLowerCase<typeof method>();
+    const lowerMethod = method.toLowerCase<'POST'>();
 
     type MethodSchema = HttpSchema.Method<{
       response: { 200: { headers: AccessControlHeaders } };

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/dynamicPaths.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/dynamicPaths.ts
@@ -48,7 +48,7 @@ export async function declareDynamicPathsHttpInterceptorTests(options: RuntimeSh
       type,
     });
 
-    const lowerMethod = method.toLowerCase<typeof method>();
+    const lowerMethod = method.toLowerCase<'POST'>();
 
     type MethodSchema = HttpSchema.Method<{
       response: { 200: { headers: AccessControlHeaders } };

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/handlers.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/handlers.ts
@@ -38,7 +38,7 @@ export function declareHandlerHttpInterceptorTests(options: RuntimeSharedHttpInt
       type,
     });
 
-    const lowerMethod = method.toLowerCase<typeof method>();
+    const lowerMethod = method.toLowerCase<'POST'>();
 
     type MethodSchema = HttpSchema.Method<{
       response: { 200: { headers: AccessControlHeaders } };

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/lifeCycle.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/lifeCycle.ts
@@ -40,7 +40,7 @@ export function declareLifeCycleHttpInterceptorTests(options: RuntimeSharedHttpI
       type,
     });
 
-    const lowerMethod = method.toLowerCase<typeof method>();
+    const lowerMethod = method.toLowerCase<'POST'>();
 
     type MethodSchema = HttpSchema.Method<{
       response: { 200: { headers: AccessControlHeaders } };

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/restrictions.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/restrictions.ts
@@ -9,6 +9,7 @@ import { promiseIfRemote } from '@/interceptor/http/interceptorWorker/__tests__/
 import LocalHttpRequestHandler from '@/interceptor/http/requestHandler/LocalHttpRequestHandler';
 import RemoteHttpRequestHandler from '@/interceptor/http/requestHandler/RemoteHttpRequestHandler';
 import { AccessControlHeaders, DEFAULT_ACCESS_CONTROL_HEADERS } from '@/interceptor/server/constants';
+import { JSONValue } from '@/types/json';
 import { getFile } from '@/utils/files';
 import { joinURL } from '@/utils/urls';
 import { usingIgnoredConsole } from '@tests/utils/console';
@@ -35,22 +36,32 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
     Handler = type === 'local' ? LocalHttpRequestHandler : RemoteHttpRequestHandler;
   });
 
-  type UserRequestHeaders = HttpSchema.Headers<{
+  type RequestHeadersSchema = HttpSchema.Headers<{
     'content-language': string;
     accept: string;
     optional?: string;
   }>;
 
-  type UserSearchParams = HttpSchema.SearchParams<{
+  type RequestSearchParamsSchema = HttpSchema.SearchParams<{
     tag: string;
     other: string;
     optional?: string;
   }>;
 
+  type RequestJSONSchema = JSONValue<{
+    message: string;
+    required: string;
+    optional?: string;
+  }>;
+
+  type RequestFormDataSchema = HttpSchema.FormData<{
+    tag: File;
+  }>;
+
   type MethodSchema = HttpSchema.Method<{
     request: {
-      headers: UserRequestHeaders;
-      searchParams: UserSearchParams;
+      headers: RequestHeadersSchema;
+      searchParams: RequestSearchParamsSchema;
     };
     response: { 200: { headers: AccessControlHeaders } };
   }>;
@@ -62,10 +73,9 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
       type,
     });
 
-    // TODO: handler.with() restriction types are not performing well when combining many interceptor types and http methods
     const lowerMethod = method.toLowerCase<'POST'>();
 
-    it(`should support intercepting ${method} requests having headers restrictions`, async () => {
+    it(`should support intercepting ${method} requests having partial headers restrictions`, async () => {
       await usingHttpInterceptor<{
         '/users': {
           GET: MethodSchema;
@@ -82,15 +92,21 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
             .with({
               headers: { 'content-language': 'en' },
             })
+            .with({
+              headers: new HttpHeaders<Partial<RequestHeadersSchema>>({ 'content-language': 'en' }),
+            })
+            .with({
+              headers: new HttpHeaders<RequestHeadersSchema>(),
+            })
             .with((request) => {
-              expectTypeOf(request.headers).toEqualTypeOf<HttpHeaders<UserRequestHeaders>>();
+              expectTypeOf(request.headers).toEqualTypeOf<HttpHeaders<RequestHeadersSchema>>();
               expect(request.headers).toBeInstanceOf(HttpHeaders);
 
               const acceptHeader = request.headers.get('accept');
               return acceptHeader ? acceptHeader.includes('application/json') : false;
             })
             .respond((request) => {
-              expectTypeOf(request.headers).toEqualTypeOf<HttpHeaders<UserRequestHeaders>>();
+              expectTypeOf(request.headers).toEqualTypeOf<HttpHeaders<RequestHeadersSchema>>();
               expect(request.headers).toBeInstanceOf(HttpHeaders);
 
               return {
@@ -105,7 +121,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
         let requests = await promiseIfRemote(handler.requests(), interceptor);
         expect(requests).toHaveLength(0);
 
-        const headers = new HttpHeaders<UserRequestHeaders>({
+        const headers = new HttpHeaders<RequestHeadersSchema>({
           'content-language': 'en',
           accept: 'application/json',
         });
@@ -155,7 +171,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
       });
     });
 
-    it(`should support intercepting ${method} requests having search params restrictions`, async () => {
+    it(`should support intercepting ${method} requests having partial search params restrictions`, async () => {
       await usingHttpInterceptor<{
         '/users': {
           GET: MethodSchema;
@@ -172,8 +188,14 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
             .with({
               searchParams: { tag: 'admin' },
             })
+            .with({
+              searchParams: new HttpSearchParams<Partial<RequestSearchParamsSchema>>({ tag: 'admin' }),
+            })
+            .with({
+              searchParams: new HttpSearchParams<RequestSearchParamsSchema>(),
+            })
             .respond((request) => {
-              expectTypeOf(request.searchParams).toEqualTypeOf<HttpSearchParams<UserSearchParams>>();
+              expectTypeOf(request.searchParams).toEqualTypeOf<HttpSearchParams<RequestSearchParamsSchema>>();
               expect(request.searchParams).toBeInstanceOf(HttpSearchParams);
 
               return {
@@ -188,7 +210,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
         let requests = await promiseIfRemote(handler.requests(), interceptor);
         expect(requests).toHaveLength(0);
 
-        const searchParams = new HttpSearchParams<UserSearchParams>({ tag: 'admin', other: 'value' });
+        const searchParams = new HttpSearchParams<RequestSearchParamsSchema>({ tag: 'admin', other: 'value' });
 
         const response = await fetch(joinURL(baseURL, `/users?${searchParams.toString()}`), {
           method,
@@ -213,12 +235,11 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
   });
 
   describe.each(HTTP_METHODS_WITH_REQUEST_BODY)('Method: %s', (method) => {
-    // TODO: handler.with() restriction types are not performing well when combining many interceptor types and http methods
     const lowerMethod = method.toLowerCase<'POST'>();
 
-    it(`should support intercepting ${method} requests having exact body JSON restrictions`, async () => {
+    it(`should support intercepting ${method} requests having partial, exact body JSON restrictions`, async () => {
       type MethodSchemaWithBody = HttpSchema.Method<{
-        request: { body: { message: string } };
+        request: { body: RequestJSONSchema };
         response: { 200: {} };
       }>;
 
@@ -237,7 +258,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
               exact: true,
             })
             .respond((request) => {
-              expectTypeOf(request.body).toEqualTypeOf<{ message: string }>();
+              expectTypeOf(request.body).toEqualTypeOf<RequestJSONSchema>();
               expect(request.body).toEqual({ message: 'ok' });
 
               return { status: 200 };
@@ -273,9 +294,9 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
       });
     });
 
-    it(`should support intercepting ${method} requests having non-exact body JSON restrictions`, async () => {
+    it(`should support intercepting ${method} requests having partial, non-exact body JSON restrictions`, async () => {
       type MethodSchemaWithBody = HttpSchema.Method<{
-        request: { body: { message: string } };
+        request: { body: RequestJSONSchema };
         response: { 200: {} };
       }>;
 
@@ -294,7 +315,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
               exact: false,
             })
             .respond((request) => {
-              expectTypeOf(request.body).toEqualTypeOf<{ message: string }>();
+              expectTypeOf(request.body).toEqualTypeOf<RequestJSONSchema>();
               expect(request.body).toEqual(expect.objectContaining({ message: 'ok' }));
 
               return { status: 200 };
@@ -340,13 +361,9 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
       });
     });
 
-    it(`should support intercepting ${method} requests having exact body form data restrictions`, async () => {
-      type FormDataSchema = HttpSchema.FormData<{
-        tag?: File;
-      }>;
-
+    it(`should support intercepting ${method} requests having partial, exact body form data restrictions`, async () => {
       type MethodSchemaWithBody = HttpSchema.Method<{
-        request: { body: HttpFormData<FormDataSchema> };
+        request: { body: HttpFormData<RequestFormDataSchema> };
         response: { 200: {} };
       }>;
 
@@ -358,7 +375,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
           DELETE: MethodSchemaWithBody;
         };
       }>(interceptorOptions, async (interceptor) => {
-        const restrictedFormData = new HttpFormData<FormDataSchema>();
+        const restrictedFormData = new HttpFormData<RequestFormDataSchema>();
         const tagFile = new File(['content'], 'tag.txt', { type: 'text/plain' });
         restrictedFormData.append('tag', tagFile);
 
@@ -369,7 +386,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
               exact: true,
             })
             .respond((request) => {
-              expectTypeOf(request.body).toEqualTypeOf<HttpFormData<FormDataSchema>>();
+              expectTypeOf(request.body).toEqualTypeOf<HttpFormData<RequestFormDataSchema>>();
               expect(request.body).toEqual(restrictedFormData);
 
               return { status: 200 };
@@ -392,14 +409,19 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
 
         const differentTagFile = new File(['more-content'], 'tag.txt', { type: 'text/plain' });
 
-        const extendedFormData = new HttpFormData<FormDataSchema>();
+        const extendedFormData = new HttpFormData<RequestFormDataSchema>();
         extendedFormData.append('tag', tagFile);
         extendedFormData.append('tag', differentTagFile);
 
-        const differentFormData = new HttpFormData<FormDataSchema>();
+        const differentFormData = new HttpFormData<RequestFormDataSchema>();
         differentFormData.append('tag', differentTagFile);
 
-        for (const body of [extendedFormData, differentFormData, new HttpFormData<FormDataSchema>(), undefined]) {
+        for (const body of [
+          extendedFormData,
+          differentFormData,
+          new HttpFormData<RequestFormDataSchema>(),
+          undefined,
+        ]) {
           await usingIgnoredConsole(['error'], async (spies) => {
             const promise = fetch(joinURL(baseURL, '/users'), {
               method,
@@ -421,13 +443,9 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
       });
     });
 
-    it(`should support intercepting ${method} requests having non-exact body form data restrictions`, async () => {
-      type FormDataSchema = HttpSchema.FormData<{
-        tag?: File;
-      }>;
-
+    it(`should support intercepting ${method} requests having partial, non-exact body form data restrictions`, async () => {
       type MethodSchemaWithBody = HttpSchema.Method<{
-        request: { body: HttpFormData<FormDataSchema> };
+        request: { body: HttpFormData<RequestFormDataSchema> };
         response: { 200: {} };
       }>;
 
@@ -439,7 +457,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
           DELETE: MethodSchemaWithBody;
         };
       }>(interceptorOptions, async (interceptor) => {
-        const restrictedFormData = new HttpFormData<FormDataSchema>();
+        const restrictedFormData = new HttpFormData<RequestFormDataSchema>();
         const tagFile = new File(['content'], 'tag.txt', { type: 'text/plain' });
         restrictedFormData.append('tag', tagFile);
 
@@ -449,8 +467,12 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
               body: restrictedFormData,
               exact: false,
             })
+            .with({
+              body: new HttpFormData<Partial<RequestFormDataSchema>>(),
+              exact: false,
+            })
             .respond((request) => {
-              expectTypeOf(request.body).toEqualTypeOf<HttpFormData<FormDataSchema>>();
+              expectTypeOf(request.body).toEqualTypeOf<HttpFormData<RequestFormDataSchema>>();
               expect(request.body.has('tag')).toBe(true);
 
               return { status: 200 };
@@ -473,7 +495,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
 
         const differentTagFile = new File(['other'], 'tag.txt', { type: 'text/plain' });
 
-        const extendedFormData = new HttpFormData<FormDataSchema>();
+        const extendedFormData = new HttpFormData<RequestFormDataSchema>();
         extendedFormData.append('tag', tagFile);
         extendedFormData.append('tag', differentTagFile);
 
@@ -486,10 +508,10 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
         requests = await promiseIfRemote(handler.requests(), interceptor);
         expect(requests).toHaveLength(2);
 
-        const differentFormData = new HttpFormData<FormDataSchema>();
+        const differentFormData = new HttpFormData<RequestFormDataSchema>();
         differentFormData.append('tag', differentTagFile);
 
-        for (const body of [differentFormData, new HttpFormData<FormDataSchema>(), undefined]) {
+        for (const body of [differentFormData, new HttpFormData<RequestFormDataSchema>(), undefined]) {
           await usingIgnoredConsole(['error'], async (spies) => {
             const promise = fetch(joinURL(baseURL, '/users'), {
               method,
@@ -511,9 +533,9 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
       });
     });
 
-    it(`should support intercepting ${method} requests having exact body search params restrictions`, async () => {
+    it(`should support intercepting ${method} requests having partial, exact body search params restrictions`, async () => {
       type SearchParamsSchema = HttpSchema.SearchParams<{
-        tag?: string;
+        tag: string;
         other?: string;
       }>;
 
@@ -578,9 +600,9 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
       });
     });
 
-    it(`should support intercepting ${method} requests having non-exact body search params restrictions`, async () => {
+    it(`should support intercepting ${method} requests having partial, non-exact body search params restrictions`, async () => {
       type SearchParamsSchema = HttpSchema.SearchParams<{
-        tag?: string;
+        tag: string;
         other?: string;
       }>;
 
@@ -603,6 +625,10 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
           interceptor[lowerMethod]('/users')
             .with({
               body: restrictedSearchParams,
+              exact: false,
+            })
+            .with({
+              body: new HttpSearchParams<Partial<SearchParamsSchema>>(),
               exact: false,
             })
             .respond((request) => {

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/restrictions.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/restrictions.ts
@@ -36,12 +36,15 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
   });
 
   type UserRequestHeaders = HttpSchema.Headers<{
-    'content-language'?: string;
-    accept?: string;
+    'content-language': string;
+    accept: string;
+    optional?: string;
   }>;
 
   type UserSearchParams = HttpSchema.SearchParams<{
-    tag?: string;
+    tag: string;
+    other: string;
+    optional?: string;
   }>;
 
   type MethodSchema = HttpSchema.Method<{
@@ -185,7 +188,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
         let requests = await promiseIfRemote(handler.requests(), interceptor);
         expect(requests).toHaveLength(0);
 
-        const searchParams = new HttpSearchParams<UserSearchParams>({ tag: 'admin' });
+        const searchParams = new HttpSearchParams<UserSearchParams>({ tag: 'admin', other: 'value' });
 
         const response = await fetch(joinURL(baseURL, `/users?${searchParams.toString()}`), {
           method,

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/unhandledRequests.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/unhandledRequests.ts
@@ -39,7 +39,6 @@ export function declareUnhandledRequestHttpInterceptorTests(options: RuntimeShar
       type,
     });
 
-    // TODO: handler.with() restriction types are not performing well when combining many interceptor types and http methods
     const lowerMethod = method.toLowerCase<'POST'>();
 
     type MethodSchemaWithoutRequestBody = HttpSchema.Method<{

--- a/packages/zimic/src/interceptor/http/interceptorWorker/HttpInterceptorWorker.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/HttpInterceptorWorker.ts
@@ -198,7 +198,6 @@ abstract class HttpInterceptorWorker {
       declaration.body instanceof FormData ||
       declaration.body instanceof URLSearchParams ||
       declaration.body instanceof Blob ||
-      declaration.body instanceof ReadableStream ||
       declaration.body instanceof ArrayBuffer
     ) {
       return new Response(declaration.body ?? null, { headers, status });

--- a/packages/zimic/src/interceptor/http/interceptorWorker/LocalHttpInterceptorWorker.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/LocalHttpInterceptorWorker.ts
@@ -1,12 +1,6 @@
-import {
-  HttpHandler as MSWHttpHandler,
-  SharedOptions as MSWWorkerSharedOptions,
-  StrictRequest as MSWStrictRequest,
-  http,
-  passthrough,
-} from 'msw';
+import { HttpHandler as MSWHttpHandler, SharedOptions as MSWWorkerSharedOptions, http, passthrough } from 'msw';
 
-import { HttpBody } from '@/http/types/requests';
+import { HttpRequest } from '@/http/types/requests';
 import { HttpMethod, HttpServiceSchema } from '@/http/types/schema';
 import { excludeNonPathParams, ensureUniquePathParams, createURL } from '@/utils/urls';
 
@@ -153,7 +147,7 @@ class LocalHttpInterceptorWorker extends HttpInterceptorWorker {
     ensureUniquePathParams(url);
 
     const httpHandler = http[lowercaseMethod](url, async (context) => {
-      const request = context.request as MSWStrictRequest<HttpBody>;
+      const request = context.request as HttpRequest;
       const requestClone = request.clone();
 
       try {

--- a/packages/zimic/src/interceptor/http/requestHandler/HttpRequestHandlerClient.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/HttpRequestHandlerClient.ts
@@ -25,6 +25,8 @@ import {
   HttpInterceptorResponse,
   HttpRequestHandlerResponseDeclaration,
   HttpRequestHandlerResponseDeclarationFactory,
+  HttpRequestHeadersSchema,
+  HttpRequestSearchParamsSchema,
   TrackedHttpInterceptorRequest,
 } from './types/requests';
 
@@ -138,7 +140,9 @@ class HttpRequestHandlerClient<
       return true;
     }
 
-    const restrictedHeaders = new HttpHeaders(restriction.headers);
+    const restrictedHeaders = new HttpHeaders(
+      restriction.headers as HttpRequestHeadersSchema<Default<Schema[Path][Method]>>,
+    );
     return restriction.exact ? request.headers.equals(restrictedHeaders) : request.headers.contains(restrictedHeaders);
   }
 
@@ -150,7 +154,9 @@ class HttpRequestHandlerClient<
       return true;
     }
 
-    const restrictedSearchParams = new HttpSearchParams(restriction.searchParams);
+    const restrictedSearchParams = new HttpSearchParams(
+      restriction.searchParams as HttpRequestSearchParamsSchema<Default<Schema[Path][Method]>>,
+    );
     return restriction.exact
       ? request.searchParams.equals(restrictedSearchParams)
       : request.searchParams.contains(restrictedSearchParams);

--- a/packages/zimic/src/interceptor/http/requestHandler/__tests__/shared/default.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/__tests__/shared/default.ts
@@ -327,17 +327,20 @@ export function declareDefaultHttpRequestHandlerTests(
     expect(interceptedRequests[0].raw.headers).toEqual(request.headers);
     expectTypeOf(interceptedRequests[0].raw.json).toEqualTypeOf<() => Promise<MethodSchema['request']['body']>>();
     expect(await interceptedRequests[0].raw.json()).toEqual<MethodSchema['request']['body']>({ name: 'User' });
+    expectTypeOf(interceptedRequests[0].raw.formData).toEqualTypeOf<() => Promise<FormData>>();
 
     expect(interceptedRequests[0].response).toEqual(parsedResponse);
 
     expectTypeOf(interceptedRequests[0].response.raw).toEqualTypeOf<HttpResponse<{ success: true }, 200>>();
     expect(interceptedRequests[0].response.raw).toBeInstanceOf(Response);
+    expectTypeOf(interceptedRequests[0].response.raw.status).toEqualTypeOf<200>();
     expect(interceptedRequests[0].response.raw.status).toBe(200);
     expect(interceptedRequests[0].response.raw.headers).toEqual(response.headers);
     expectTypeOf(interceptedRequests[0].response.raw.json).toEqualTypeOf<() => Promise<{ success: true }>>();
     expect(await interceptedRequests[0].response.raw.json()).toEqual<MethodSchema['response'][200]['body']>({
       success: true,
     });
+    expectTypeOf(interceptedRequests[0].response.raw.formData).toEqualTypeOf<() => Promise<FormData>>();
   });
 
   it('should provide no access to hidden properties in raw intercepted requests and responses', async () => {

--- a/packages/zimic/src/interceptor/http/requestHandler/types/public.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/types/public.ts
@@ -22,7 +22,7 @@ import {
   TrackedHttpInterceptorRequest,
 } from './requests';
 
-type HttpHeadersOrPartialSchema<Schema extends HttpHeadersSchema> =
+type PartialHttpHeadersOrSchema<Schema extends HttpHeadersSchema> =
   | Partial<Schema>
   | HttpHeaders<Partial<Schema>>
   | HttpHeaders<Schema>;
@@ -36,9 +36,9 @@ export type HttpRequestHandlerHeadersStaticRestriction<
   Schema extends HttpServiceSchema,
   Path extends HttpServiceSchemaPath<Schema, Method>,
   Method extends HttpServiceSchemaMethod<Schema>,
-> = HttpHeadersOrPartialSchema<HttpRequestHeadersSchema<Default<Schema[Path][Method]>>>;
+> = PartialHttpHeadersOrSchema<HttpRequestHeadersSchema<Default<Schema[Path][Method]>>>;
 
-type HttpSearchParamsOrPartialSchema<Schema extends HttpSearchParamsSchema> =
+type PartialHttpSearchParamsOrSchema<Schema extends HttpSearchParamsSchema> =
   | Partial<Schema>
   | HttpSearchParams<Partial<Schema>>
   | HttpSearchParams<Schema>;
@@ -52,9 +52,9 @@ export type HttpRequestHandlerSearchParamsStaticRestriction<
   Schema extends HttpServiceSchema,
   Path extends HttpServiceSchemaPath<Schema, Method>,
   Method extends HttpServiceSchemaMethod<Schema>,
-> = HttpSearchParamsOrPartialSchema<HttpRequestSearchParamsSchema<Default<Schema[Path][Method]>>>;
+> = PartialHttpSearchParamsOrSchema<HttpRequestSearchParamsSchema<Default<Schema[Path][Method]>>>;
 
-type BodyOrPartialSchema<Body extends HttpBody> =
+type PartialBodyOrSchema<Body extends HttpBody> =
   Body extends HttpFormData<infer Schema>
     ? HttpFormData<Partial<Schema>> | HttpFormData<Schema>
     : Body extends HttpSearchParams<infer Schema>
@@ -72,7 +72,7 @@ export type HttpRequestHandlerBodyStaticRestriction<
   Schema extends HttpServiceSchema,
   Path extends HttpServiceSchemaPath<Schema, Method>,
   Method extends HttpServiceSchemaMethod<Schema>,
-> = BodyOrPartialSchema<Default<HttpRequestBodySchema<Default<Schema[Path][Method]>>, null>>;
+> = PartialBodyOrSchema<HttpRequestBodySchema<Default<Schema[Path][Method]>>>;
 
 /**
  * A static restriction to match intercepted requests.

--- a/packages/zimic/src/interceptor/http/requestHandler/types/public.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/types/public.ts
@@ -13,16 +13,19 @@ import {
 import { DeepPartial, Default, PossiblePromise } from '@/types/utils';
 
 import {
-  HttpRequestHeadersSchema,
   HttpInterceptorRequest,
+  HttpRequestBodySchema,
   HttpRequestHandlerResponseDeclaration,
   HttpRequestHandlerResponseDeclarationFactory,
+  HttpRequestHeadersSchema,
   HttpRequestSearchParamsSchema,
   TrackedHttpInterceptorRequest,
-  HttpRequestBodySchema,
 } from './requests';
 
-type HttpHeadersOrPartialSchema<Schema extends HttpHeadersSchema> = Partial<Schema> | HttpHeaders<Schema>;
+type HttpHeadersOrPartialSchema<Schema extends HttpHeadersSchema> =
+  | Partial<Schema>
+  | HttpHeaders<Partial<Schema>>
+  | HttpHeaders<Schema>;
 
 /**
  * A static headers restriction to match intercepted requests.
@@ -37,6 +40,7 @@ export type HttpRequestHandlerHeadersStaticRestriction<
 
 type HttpSearchParamsOrPartialSchema<Schema extends HttpSearchParamsSchema> =
   | Partial<Schema>
+  | HttpSearchParams<Partial<Schema>>
   | HttpSearchParams<Schema>;
 
 /**
@@ -50,12 +54,14 @@ export type HttpRequestHandlerSearchParamsStaticRestriction<
   Method extends HttpServiceSchemaMethod<Schema>,
 > = HttpSearchParamsOrPartialSchema<HttpRequestSearchParamsSchema<Default<Schema[Path][Method]>>>;
 
-type BodyOrPartialSchema<Body extends HttpBody> = Body extends
-  | HttpFormData<infer _HttpFormDataSchema>
-  | HttpSearchParams<infer _HttpSearchParamsSchema>
-  | Blob
-  ? Body
-  : DeepPartial<Body>;
+type BodyOrPartialSchema<Body extends HttpBody> =
+  Body extends HttpFormData<infer Schema>
+    ? HttpFormData<Partial<Schema>> | HttpFormData<Schema>
+    : Body extends HttpSearchParams<infer Schema>
+      ? HttpSearchParams<Partial<Schema>> | HttpSearchParams<Schema>
+      : Body extends Blob
+        ? Body
+        : DeepPartial<Body>;
 
 /**
  * A static body restriction to match intercepted requests.

--- a/packages/zimic/src/interceptor/http/requestHandler/types/public.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/types/public.ts
@@ -1,12 +1,16 @@
+import HttpFormData from '@/http/formData/HttpFormData';
 import HttpHeaders from '@/http/headers/HttpHeaders';
+import { HttpHeadersSchema } from '@/http/headers/types';
 import HttpSearchParams from '@/http/searchParams/HttpSearchParams';
+import { HttpSearchParamsSchema } from '@/http/searchParams/types';
+import { HttpBody } from '@/http/types/requests';
 import {
   HttpServiceResponseSchemaStatusCode,
   HttpServiceSchema,
   HttpServiceSchemaMethod,
   HttpServiceSchemaPath,
 } from '@/http/types/schema';
-import { Default, PossiblePromise } from '@/types/utils';
+import { DeepPartial, Default, PossiblePromise } from '@/types/utils';
 
 import {
   HttpRequestHeadersSchema,
@@ -18,6 +22,8 @@ import {
   HttpRequestBodySchema,
 } from './requests';
 
+type HttpHeadersOrPartialSchema<Schema extends HttpHeadersSchema> = Partial<Schema> | HttpHeaders<Schema>;
+
 /**
  * A static headers restriction to match intercepted requests.
  *
@@ -27,9 +33,11 @@ export type HttpRequestHandlerHeadersStaticRestriction<
   Schema extends HttpServiceSchema,
   Path extends HttpServiceSchemaPath<Schema, Method>,
   Method extends HttpServiceSchemaMethod<Schema>,
-> =
-  | Default<HttpRequestHeadersSchema<Default<Schema[Path][Method]>>>
-  | HttpHeaders<Default<HttpRequestHeadersSchema<Default<Schema[Path][Method]>>>>;
+> = HttpHeadersOrPartialSchema<HttpRequestHeadersSchema<Default<Schema[Path][Method]>>>;
+
+type HttpSearchParamsOrPartialSchema<Schema extends HttpSearchParamsSchema> =
+  | Partial<Schema>
+  | HttpSearchParams<Schema>;
 
 /**
  * A static search params restriction to match intercepted requests.
@@ -40,9 +48,14 @@ export type HttpRequestHandlerSearchParamsStaticRestriction<
   Schema extends HttpServiceSchema,
   Path extends HttpServiceSchemaPath<Schema, Method>,
   Method extends HttpServiceSchemaMethod<Schema>,
-> =
-  | Default<HttpRequestSearchParamsSchema<Default<Schema[Path][Method]>>>
-  | HttpSearchParams<Default<HttpRequestSearchParamsSchema<Default<Schema[Path][Method]>>>>;
+> = HttpSearchParamsOrPartialSchema<HttpRequestSearchParamsSchema<Default<Schema[Path][Method]>>>;
+
+type BodyOrPartialSchema<Body extends HttpBody> = Body extends
+  | HttpFormData<infer _HttpFormDataSchema>
+  | HttpSearchParams<infer _HttpSearchParamsSchema>
+  | Blob
+  ? Body
+  : DeepPartial<Body>;
 
 /**
  * A static body restriction to match intercepted requests.
@@ -53,7 +66,7 @@ export type HttpRequestHandlerBodyStaticRestriction<
   Schema extends HttpServiceSchema,
   Path extends HttpServiceSchemaPath<Schema, Method>,
   Method extends HttpServiceSchemaMethod<Schema>,
-> = Default<HttpRequestBodySchema<Default<Schema[Path][Method]>>, null>;
+> = BodyOrPartialSchema<Default<HttpRequestBodySchema<Default<Schema[Path][Method]>>, null>>;
 
 /**
  * A static restriction to match intercepted requests.

--- a/packages/zimic/src/interceptor/http/requestHandler/types/requests.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/types/requests.ts
@@ -42,19 +42,19 @@ export type HttpRequestHandlerResponseDeclarationFactory<
 ) => PossiblePromise<HttpRequestHandlerResponseDeclaration<MethodSchema, StatusCode>>;
 
 export type HttpRequestHeadersSchema<MethodSchema extends HttpServiceMethodSchema> = IfNever<
-  Default<DefaultNoExclude<Default<MethodSchema['request'], { headers: {} }>['headers'], {}>>,
+  Default<DefaultNoExclude<Default<MethodSchema['request']>['headers']>>,
   {}
 >;
 
 export type HttpRequestSearchParamsSchema<MethodSchema extends HttpServiceMethodSchema> = IfNever<
-  Default<DefaultNoExclude<Default<MethodSchema['request'], { searchParams: {} }>['searchParams'], {}>>,
+  Default<DefaultNoExclude<Default<MethodSchema['request']>['searchParams']>>,
   {}
 >;
 
 export type HttpRequestBodySchema<MethodSchema extends HttpServiceMethodSchema> = ReplaceBy<
-  DefaultNoExclude<Default<MethodSchema['request'], { body: null }>['body'], null>,
-  undefined,
-  null
+  ReplaceBy<IfNever<DefaultNoExclude<Default<MethodSchema['request']>['body']>, null>, undefined, null>,
+  ArrayBuffer,
+  Blob
 >;
 
 /**
@@ -70,7 +70,7 @@ export interface HttpInterceptorRequest<Path extends string, MethodSchema extend
   /** The search parameters of the request. */
   searchParams: HttpSearchParams<HttpRequestSearchParamsSchema<MethodSchema>>;
   /** The body of the request. It is already parsed by default. */
-  body: ReplaceBy<HttpRequestBodySchema<MethodSchema>, ArrayBuffer | ReadableStream, Blob>;
+  body: ReplaceBy<HttpRequestBodySchema<MethodSchema>, ArrayBuffer, Blob>;
   /** The raw request object. */
   raw: HttpRequest<HttpRequestBodySchema<MethodSchema>>;
 }
@@ -83,7 +83,11 @@ export type HttpResponseHeadersSchema<
 export type HttpResponseBodySchema<
   MethodSchema extends HttpServiceMethodSchema,
   StatusCode extends HttpServiceResponseSchemaStatusCode<Default<MethodSchema['response']>>,
-> = ReplaceBy<DefaultNoExclude<Default<MethodSchema['response']>[StatusCode]['body'], null>, undefined, null>;
+> = ReplaceBy<
+  ReplaceBy<DefaultNoExclude<Default<MethodSchema['response']>[StatusCode]['body'], null>, undefined, null>,
+  ArrayBuffer,
+  Blob
+>;
 
 /**
  * A strict representation of an intercepted HTTP response. The body, search params and path params are already parsed
@@ -98,7 +102,7 @@ export interface HttpInterceptorResponse<
   /** The status code of the response. */
   status: StatusCode;
   /** The body of the response. It is already parsed by default. */
-  body: ReplaceBy<HttpResponseBodySchema<MethodSchema, StatusCode>, ArrayBuffer | ReadableStream, Blob>;
+  body: HttpResponseBodySchema<MethodSchema, StatusCode>;
   /** The raw response object. */
   raw: HttpResponse<HttpResponseBodySchema<MethodSchema, StatusCode>, StatusCode>;
 }

--- a/packages/zimic/src/interceptor/http/requestHandler/types/requests.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/types/requests.ts
@@ -41,13 +41,13 @@ export type HttpRequestHandlerResponseDeclarationFactory<
   request: Omit<HttpInterceptorRequest<Path, MethodSchema>, 'response'>,
 ) => PossiblePromise<HttpRequestHandlerResponseDeclaration<MethodSchema, StatusCode>>;
 
-export type HttpRequestHeadersSchema<MethodSchema extends HttpServiceMethodSchema> = DefaultNoExclude<
-  Default<MethodSchema['request'], { headers: {} }>['headers'],
+export type HttpRequestHeadersSchema<MethodSchema extends HttpServiceMethodSchema> = IfNever<
+  Default<DefaultNoExclude<Default<MethodSchema['request'], { headers: {} }>['headers'], {}>>,
   {}
 >;
 
-export type HttpRequestSearchParamsSchema<MethodSchema extends HttpServiceMethodSchema> = DefaultNoExclude<
-  Default<MethodSchema['request'], { searchParams: {} }>['searchParams'],
+export type HttpRequestSearchParamsSchema<MethodSchema extends HttpServiceMethodSchema> = IfNever<
+  Default<DefaultNoExclude<Default<MethodSchema['request'], { searchParams: {} }>['searchParams'], {}>>,
   {}
 >;
 
@@ -64,13 +64,13 @@ export type HttpRequestBodySchema<MethodSchema extends HttpServiceMethodSchema> 
 export interface HttpInterceptorRequest<Path extends string, MethodSchema extends HttpServiceMethodSchema>
   extends Omit<HttpRequest, keyof Body | 'headers'> {
   /** The headers of the request. */
-  headers: HttpHeaders<IfNever<Default<HttpRequestHeadersSchema<MethodSchema>>, {}>>;
+  headers: HttpHeaders<HttpRequestHeadersSchema<MethodSchema>>;
   /** The path parameters of the request. They are parsed from the path string when using dynamic paths. */
   pathParams: PathParamsSchemaFromPath<Path>;
   /** The search parameters of the request. */
-  searchParams: HttpSearchParams<IfNever<Default<HttpRequestSearchParamsSchema<MethodSchema>>, {}>>;
+  searchParams: HttpSearchParams<HttpRequestSearchParamsSchema<MethodSchema>>;
   /** The body of the request. It is already parsed by default. */
-  body: HttpRequestBodySchema<MethodSchema>;
+  body: ReplaceBy<HttpRequestBodySchema<MethodSchema>, ArrayBuffer | ReadableStream, Blob>;
   /** The raw request object. */
   raw: HttpRequest<HttpRequestBodySchema<MethodSchema>>;
 }
@@ -98,7 +98,7 @@ export interface HttpInterceptorResponse<
   /** The status code of the response. */
   status: StatusCode;
   /** The body of the response. It is already parsed by default. */
-  body: HttpResponseBodySchema<MethodSchema, StatusCode>;
+  body: ReplaceBy<HttpResponseBodySchema<MethodSchema, StatusCode>, ArrayBuffer | ReadableStream, Blob>;
   /** The raw response object. */
   raw: HttpResponse<HttpResponseBodySchema<MethodSchema, StatusCode>, StatusCode>;
 }

--- a/packages/zimic/src/types/utils.ts
+++ b/packages/zimic/src/types/utils.ts
@@ -42,3 +42,12 @@ export type NonArrayKey<Type> =
 export type ReplaceBy<Type, Source, Target> = Type extends Source ? Target : Type;
 
 export type Collection<Type> = Type[] | Set<Type>;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type DeepPartial<Type> = Type extends (...parameters: any[]) => any
+  ? Type
+  : Type extends (infer ArrayItem)[]
+    ? DeepPartial<ArrayItem>[]
+    : Type extends object
+      ? { [Key in keyof Type]?: DeepPartial<Type[Key]> }
+      : Type;

--- a/packages/zimic/tests/utils/interceptors.ts
+++ b/packages/zimic/tests/utils/interceptors.ts
@@ -23,7 +23,7 @@ import {
 import InterceptorServer from '@/interceptor/server/InterceptorServer';
 import { PossiblePromise } from '@/types/utils';
 import { getCrypto } from '@/utils/crypto';
-import { joinURL, createURL, ExtendedURL } from '@/utils/urls';
+import { createURL, ExtendedURL, joinURL } from '@/utils/urls';
 import { GLOBAL_SETUP_SERVER_HOSTNAME, GLOBAL_SETUP_SERVER_PORT } from '@tests/setup/global/browser';
 
 export async function getBrowserBaseURL(workerType: HttpInterceptorType) {


### PR DESCRIPTION
### Fixes
- [#zimic] Updated the restriction types to allow partial matches. Previously, a static restriction would have the same type as the header, search params or body. However, the restriction matches are partial by default, so it should be possible to specify partial headers, search params and body restrictions.
- [#zimic] Fixed the types `StrictRequest` and `StrictResponse` to correctly type the methods `.json() and `.formData()`, considering if the typed body is a JSON value or a form data.
- [#zimic] Removed the type `ReadableStream` from `HttpBody`, no longer allowing request and response body schemas to have a readable stream as body type. This type was incorrect because `ReadableStream` objects are not supported. If you are working with streams, consider transforming them to an `ArrayBuffer` or `Blob`, since these are fully supported. 

### Tests
- [#zimic] Added more checks to verify the types used in raw requests and responses.
- [#zimic] Added more tests to verify `ArrayBuffer`'s can be used as request and response body types.

Closes #212.