### PR TITLE
build(#zimic): build improvements

### DIFF
--- a/.github/actions/zimic-setup/action.yaml
+++ b/.github/actions/zimic-setup/action.yaml
@@ -22,10 +22,6 @@ inputs:
     description: Filter to build the dependencies of a specific app or package
     required: false
     default: './packages/*'
-  build-node-env:
-    description: NODE_ENV to use when building packages
-    required: false
-    default: 'development'
   install-playwright-browsers:
     description: Whether to install the browsers for Playwright
     required: false
@@ -100,7 +96,7 @@ runs:
         fi
 
         echo "build-filters=$buildFlag" >> $GITHUB_OUTPUT
-        NODE_ENV='${{ inputs.build-node-env }}' pnpm turbo build $buildFlag
+        pnpm turbo build $buildFlag
 
         # apply the build outputs of the internal packages
         pnpm install --offline $installFlag

--- a/.github/actions/zimic-setup/action.yaml
+++ b/.github/actions/zimic-setup/action.yaml
@@ -106,7 +106,7 @@ runs:
           pnpm --dir apps/zimic-test-client deps:install-playwright
         fi
       env:
-        NODE_VERSION: ${{ matrix.node-version }}
+        NODE_VERSION: ${{ inputs.node-version }}
         TURBO_TOKEN: ${{ inputs.turbo-token }}
         TURBO_TEAM: ${{ inputs.turbo-team }}
         TURBO_LOG_ORDER: stream

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ concurrency:
 
 env:
   CI: true
-  LTS_NODE_VERSION: 20
+  NODE_VERSION: 20
   IS_PULL_REQUEST_TO_MAIN:
     ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' && 'true' || 'false' }}
   TURBO_LOG_ORDER: stream
@@ -46,7 +46,7 @@ jobs:
         id: zimic-setup
         uses: ./.github/actions/zimic-setup
         with:
-          node-version: ${{ env.LTS_NODE_VERSION }}
+          node-version: ${{ env.NODE_VERSION }}
           turbo-token: ${{ env.TURBO_TOKEN }}
           turbo-team: ${{ env.TURBO_TEAM }}
           install: ${{ env.INSTALL_OPTIONS }}
@@ -57,7 +57,7 @@ jobs:
       - name: Check formatting style
         uses: ./.github/actions/zimic-style-check
         with:
-          node-version: ${{ env.LTS_NODE_VERSION }}
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Lint code and check types
         run: |
@@ -140,7 +140,7 @@ jobs:
         id: zimic-setup
         uses: ./.github/actions/zimic-setup
         with:
-          node-version: ${{ env.LTS_NODE_VERSION }}
+          node-version: ${{ env.NODE_VERSION }}
           turbo-token: ${{ env.TURBO_TOKEN }}
           turbo-team: ${{ env.TURBO_TEAM }}
           install: ${{ env.INSTALL_OPTIONS }}

--- a/.github/workflows/release-npm.yaml
+++ b/.github/workflows/release-npm.yaml
@@ -44,8 +44,6 @@ jobs:
 
       - name: Build zimic
         run: pnpm turbo build --filter zimic
-        env:
-          NODE_ENV: production
 
       - name: Prepare NPM tag
         id: npm-tag

--- a/apps/zimic-test-client/package.json
+++ b/apps/zimic-test-client/package.json
@@ -11,11 +11,9 @@
     "test": "dotenv -v NODE_ENV=test -- zimic server start --port 4000 --ephemeral -- vitest",
     "test:turbo": "pnpm run test run --coverage",
     "types:check": "tsc --noEmit",
-    "deps:prepare": "pnpm deps:build && pnpm deps:install",
-    "deps:build": "pnpm turbo build --filter zimic-test-client^...",
-    "deps:install": "pnpm install --filter zimic-test-client && pnpm deps:install-playwright && pnpm deps:init-zimic",
     "deps:install-playwright": "pnpm playwright install chromium",
-    "deps:init-zimic": "zimic browser init ./public"
+    "deps:init-zimic": "zimic browser init ./public",
+    "postinstall": "pnpm deps:install-playwright && pnpm deps:init-zimic || echo 'Could not postinstall.'"
   },
   "dependencies": {
     "zimic0": "workspace:zimic@*"

--- a/apps/zimic-test-client/tests/utils/crypto.ts
+++ b/apps/zimic-test-client/tests/utils/crypto.ts
@@ -1,6 +1,6 @@
 export type IsomorphicCrypto = Crypto | typeof import('crypto');
 
-export async function getCrypto(): Promise<IsomorphicCrypto> {
+export async function importCrypto(): Promise<IsomorphicCrypto> {
   const globalCrypto = globalThis.crypto as Crypto | undefined;
   /* istanbul ignore next -- @preserve
    * Ignoring as Node.js >=20 provides a global crypto and the import fallback won't run. */

--- a/apps/zimic-test-client/tests/utils/crypto.ts
+++ b/apps/zimic-test-client/tests/utils/crypto.ts
@@ -1,8 +1,15 @@
 export type IsomorphicCrypto = Crypto | typeof import('crypto');
 
+let cryptoSingleton: IsomorphicCrypto | undefined;
+
 export async function importCrypto(): Promise<IsomorphicCrypto> {
-  const globalCrypto = globalThis.crypto as Crypto | undefined;
+  if (cryptoSingleton) {
+    return cryptoSingleton;
+  }
+
+  const globalCrypto = globalThis.crypto as typeof globalThis.crypto | undefined;
   /* istanbul ignore next -- @preserve
    * Ignoring as Node.js >=20 provides a global crypto and the import fallback won't run. */
-  return globalCrypto ?? (await import('crypto'));
+  cryptoSingleton = globalCrypto ?? (await import('crypto'));
+  return cryptoSingleton;
 }

--- a/apps/zimic-test-client/tests/v0/interceptor/thirdParty/shared/default.ts
+++ b/apps/zimic-test-client/tests/v0/interceptor/thirdParty/shared/default.ts
@@ -2,7 +2,7 @@ import { beforeAll, beforeEach, afterAll, expect, describe, it, expectTypeOf } f
 import { HttpRequest, HttpResponse, HttpSearchParams, JSONSerialized } from 'zimic0';
 import { http, HttpInterceptorType } from 'zimic0/interceptor';
 
-import { getCrypto } from '@tests/utils/crypto';
+import { importCrypto } from '@tests/utils/crypto';
 
 import { ClientTestOptionsByWorkerType, ZIMIC_SERVER_PORT } from '.';
 import {
@@ -18,7 +18,7 @@ import {
 } from './schema';
 
 async function getAuthBaseURL(type: HttpInterceptorType) {
-  const crypto = await getCrypto();
+  const crypto = await importCrypto();
 
   return type === 'local'
     ? 'http://localhost:3000'
@@ -26,7 +26,7 @@ async function getAuthBaseURL(type: HttpInterceptorType) {
 }
 
 async function getNotificationsBaseURL(type: HttpInterceptorType) {
-  const crypto = await getCrypto();
+  const crypto = await importCrypto();
 
   return type === 'local'
     ? 'http://localhost:3001'
@@ -86,7 +86,7 @@ async function declareDefaultClientTests(options: ClientTestOptionsByWorkerType)
   }
 
   describe('Users', async () => {
-    const crypto = await getCrypto();
+    const crypto = await importCrypto();
 
     const user: User = {
       id: crypto.randomUUID(),
@@ -597,7 +597,7 @@ async function declareDefaultClientTests(options: ClientTestOptionsByWorkerType)
   });
 
   describe('Notifications', async () => {
-    const crypto = await getCrypto();
+    const crypto = await importCrypto();
 
     const notification: Notification = {
       id: crypto.randomUUID(),

--- a/apps/zimic-test-client/turbo.json
+++ b/apps/zimic-test-client/turbo.json
@@ -2,14 +2,8 @@
   "$schema": "https://turbo.build/schema.json",
   "extends": ["//"],
   "tasks": {
-    "deps:init-zimic": {
-      "dependsOn": ["^build"],
-      "inputs": ["package.json"],
-      "outputs": ["public/mockServiceWorker.js"]
-    },
-
     "test:turbo": {
-      "dependsOn": ["^build", "deps:init-zimic"],
+      "dependsOn": ["^build"],
       "inputs": ["{src,tests}/**/*.{ts,json}", "{package,tsconfig}.json", "vitest.config.mts"]
     },
 

--- a/examples/turbo.json
+++ b/examples/turbo.json
@@ -3,6 +3,7 @@
   "extends": ["//"],
   "tasks": {
     "lint:turbo": {
+      "dependsOn": ["^build", "zimic#build"],
       "inputs": [
         "with-*/{src,tests}/**/*.{ts,json}",
         "with-*/{package,tsconfig}.json",
@@ -10,10 +11,6 @@
         ".eslintrc.js",
         "../.prettierrc.json"
       ]
-    },
-
-    "types:check": {
-      "inputs": ["with-*/{src,tests}/**/*.{ts,json}", "with-*/{package,tsconfig}.json", "{package,tsconfig}.json"]
     }
   }
 }

--- a/examples/with-jest-jsdom/turbo.json
+++ b/examples/with-jest-jsdom/turbo.json
@@ -3,8 +3,12 @@
   "extends": ["//"],
   "tasks": {
     "test:turbo": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "zimic#build"],
       "inputs": ["{src,tests}/**/*.{ts,json}", "{package,tsconfig}.json", "jest.config.js"]
+    },
+
+    "types:check": {
+      "dependsOn": ["^build", "zimic#build"]
     }
   }
 }

--- a/examples/with-jest-node/turbo.json
+++ b/examples/with-jest-node/turbo.json
@@ -3,8 +3,12 @@
   "extends": ["//"],
   "tasks": {
     "test:turbo": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "zimic#build"],
       "inputs": ["{src,tests}/**/*.{ts,json}", "{package,tsconfig}.json", "jest.config.js"]
+    },
+
+    "types:check": {
+      "dependsOn": ["^build", "zimic#build"]
     }
   }
 }

--- a/examples/with-next-js-app/turbo.json
+++ b/examples/with-next-js-app/turbo.json
@@ -3,12 +3,16 @@
   "extends": ["//"],
   "tasks": {
     "test:turbo": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "zimic#build"],
       "inputs": [
         "{src,tests}/**/*.{ts,tsx,json}",
         "{package,tsconfig}.json",
         "{playwright,tailwind,postcss,next}.config.{ts,mts,js}"
       ]
+    },
+
+    "types:check": {
+      "dependsOn": ["^build", "zimic#build"]
     }
   }
 }

--- a/examples/with-next-js-app/turbo.json
+++ b/examples/with-next-js-app/turbo.json
@@ -8,8 +8,7 @@
         "{src,tests}/**/*.{ts,tsx,json}",
         "{package,tsconfig}.json",
         "{playwright,tailwind,postcss,next}.config.{ts,mts,js}"
-      ],
-      "outputs": ["tests/outputs", "tests/reports"]
+      ]
     }
   }
 }

--- a/examples/with-next-js-pages/README.md
+++ b/examples/with-next-js-pages/README.md
@@ -16,6 +16,10 @@ The application is a simple [Next.js](https://nextjs.org) project using the
 The file [`_app.page.tsx`](./src/pages/_app.page.tsx) loads the interceptors and mocks before the rest of the
 application is rendered in development.
 
+A `postinstall` script in [`package.json`](./package.json) is used to install Playwright's browsers and initialize
+Zimic's mock service worker to the `./public` directory. The mock service worker at `./public/mockServiceWorker.js` is
+ignored in the [`.gitignore`](./.gitignore) file.
+
 ## Testing
 
 An example test suite uses [Playwright](https://playwright.dev) to test the application. Zimic is used to mock the

--- a/examples/with-next-js-pages/package.json
+++ b/examples/with-next-js-pages/package.json
@@ -8,7 +8,8 @@
     "test:turbo": "pnpm run test",
     "types:check": "tsc --noEmit",
     "deps:install-playwright": "pnpm playwright install chromium",
-    "postinstall": "pnpm deps:install-playwright && zimic browser init ./public || echo 'Could not postinstall.'"
+    "deps:init-zimic": "zimic browser init ./public",
+    "postinstall": "pnpm deps:install-playwright && pnpm deps:init-zimic || echo 'Could not postinstall.'"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.40.0",

--- a/examples/with-next-js-pages/turbo.json
+++ b/examples/with-next-js-pages/turbo.json
@@ -3,12 +3,16 @@
   "extends": ["//"],
   "tasks": {
     "test:turbo": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "zimic#build"],
       "inputs": [
         "{src,tests}/**/*.{ts,tsx,json}",
         "{package,tsconfig}.json",
         "{playwright,tailwind,postcss,next}.config.{ts,mts,js}"
       ]
+    },
+
+    "types:check": {
+      "dependsOn": ["^build", "zimic#build"]
     }
   }
 }

--- a/examples/with-next-js-pages/turbo.json
+++ b/examples/with-next-js-pages/turbo.json
@@ -8,8 +8,7 @@
         "{src,tests}/**/*.{ts,tsx,json}",
         "{package,tsconfig}.json",
         "{playwright,tailwind,postcss,next}.config.{ts,mts,js}"
-      ],
-      "outputs": ["tests/outputs", "tests/reports"]
+      ]
     }
   }
 }

--- a/examples/with-playwright/turbo.json
+++ b/examples/with-playwright/turbo.json
@@ -3,12 +3,16 @@
   "extends": ["//"],
   "tasks": {
     "test:turbo": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "zimic#build"],
       "inputs": [
         "{src,tests}/**/*.{ts,tsx,json}",
         "{package,tsconfig}.json",
         "{playwright,tailwind,postcss,next}.config.{ts,mts,js}"
       ]
+    },
+
+    "types:check": {
+      "dependsOn": ["^build", "zimic#build"]
     }
   }
 }

--- a/examples/with-playwright/turbo.json
+++ b/examples/with-playwright/turbo.json
@@ -8,8 +8,7 @@
         "{src,tests}/**/*.{ts,tsx,json}",
         "{package,tsconfig}.json",
         "{playwright,tailwind,postcss,next}.config.{ts,mts,js}"
-      ],
-      "outputs": ["tests/outputs", "tests/reports"]
+      ]
     }
   }
 }

--- a/examples/with-vitest-browser/turbo.json
+++ b/examples/with-vitest-browser/turbo.json
@@ -3,14 +3,18 @@
   "extends": ["//"],
   "tasks": {
     "deps:init-zimic": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "zimic#build"],
       "inputs": ["package.json"],
       "outputs": ["public/mockServiceWorker.js"]
     },
 
     "test:turbo": {
-      "dependsOn": ["^build", "deps:init-zimic"],
+      "dependsOn": ["^build", "zimic#build", "deps:init-zimic"],
       "inputs": ["{src,tests}/**/*.{ts,json}", "{package,tsconfig}.json", "vitest.config.mts"]
+    },
+
+    "types:check": {
+      "dependsOn": ["^build", "zimic#build"]
     }
   }
 }

--- a/examples/with-vitest-browser/turbo.json
+++ b/examples/with-vitest-browser/turbo.json
@@ -2,14 +2,8 @@
   "$schema": "https://turbo.build/schema.json",
   "extends": ["//"],
   "tasks": {
-    "deps:init-zimic": {
-      "dependsOn": ["^build", "zimic#build"],
-      "inputs": ["package.json"],
-      "outputs": ["public/mockServiceWorker.js"]
-    },
-
     "test:turbo": {
-      "dependsOn": ["^build", "zimic#build", "deps:init-zimic"],
+      "dependsOn": ["^build", "zimic#build"],
       "inputs": ["{src,tests}/**/*.{ts,json}", "{package,tsconfig}.json", "vitest.config.mts"]
     },
 

--- a/examples/with-vitest-jsdom/turbo.json
+++ b/examples/with-vitest-jsdom/turbo.json
@@ -3,8 +3,12 @@
   "extends": ["//"],
   "tasks": {
     "test:turbo": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "zimic#build"],
       "inputs": ["{src,tests}/**/*.{ts,json}", "{package,tsconfig}.json", "vitest.config.mts"]
+    },
+
+    "types:check": {
+      "dependsOn": ["^build", "zimic#build"]
     }
   }
 }

--- a/examples/with-vitest-node/turbo.json
+++ b/examples/with-vitest-node/turbo.json
@@ -3,8 +3,12 @@
   "extends": ["//"],
   "tasks": {
     "test:turbo": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "zimic#build"],
       "inputs": ["{src,tests}/**/*.{ts,json}", "{package,tsconfig}.json", "vitest.config.mts"]
+    },
+
+    "types:check": {
+      "dependsOn": ["^build", "zimic#build"]
     }
   }
 }

--- a/packages/release/package.json
+++ b/packages/release/package.json
@@ -24,10 +24,7 @@
     "style:format": "pnpm style --write",
     "test": "dotenv -v NODE_ENV=test -- vitest",
     "test:turbo": "pnpm run test run --coverage",
-    "types:check": "tsc --noEmit",
-    "deps:prepare": "pnpm deps:build && pnpm deps:install",
-    "deps:build": "pnpm turbo build --filter @zimic/release^...",
-    "deps:install": "pnpm install --filter @zimic/release"
+    "types:check": "tsc --noEmit"
   },
   "dependencies": {
     "fs-extra": "^11.2.0",

--- a/packages/release/tsup.config.ts
+++ b/packages/release/tsup.config.ts
@@ -1,20 +1,32 @@
-import { defineConfig } from 'tsup';
+import { Options, defineConfig } from 'tsup';
 
-const NODE_ENV = process.env.NODE_ENV ?? 'development';
-const isProduction = NODE_ENV === 'production';
-
-export default defineConfig({
-  entry: {
-    index: 'src/index.ts',
-    cli: 'src/cli/entry.ts',
-  },
-  env: {
-    NODE_ENV,
-  },
-  format: ['cjs'],
+const sharedConfig: Options = {
+  format: ['cjs', 'esm'],
   dts: true,
-  sourcemap: !isProduction,
-  treeshake: isProduction,
-  minify: isProduction,
+  bundle: true,
+  sourcemap: true,
+  treeshake: true,
+  minify: false,
   clean: true,
-});
+};
+
+export default defineConfig([
+  {
+    ...sharedConfig,
+    name: 'node',
+    platform: 'node',
+    entry: {
+      index: 'src/index.ts',
+    },
+  },
+  {
+    ...sharedConfig,
+    name: 'cli',
+    platform: 'node',
+    format: ['cjs'],
+    dts: false,
+    entry: {
+      cli: 'src/cli/entry.ts',
+    },
+  },
+]);

--- a/packages/zimic/package.json
+++ b/packages/zimic/package.json
@@ -72,14 +72,11 @@
     "test": "dotenv -v NODE_ENV=test -- vitest",
     "test:turbo": "pnpm run test run --coverage",
     "types:check": "tsc --noEmit",
-    "deps:prepare": "pnpm deps:build && pnpm deps:install",
-    "deps:build": "pnpm turbo build --filter zimic^...",
-    "deps:install": "pnpm install --filter zimic && pnpm deps:install-playwright && pnpm deps:init-msw",
     "deps:install-playwright": "pnpm playwright install chromium",
     "deps:init-msw": "msw init ./public --no-save",
     "postinstall": "node -e \"try{require('./dist/scripts/postinstall.js')}catch(error){console.error(error)}\"",
-    "prepublish:adapt-relative-paths": "sed -E -i 's/\\]\\(\\.\\/([^\\)]+)\\)/](..\\/..\\/\\1)/g;s/\"\\.\\/([^\"]+)\"/\"..\\/..\\/\\1\"/g'",
-    "prepublishOnly": "cp ../../README.md ../../LICENSE.md . && pnpm prepublish:adapt-relative-paths README.md"
+    "prepublish:patch-relative-paths": "sed -E -i 's/\\]\\(\\.\\/([^\\)]+)\\)/](..\\/..\\/\\1)/g;s/\"\\.\\/([^\"]+)\"/\"..\\/..\\/\\1\"/g'",
+    "prepublishOnly": "cp ../../README.md ../../LICENSE.md . && pnpm prepublish:patch-relative-paths README.md"
   },
   "dependencies": {
     "@whatwg-node/server": "^0.9.34",

--- a/packages/zimic/package.json
+++ b/packages/zimic/package.json
@@ -62,8 +62,7 @@
   "scripts": {
     "dev": "pnpm build --watch",
     "cli": "node ./dist/cli.js",
-    "build": "pnpm build:clear && tsup",
-    "build:clear": "rimraf ./dist",
+    "build": "tsup",
     "lint": "eslint --ext 'ts,tsx' --cache --no-error-on-unmatched-pattern --fix",
     "lint:turbo": "pnpm lint . --max-warnings 0",
     "style": "prettier --log-level warn --ignore-unknown --no-error-on-unmatched-pattern --cache",
@@ -99,7 +98,6 @@
     "@zimic/tsconfig": "workspace:*",
     "dotenv-cli": "^7.4.2",
     "playwright": "^1.44.1",
-    "rimraf": "^5.0.7",
     "tsup": "^8.1.0",
     "typescript": "^5.4.5",
     "vitest": "1.6.0"

--- a/packages/zimic/package.json
+++ b/packages/zimic/package.json
@@ -62,7 +62,8 @@
   "scripts": {
     "dev": "pnpm build --watch",
     "cli": "node ./dist/cli.js",
-    "build": "tsup",
+    "build": "pnpm build:clear && tsup",
+    "build:clear": "rimraf ./dist",
     "lint": "eslint --ext 'ts,tsx' --cache --no-error-on-unmatched-pattern --fix",
     "lint:turbo": "pnpm lint . --max-warnings 0",
     "style": "prettier --log-level warn --ignore-unknown --no-error-on-unmatched-pattern --cache",
@@ -101,6 +102,7 @@
     "@zimic/tsconfig": "workspace:*",
     "dotenv-cli": "^7.4.2",
     "playwright": "^1.44.1",
+    "rimraf": "^5.0.7",
     "tsup": "^8.1.0",
     "typescript": "^5.4.5",
     "vitest": "1.6.0"

--- a/packages/zimic/src/cli/__tests__/server.cli.node.test.ts
+++ b/packages/zimic/src/cli/__tests__/server.cli.node.test.ts
@@ -17,7 +17,7 @@ import { usingIgnoredConsole } from '@tests/utils/console';
 import { expectFetchError } from '@tests/utils/fetch';
 
 import runCLI from '../cli';
-import { singletonServer as server } from '../server/start';
+import { serverSingleton as server } from '../server/start';
 import { delayHttpServerCloseIndefinitely, delayHttpServerListenIndefinitely } from './utils';
 
 function watchExitEventListeners(exitEvent: (typeof PROCESS_EXIT_EVENTS)[number]) {

--- a/packages/zimic/src/cli/__tests__/server.cli.node.test.ts
+++ b/packages/zimic/src/cli/__tests__/server.cli.node.test.ts
@@ -8,7 +8,7 @@ import { verifyUnhandledRequestMessage } from '@/interceptor/http/interceptor/__
 import { createHttpInterceptor } from '@/interceptor/http/interceptor/factory';
 import { DEFAULT_SERVER_LIFE_CYCLE_TIMEOUT } from '@/interceptor/server/constants';
 import { PossiblePromise } from '@/types/utils';
-import { getCrypto } from '@/utils/crypto';
+import { importCrypto } from '@/utils/crypto';
 import { HttpServerStartTimeoutError, HttpServerStopTimeoutError } from '@/utils/http';
 import { CommandError, PROCESS_EXIT_EVENTS } from '@/utils/processes';
 import WebSocketClient from '@/webSocket/WebSocketClient';
@@ -34,7 +34,7 @@ function watchExitEventListeners(exitEvent: (typeof PROCESS_EXIT_EVENTS)[number]
 }
 
 describe('CLI (server)', async () => {
-  const crypto = await getCrypto();
+  const crypto = await importCrypto();
 
   const processArgvSpy = vi.spyOn(process, 'argv', 'get');
   const processOnSpy = vi.spyOn(process, 'on');

--- a/packages/zimic/src/cli/server/start.ts
+++ b/packages/zimic/src/cli/server/start.ts
@@ -12,7 +12,7 @@ interface InterceptorServerStartOptions extends InterceptorServerOptions {
   };
 }
 
-export let singletonServer: InterceptorServer | undefined;
+export let serverSingleton: InterceptorServer | undefined;
 
 async function startInterceptorServer({
   hostname,
@@ -27,7 +27,7 @@ async function startInterceptorServer({
     onUnhandledRequest,
   });
 
-  singletonServer = server;
+  serverSingleton = server;
 
   await server.start();
 

--- a/packages/zimic/src/http/formData/__tests__/HttpFormData.test.ts
+++ b/packages/zimic/src/http/formData/__tests__/HttpFormData.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
 
-import { getFile } from '@/utils/files';
+import { importFile } from '@/utils/files';
 
 import HttpFormData from '../HttpFormData';
 
 describe('HttpFormData', async () => {
-  const File = await getFile();
+  const File = await importFile();
 
   const file = new File(['content'], 'file.txt', { type: 'text/plain' });
 

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/bodies.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/bodies.ts
@@ -10,8 +10,8 @@ import { promiseIfRemote } from '@/interceptor/http/interceptorWorker/__tests__/
 import LocalHttpRequestHandler from '@/interceptor/http/requestHandler/LocalHttpRequestHandler';
 import RemoteHttpRequestHandler from '@/interceptor/http/requestHandler/RemoteHttpRequestHandler';
 import { JSONValue } from '@/types/json';
-import { getCrypto } from '@/utils/crypto';
-import { getFile } from '@/utils/files';
+import { importCrypto } from '@/utils/crypto';
+import { importFile } from '@/utils/files';
 import { randomInt } from '@/utils/numbers';
 import { joinURL } from '@/utils/urls';
 import { usingIgnoredConsole } from '@tests/utils/console';
@@ -30,7 +30,7 @@ export async function createRandomFile(
     | 'application/octet-stream'
     | 'multipart/mixed',
 ): Promise<File> {
-  const File = await getFile();
+  const File = await importFile();
 
   const randomContent = Uint8Array.from({ length: 1024 }, () => randomInt(0, 256));
 
@@ -52,7 +52,7 @@ export async function createRandomFile(
 export async function declareBodyHttpInterceptorTests(options: RuntimeSharedHttpInterceptorTestsOptions) {
   const { getBaseURL, getInterceptorOptions } = options;
 
-  const crypto = await getCrypto();
+  const crypto = await importCrypto();
 
   type User = JSONValue<{
     id: string;
@@ -775,7 +775,7 @@ export async function declareBodyHttpInterceptorTests(options: RuntimeSharedHttp
             DELETE: MethodSchema;
           };
         }>(interceptorOptions, async (interceptor) => {
-          const File = await getFile();
+          const File = await importFile();
 
           const responseFormData = new HttpFormData<UserFormDataSchema>();
           const responseTagFile = new File(['response'], 'tag.txt', { type: 'text/plain' });

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/dynamicPaths.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/dynamicPaths.ts
@@ -6,7 +6,7 @@ import LocalHttpRequestHandler from '@/interceptor/http/requestHandler/LocalHttp
 import RemoteHttpRequestHandler from '@/interceptor/http/requestHandler/RemoteHttpRequestHandler';
 import { AccessControlHeaders, DEFAULT_ACCESS_CONTROL_HEADERS } from '@/interceptor/server/constants';
 import { JSONValue } from '@/types/json';
-import { getCrypto } from '@/utils/crypto';
+import { importCrypto } from '@/utils/crypto';
 import { joinURL } from '@/utils/urls';
 import { expectFetchErrorOrPreflightResponse } from '@tests/utils/fetch';
 import { assessPreflightInterference, usingHttpInterceptor } from '@tests/utils/interceptors';
@@ -17,7 +17,7 @@ import { RuntimeSharedHttpInterceptorTestsOptions } from './types';
 export async function declareDynamicPathsHttpInterceptorTests(options: RuntimeSharedHttpInterceptorTestsOptions) {
   const { platform, type, getBaseURL, getInterceptorOptions } = options;
 
-  const crypto = await getCrypto();
+  const crypto = await importCrypto();
 
   type User = JSONValue<{
     id: string;

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/restrictions.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/restrictions.ts
@@ -10,7 +10,7 @@ import LocalHttpRequestHandler from '@/interceptor/http/requestHandler/LocalHttp
 import RemoteHttpRequestHandler from '@/interceptor/http/requestHandler/RemoteHttpRequestHandler';
 import { AccessControlHeaders, DEFAULT_ACCESS_CONTROL_HEADERS } from '@/interceptor/server/constants';
 import { JSONValue } from '@/types/json';
-import { getFile } from '@/utils/files';
+import { importFile } from '@/utils/files';
 import { joinURL } from '@/utils/urls';
 import { usingIgnoredConsole } from '@tests/utils/console';
 import { expectFetchError, expectFetchErrorOrPreflightResponse } from '@tests/utils/fetch';
@@ -22,7 +22,7 @@ import { RuntimeSharedHttpInterceptorTestsOptions } from './types';
 export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSharedHttpInterceptorTestsOptions) {
   const { platform, type, getBaseURL, getInterceptorOptions } = options;
 
-  const File = await getFile();
+  const File = await importFile();
 
   let baseURL: URL;
   let interceptorOptions: HttpInterceptorOptions;

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/utils.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/utils.ts
@@ -29,7 +29,7 @@ export async function verifyUnhandledRequestMessage(
     const headersLine = message.match(/Headers: (?<headers>[^\n]*)\n/)!;
     expect(headersLine).not.toBe(null);
 
-    const formattedHeaders = formatObjectToLog(Object.fromEntries(request.headers)) as string;
+    const formattedHeaders = (await formatObjectToLog(Object.fromEntries(request.headers))) as string;
     const formattedHeadersIgnoringWrapperBrackets = formattedHeaders.slice(1, -1);
 
     for (const headerKeyValuePair of formattedHeadersIgnoringWrapperBrackets.split(', ')) {
@@ -39,17 +39,19 @@ export async function verifyUnhandledRequestMessage(
 
   expect(message).toContain(
     platform === 'node'
-      ? `Search params: ${formatObjectToLog(Object.fromEntries(request.searchParams))}`
+      ? `Search params: ${await formatObjectToLog(Object.fromEntries(request.searchParams))}`
       : 'Search params: [object Object]',
   );
 
   const body: unknown = request.body;
 
   if (body === null) {
-    expect(message).toContain(platform === 'node' ? `Body: ${formatObjectToLog(body)}` : 'Body: ');
+    expect(message).toContain(platform === 'node' ? `Body: ${await formatObjectToLog(body)}` : 'Body: ');
   } else {
     expect(message).toContain(
-      platform === 'node' || typeof body !== 'object' ? `Body: ${formatObjectToLog(body)}` : 'Body: [object Object]',
+      platform === 'node' || typeof body !== 'object'
+        ? `Body: ${await formatObjectToLog(body)}`
+        : 'Body: [object Object]',
     );
   }
 }

--- a/packages/zimic/src/interceptor/http/interceptorWorker/HttpInterceptorWorker.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/HttpInterceptorWorker.ts
@@ -5,7 +5,7 @@ import InvalidJSONError from '@/http/errors/InvalidJSONError';
 import HttpFormData from '@/http/formData/HttpFormData';
 import HttpHeaders from '@/http/headers/HttpHeaders';
 import { HttpHeadersInit, HttpHeadersSchema } from '@/http/headers/types';
-import { HttpResponse, HttpRequest, HttpBody } from '@/http/types/requests';
+import { HttpBody, HttpRequest, HttpResponse } from '@/http/types/requests';
 import {
   HttpMethod,
   HttpServiceMethodSchema,
@@ -427,11 +427,11 @@ abstract class HttpInterceptorWorker {
           `${action === 'bypass' ? chalk.yellow('bypassed') : chalk.red('rejected')}.\n\n `,
         `${request.method} ${request.url}`,
         '\n    Headers:',
-        formatObjectToLog(Object.fromEntries(request.headers)),
+        await formatObjectToLog(Object.fromEntries(request.headers)),
         '\n    Search params:',
-        formatObjectToLog(Object.fromEntries(request.searchParams)),
+        await formatObjectToLog(Object.fromEntries(request.searchParams)),
         '\n    Body:',
-        formatObjectToLog(request.body),
+        await formatObjectToLog(request.body),
         '\n\nLearn more about unhandled requests: https://github.com/zimicjs/zimic#unhandled-requests',
       ],
       { method: action === 'bypass' ? 'warn' : 'error' },

--- a/packages/zimic/src/interceptor/http/interceptorWorker/LocalHttpInterceptorWorker.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/LocalHttpInterceptorWorker.ts
@@ -2,7 +2,8 @@ import { HttpHandler as MSWHttpHandler, SharedOptions as MSWWorkerSharedOptions,
 
 import { HttpRequest } from '@/http/types/requests';
 import { HttpMethod, HttpServiceSchema } from '@/http/types/schema';
-import { excludeNonPathParams, ensureUniquePathParams, createURL } from '@/utils/urls';
+import { getMSWBrowser, getMSWNode } from '@/utils/msw';
+import { createURL, ensureUniquePathParams, excludeNonPathParams } from '@/utils/urls';
 
 import NotStartedHttpInterceptorError from '../interceptor/errors/NotStartedHttpInterceptorError';
 import UnknownHttpInterceptorPlatformError from '../interceptor/errors/UnknownHttpInterceptorPlatformError';
@@ -42,12 +43,12 @@ class LocalHttpInterceptorWorker extends HttpInterceptorWorker {
   }
 
   private async createInternalWorker() {
-    const { setupServer } = await import('msw/node');
+    const { setupServer } = await getMSWNode();
     if (typeof setupServer !== 'undefined') {
       return setupServer();
     }
 
-    const { setupWorker } = await import('msw/browser');
+    const { setupWorker } = await getMSWBrowser();
     /* istanbul ignore else -- @preserve */
     if (typeof setupWorker !== 'undefined') {
       return setupWorker();

--- a/packages/zimic/src/interceptor/http/interceptorWorker/LocalHttpInterceptorWorker.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/LocalHttpInterceptorWorker.ts
@@ -2,7 +2,7 @@ import { HttpHandler as MSWHttpHandler, SharedOptions as MSWWorkerSharedOptions,
 
 import { HttpRequest } from '@/http/types/requests';
 import { HttpMethod, HttpServiceSchema } from '@/http/types/schema';
-import { getMSWBrowser, getMSWNode } from '@/utils/msw';
+import { importMSWBrowser, importMSWNode } from '@/utils/msw';
 import { createURL, ensureUniquePathParams, excludeNonPathParams } from '@/utils/urls';
 
 import NotStartedHttpInterceptorError from '../interceptor/errors/NotStartedHttpInterceptorError';
@@ -43,12 +43,12 @@ class LocalHttpInterceptorWorker extends HttpInterceptorWorker {
   }
 
   private async createInternalWorker() {
-    const { setupServer } = await getMSWNode();
+    const { setupServer } = await importMSWNode();
     if (typeof setupServer !== 'undefined') {
       return setupServer();
     }
 
-    const { setupWorker } = await getMSWBrowser();
+    const { setupWorker } = await importMSWBrowser();
     /* istanbul ignore else -- @preserve */
     if (typeof setupWorker !== 'undefined') {
       return setupWorker();

--- a/packages/zimic/src/interceptor/http/interceptorWorker/RemoteHttpInterceptorWorker.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/RemoteHttpInterceptorWorker.ts
@@ -3,7 +3,8 @@ import { HttpMethod, HttpServiceSchema } from '@/http/types/schema';
 import { HttpHandlerCommit, InterceptorServerWebSocketSchema } from '@/interceptor/server/types/schema';
 import { getCrypto, IsomorphicCrypto } from '@/utils/crypto';
 import { deserializeRequest, serializeResponse } from '@/utils/fetch';
-import { excludeNonPathParams, ExtendedURL, ensureUniquePathParams, createURL } from '@/utils/urls';
+import { getMSWBrowser, getMSWNode } from '@/utils/msw';
+import { createURL, ensureUniquePathParams, excludeNonPathParams, ExtendedURL } from '@/utils/urls';
 import { WebSocket } from '@/webSocket/types';
 import WebSocketClient from '@/webSocket/WebSocketClient';
 
@@ -91,12 +92,12 @@ class RemoteHttpInterceptorWorker extends HttpInterceptorWorker {
   };
 
   private async readPlatform(): Promise<HttpInterceptorPlatform> {
-    const { setupServer } = await import('msw/node');
+    const { setupServer } = await getMSWNode();
     if (typeof setupServer !== 'undefined') {
       return 'node';
     }
 
-    const { setupWorker } = await import('msw/browser');
+    const { setupWorker } = await getMSWBrowser();
     /* istanbul ignore else -- @preserve */
     if (typeof setupWorker !== 'undefined') {
       return 'browser';

--- a/packages/zimic/src/interceptor/http/interceptorWorker/RemoteHttpInterceptorWorker.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/RemoteHttpInterceptorWorker.ts
@@ -1,9 +1,9 @@
 import { HttpResponse } from '@/http/types/requests';
 import { HttpMethod, HttpServiceSchema } from '@/http/types/schema';
 import { HttpHandlerCommit, InterceptorServerWebSocketSchema } from '@/interceptor/server/types/schema';
-import { getCrypto, IsomorphicCrypto } from '@/utils/crypto';
+import { importCrypto, IsomorphicCrypto } from '@/utils/crypto';
 import { deserializeRequest, serializeResponse } from '@/utils/fetch';
-import { getMSWBrowser, getMSWNode } from '@/utils/msw';
+import { importMSWBrowser, importMSWNode } from '@/utils/msw';
 import { createURL, ensureUniquePathParams, excludeNonPathParams, ExtendedURL } from '@/utils/urls';
 import { WebSocket } from '@/webSocket/types';
 import WebSocketClient from '@/webSocket/WebSocketClient';
@@ -50,7 +50,7 @@ class RemoteHttpInterceptorWorker extends HttpInterceptorWorker {
 
   private async crypto() {
     if (!this._crypto) {
-      this._crypto = await getCrypto();
+      this._crypto = await importCrypto();
     }
     return this._crypto;
   }
@@ -92,12 +92,12 @@ class RemoteHttpInterceptorWorker extends HttpInterceptorWorker {
   };
 
   private async readPlatform(): Promise<HttpInterceptorPlatform> {
-    const { setupServer } = await getMSWNode();
+    const { setupServer } = await importMSWNode();
     if (typeof setupServer !== 'undefined') {
       return 'node';
     }
 
-    const { setupWorker } = await getMSWBrowser();
+    const { setupWorker } = await importMSWBrowser();
     /* istanbul ignore else -- @preserve */
     if (typeof setupWorker !== 'undefined') {
       return 'browser';

--- a/packages/zimic/src/utils/console.ts
+++ b/packages/zimic/src/utils/console.ts
@@ -1,12 +1,23 @@
 import chalk from 'chalk';
-import util from 'util';
 
 import { isClientSide } from './environment';
 
-export function formatObjectToLog(value: unknown) {
+let utilSingleton: typeof import('util') | undefined;
+
+async function getUtil() {
+  if (!utilSingleton) {
+    utilSingleton = await import('util');
+  }
+  return utilSingleton;
+}
+
+export async function formatObjectToLog(value: unknown) {
   if (isClientSide()) {
     return value;
   }
+
+  const util = await getUtil();
+
   return util.inspect(value, {
     colors: true,
     compact: true,

--- a/packages/zimic/src/utils/console.ts
+++ b/packages/zimic/src/utils/console.ts
@@ -4,7 +4,7 @@ import { isClientSide } from './environment';
 
 let utilSingleton: typeof import('util') | undefined;
 
-async function getUtil() {
+async function importUtil() {
   if (!utilSingleton) {
     utilSingleton = await import('util');
   }
@@ -16,7 +16,7 @@ export async function formatObjectToLog(value: unknown) {
     return value;
   }
 
-  const util = await getUtil();
+  const util = await importUtil();
 
   return util.inspect(value, {
     colors: true,

--- a/packages/zimic/src/utils/crypto.ts
+++ b/packages/zimic/src/utils/crypto.ts
@@ -1,8 +1,15 @@
 export type IsomorphicCrypto = Crypto | typeof import('crypto');
 
+let cryptoSingleton: IsomorphicCrypto | undefined;
+
 export async function getCrypto(): Promise<IsomorphicCrypto> {
-  const globalCrypto = globalThis.crypto as Crypto | undefined;
+  if (cryptoSingleton) {
+    return cryptoSingleton;
+  }
+
+  const globalCrypto = globalThis.crypto as typeof globalThis.crypto | undefined;
   /* istanbul ignore next -- @preserve
    * Ignoring as Node.js >=20 provides a global crypto and the import fallback won't run. */
-  return globalCrypto ?? (await import('crypto'));
+  cryptoSingleton = globalCrypto ?? (await import('crypto'));
+  return cryptoSingleton;
 }

--- a/packages/zimic/src/utils/crypto.ts
+++ b/packages/zimic/src/utils/crypto.ts
@@ -2,7 +2,7 @@ export type IsomorphicCrypto = Crypto | typeof import('crypto');
 
 let cryptoSingleton: IsomorphicCrypto | undefined;
 
-export async function getCrypto(): Promise<IsomorphicCrypto> {
+export async function importCrypto(): Promise<IsomorphicCrypto> {
   if (cryptoSingleton) {
     return cryptoSingleton;
   }

--- a/packages/zimic/src/utils/files.ts
+++ b/packages/zimic/src/utils/files.ts
@@ -1,10 +1,27 @@
 import { blobEquals } from './data';
 
+let bufferSingleton: typeof import('buffer') | undefined;
+
+export async function getBuffer() {
+  if (bufferSingleton) {
+    return bufferSingleton;
+  }
+  bufferSingleton = await import('buffer');
+  return bufferSingleton;
+}
+
+let FileSingleton: typeof File | undefined;
+
 export async function getFile() {
+  if (FileSingleton) {
+    return FileSingleton;
+  }
+
   /* istanbul ignore next -- @preserve
    * Ignoring as Node.js >=20 provides a global file and the import fallback won't run. */
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-  return globalThis.File ?? (await import('buffer')).File;
+  FileSingleton = globalThis.File ?? (await getBuffer()).File;
+  return FileSingleton;
 }
 
 export async function fileEquals(file: File, otherFile: File) {

--- a/packages/zimic/src/utils/files.ts
+++ b/packages/zimic/src/utils/files.ts
@@ -2,6 +2,8 @@ import { blobEquals } from './data';
 
 let bufferSingleton: typeof import('buffer') | undefined;
 
+/* istanbul ignore next -- @preserve
+ * Ignoring as Node.js >=20 provides a global file and the buffer import won't run. */
 export async function getBuffer() {
   if (bufferSingleton) {
     return bufferSingleton;

--- a/packages/zimic/src/utils/files.ts
+++ b/packages/zimic/src/utils/files.ts
@@ -4,7 +4,7 @@ let bufferSingleton: typeof import('buffer') | undefined;
 
 /* istanbul ignore next -- @preserve
  * Ignoring as Node.js >=20 provides a global file and the buffer import won't run. */
-export async function getBuffer() {
+export async function importBuffer() {
   if (bufferSingleton) {
     return bufferSingleton;
   }
@@ -14,7 +14,7 @@ export async function getBuffer() {
 
 let FileSingleton: typeof File | undefined;
 
-export async function getFile() {
+export async function importFile() {
   if (FileSingleton) {
     return FileSingleton;
   }
@@ -22,7 +22,7 @@ export async function getFile() {
   /* istanbul ignore next -- @preserve
    * Ignoring as Node.js >=20 provides a global file and the import fallback won't run. */
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-  FileSingleton = globalThis.File ?? (await getBuffer()).File;
+  FileSingleton = globalThis.File ?? (await importBuffer()).File;
   return FileSingleton;
 }
 

--- a/packages/zimic/src/utils/msw.ts
+++ b/packages/zimic/src/utils/msw.ts
@@ -1,19 +1,20 @@
-let mswNodeSingleton: typeof import('msw/node') | undefined;
+const mswSingleton: {
+  node?: typeof import('msw/node');
+  browser?: typeof import('msw/browser');
+} = {};
 
-export async function getMSWNode() {
-  if (mswNodeSingleton) {
-    return mswNodeSingleton;
+export async function importMSWNode() {
+  if (mswSingleton.node) {
+    return mswSingleton.node;
   }
-  mswNodeSingleton = await import('msw/node');
-  return mswNodeSingleton;
+  mswSingleton.node = await import('msw/node');
+  return mswSingleton.node;
 }
 
-let mswBrowserSingleton: typeof import('msw/browser') | undefined;
-
-export async function getMSWBrowser() {
-  if (mswBrowserSingleton) {
-    return mswBrowserSingleton;
+export async function importMSWBrowser() {
+  if (mswSingleton.browser) {
+    return mswSingleton.browser;
   }
-  mswBrowserSingleton = await import('msw/browser');
-  return mswBrowserSingleton;
+  mswSingleton.browser = await import('msw/browser');
+  return mswSingleton.browser;
 }

--- a/packages/zimic/src/utils/msw.ts
+++ b/packages/zimic/src/utils/msw.ts
@@ -1,0 +1,19 @@
+let mswNodeSingleton: typeof import('msw/node') | undefined;
+
+export async function getMSWNode() {
+  if (mswNodeSingleton) {
+    return mswNodeSingleton;
+  }
+  mswNodeSingleton = await import('msw/node');
+  return mswNodeSingleton;
+}
+
+let mswBrowserSingleton: typeof import('msw/browser') | undefined;
+
+export async function getMSWBrowser() {
+  if (mswBrowserSingleton) {
+    return mswBrowserSingleton;
+  }
+  mswBrowserSingleton = await import('msw/browser');
+  return mswBrowserSingleton;
+}

--- a/packages/zimic/src/webSocket/WebSocketHandler.ts
+++ b/packages/zimic/src/webSocket/WebSocketHandler.ts
@@ -1,7 +1,7 @@
 import ClientSocket from 'isomorphic-ws';
 
 import { Collection } from '@/types/utils';
-import { IsomorphicCrypto, getCrypto } from '@/utils/crypto';
+import { IsomorphicCrypto, importCrypto } from '@/utils/crypto';
 import { isClientSide } from '@/utils/environment';
 import {
   DEFAULT_WEB_SOCKET_LIFECYCLE_TIMEOUT,
@@ -38,7 +38,7 @@ abstract class WebSocketHandler<Schema extends WebSocket.ServiceSchema> {
 
   private async crypto() {
     if (!this._crypto) {
-      this._crypto = await getCrypto();
+      this._crypto = await importCrypto();
     }
     return this._crypto;
   }

--- a/packages/zimic/src/webSocket/__tests__/WebSocketClient.node.test.ts
+++ b/packages/zimic/src/webSocket/__tests__/WebSocketClient.node.test.ts
@@ -3,7 +3,7 @@ import ClientSocket from 'isomorphic-ws';
 import { AddressInfo } from 'net';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { getCrypto } from '@/utils/crypto';
+import { importCrypto } from '@/utils/crypto';
 import { startHttpServer, stopHttpServer } from '@/utils/http';
 import {
   closeServerSocket,
@@ -23,7 +23,7 @@ import { delayClientSocketClose, delayClientSocketOpen, delayClientSocketSend } 
 const { WebSocketServer: ServerSocket } = ClientSocket;
 
 describe('Web socket client', async () => {
-  const crypto = await getCrypto();
+  const crypto = await importCrypto();
 
   const httpServer = createServer();
   let port: number;

--- a/packages/zimic/src/webSocket/__tests__/WebSocketServer.node.test.ts
+++ b/packages/zimic/src/webSocket/__tests__/WebSocketServer.node.test.ts
@@ -3,7 +3,7 @@ import ClientSocket from 'isomorphic-ws';
 import { AddressInfo } from 'net';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { getCrypto } from '@/utils/crypto';
+import { importCrypto } from '@/utils/crypto';
 import { startHttpServer, stopHttpServer } from '@/utils/http';
 import {
   closeClientSocket,
@@ -28,7 +28,7 @@ import {
 } from './utils';
 
 describe('Web socket server', async () => {
-  const crypto = await getCrypto();
+  const crypto = await importCrypto();
 
   const httpServer = createServer();
   let port: number;

--- a/packages/zimic/tests/utils/interceptors.ts
+++ b/packages/zimic/tests/utils/interceptors.ts
@@ -22,7 +22,7 @@ import {
 } from '@/interceptor/http/interceptorWorker/types/options';
 import InterceptorServer from '@/interceptor/server/InterceptorServer';
 import { PossiblePromise } from '@/types/utils';
-import { getCrypto } from '@/utils/crypto';
+import { importCrypto } from '@/utils/crypto';
 import { createURL, ExtendedURL, joinURL } from '@/utils/urls';
 import { GLOBAL_SETUP_SERVER_HOSTNAME, GLOBAL_SETUP_SERVER_PORT } from '@tests/setup/global/browser';
 
@@ -31,7 +31,7 @@ export async function getBrowserBaseURL(workerType: HttpInterceptorType) {
     return createURL('http://localhost:3000');
   }
 
-  const crypto = await getCrypto();
+  const crypto = await importCrypto();
   const pathPrefix = `path-${crypto.randomUUID()}`;
   const baseURL = joinURL(`http://${GLOBAL_SETUP_SERVER_HOSTNAME}:${GLOBAL_SETUP_SERVER_PORT}`, pathPrefix);
   return createURL(baseURL);
@@ -46,7 +46,7 @@ export async function getNodeBaseURL(type: HttpInterceptorType, server: Intercep
   const port = server.port()!;
   expect(port).not.toBe(null);
 
-  const crypto = await getCrypto();
+  const crypto = await importCrypto();
   const pathPrefix = `path-${crypto.randomUUID()}`;
   const baseURL = joinURL(`http://${hostname}:${port}`, pathPrefix);
   return createURL(baseURL);

--- a/packages/zimic/tsup.config.ts
+++ b/packages/zimic/tsup.config.ts
@@ -7,7 +7,7 @@ const sharedConfig: Options = {
   sourcemap: true,
   treeshake: true,
   minify: false,
-  clean: true,
+  clean: false,
   env: {
     SERVER_ACCESS_CONTROL_MAX_AGE: '',
   },

--- a/packages/zimic/tsup.config.ts
+++ b/packages/zimic/tsup.config.ts
@@ -1,16 +1,13 @@
 import { Options, defineConfig } from 'tsup';
 
-const NODE_ENV = process.env.NODE_ENV ?? 'development';
-const isProductionBuild = NODE_ENV === 'production';
-
 const sharedConfig: Options = {
   format: ['cjs', 'esm'],
   dts: true,
   bundle: true,
   sourcemap: true,
-  treeshake: isProductionBuild,
+  treeshake: true,
   minify: false,
-  clean: false,
+  clean: true,
   env: {
     SERVER_ACCESS_CONTROL_MAX_AGE: '',
   },
@@ -19,13 +16,17 @@ const sharedConfig: Options = {
 export default defineConfig([
   {
     ...sharedConfig,
+    name: 'neutral',
+    platform: 'neutral',
     entry: {
       index: 'src/index.ts',
       interceptor: 'src/interceptor/index.ts',
     },
+    external: ['util', 'buffer', 'crypto'],
   },
   {
     ...sharedConfig,
+    name: 'node',
     platform: 'node',
     entry: {
       server: 'src/interceptor/server/index.ts',
@@ -33,12 +34,13 @@ export default defineConfig([
   },
   {
     ...sharedConfig,
+    name: 'cli',
     platform: 'node',
+    format: ['cjs'],
+    dts: false,
     entry: {
       cli: 'src/cli/index.ts',
       'scripts/postinstall': 'scripts/postinstall.ts',
     },
-    format: ['cjs'],
-    dts: false,
   },
 ]);

--- a/packages/zimic/tsup.config.ts
+++ b/packages/zimic/tsup.config.ts
@@ -7,7 +7,7 @@ const sharedConfig: Options = {
   sourcemap: true,
   treeshake: true,
   minify: false,
-  clean: false,
+  clean: true,
   env: {
     SERVER_ACCESS_CONTROL_MAX_AGE: '',
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -543,6 +543,9 @@ importers:
       playwright:
         specifier: ^1.44.1
         version: 1.44.1
+      rimraf:
+        specifier: ^5.0.7
+        version: 5.0.7
       tsup:
         specifier: ^8.1.0
         version: 8.1.0(@swc/core@1.5.25)(postcss@8.4.38)(typescript@5.4.5)
@@ -4146,6 +4149,11 @@ packages:
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
+
+  rimraf@5.0.7:
+    resolution: {integrity: sha512-nV6YcJo5wbLW77m+8KjH8aB/7/rxQy9SZ0HY5shnwULfS+9nmTtVXAJET5NdZmCzA4fPI/Hm1wo/Po/4mopOdg==}
+    engines: {node: '>=14.18'}
     hasBin: true
 
   rollup@4.18.0:
@@ -8932,6 +8940,10 @@ snapshots:
   rimraf@3.0.2:
     dependencies:
       glob: 7.2.3
+
+  rimraf@5.0.7:
+    dependencies:
+      glob: 10.4.1
 
   rollup@4.18.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -543,9 +543,6 @@ importers:
       playwright:
         specifier: ^1.44.1
         version: 1.44.1
-      rimraf:
-        specifier: ^5.0.7
-        version: 5.0.7
       tsup:
         specifier: ^8.1.0
         version: 8.1.0(@swc/core@1.5.25)(postcss@8.4.38)(typescript@5.4.5)
@@ -4149,11 +4146,6 @@ packages:
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     deprecated: Rimraf versions prior to v4 are no longer supported
-    hasBin: true
-
-  rimraf@5.0.7:
-    resolution: {integrity: sha512-nV6YcJo5wbLW77m+8KjH8aB/7/rxQy9SZ0HY5shnwULfS+9nmTtVXAJET5NdZmCzA4fPI/Hm1wo/Po/4mopOdg==}
-    engines: {node: '>=14.18'}
     hasBin: true
 
   rollup@4.18.0:
@@ -8940,10 +8932,6 @@ snapshots:
   rimraf@3.0.2:
     dependencies:
       glob: 7.2.3
-
-  rimraf@5.0.7:
-    dependencies:
-      glob: 10.4.1
 
   rollup@4.18.0:
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "ui": "stream",
-  "globalEnv": ["NODE_ENV", "NODE_VERSION", "TYPESCRIPT_VERSION"],
+  "globalEnv": ["NODE_VERSION", "TYPESCRIPT_VERSION"],
   "tasks": {
     "dev": {
       "cache": false,


### PR DESCRIPTION
### Performance
- [examples] Removed e2e test outputs and reports from turbo cache outputs.
- [#zimic] Saved dynamic imports to singletons.

### Refactoring
- Removed `NODE_ENV` as a global dependency because it is not necessary.
- [#zimic] Improved the `tsup` build settings.