### PR TITLE
fix(#zimic): computed responses with multiple status codes (#213)

### DIFF
--- a/packages/zimic/src/interceptor/http/requestHandler/__tests__/shared/default.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/__tests__/shared/default.ts
@@ -184,7 +184,7 @@ export function declareDefaultHttpRequestHandlerTests(
       body: responseBody,
     }));
 
-    const handler = new Handler<Schema, 'POST', '/users'>(interceptorClient, 'POST', '/users');
+    const handler = new Handler<Schema, 'POST', '/users', 200>(interceptorClient, 'POST', '/users');
     await promiseIfRemote(handler.respond(responseFactory), interceptor);
 
     const request = new Request(baseURL);

--- a/packages/zimic/src/interceptor/http/requestHandler/types/requests.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/types/requests.ts
@@ -22,10 +22,12 @@ export type HttpRequestHandlerResponseHeadersAttribute<ResponseSchema extends Ht
 export type HttpRequestHandlerResponseDeclaration<
   MethodSchema extends HttpServiceMethodSchema,
   StatusCode extends HttpServiceResponseSchemaStatusCode<Default<MethodSchema['response']>>,
-> = {
-  status: StatusCode;
-} & HttpRequestHandlerResponseBodyAttribute<Default<MethodSchema['response']>[StatusCode]> &
-  HttpRequestHandlerResponseHeadersAttribute<Default<MethodSchema['response']>[StatusCode]>;
+> = StatusCode extends StatusCode
+  ? {
+      status: StatusCode;
+    } & HttpRequestHandlerResponseBodyAttribute<Default<MethodSchema['response']>[StatusCode]> &
+      HttpRequestHandlerResponseHeadersAttribute<Default<MethodSchema['response']>[StatusCode]>
+  : never;
 
 /**
  * A factory to create {@link HttpRequestHandlerResponseDeclaration} objects.
@@ -78,13 +80,13 @@ export interface HttpInterceptorRequest<Path extends string, MethodSchema extend
 export type HttpResponseHeadersSchema<
   MethodSchema extends HttpServiceMethodSchema,
   StatusCode extends HttpServiceResponseSchemaStatusCode<Default<MethodSchema['response']>>,
-> = DefaultNoExclude<Default<MethodSchema['response']>[StatusCode]['headers']>;
+> = IfNever<Default<DefaultNoExclude<Default<MethodSchema['response']>[StatusCode]['headers']>>, {}>;
 
 export type HttpResponseBodySchema<
   MethodSchema extends HttpServiceMethodSchema,
   StatusCode extends HttpServiceResponseSchemaStatusCode<Default<MethodSchema['response']>>,
 > = ReplaceBy<
-  ReplaceBy<DefaultNoExclude<Default<MethodSchema['response']>[StatusCode]['body'], null>, undefined, null>,
+  ReplaceBy<IfNever<DefaultNoExclude<Default<MethodSchema['response']>[StatusCode]['body']>, null>, undefined, null>,
   ArrayBuffer,
   Blob
 >;
@@ -98,7 +100,7 @@ export interface HttpInterceptorResponse<
   StatusCode extends HttpServiceResponseSchemaStatusCode<Default<MethodSchema['response']>>,
 > extends Omit<HttpResponse, keyof Body | 'headers'> {
   /** The headers of the response. */
-  headers: HttpHeaders<Default<HttpResponseHeadersSchema<MethodSchema, StatusCode>>>;
+  headers: HttpHeaders<HttpResponseHeadersSchema<MethodSchema, StatusCode>>;
   /** The status code of the response. */
   status: StatusCode;
   /** The body of the response. It is already parsed by default. */


### PR DESCRIPTION
### Fixes
- [#zimic]  Fixed the type validation about computed response factories. Previously, the handlers would not validate that the body and headers are correct based on the status code, when an endpoint had more than one status code defined. This is now fixed.

Closes #213.