### PR TITLE
perf(ci): cache improvements

### DIFF
--- a/.github/actions/zimic-setup/action.yaml
+++ b/.github/actions/zimic-setup/action.yaml
@@ -57,9 +57,9 @@ runs:
       uses: actions/cache@v4
       with:
         path: ${{ steps.pnpm-store.outputs.path }}
-        key: ${{ runner.os }}-node-${{ inputs.node-version }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
         restore-keys: |
-          ${{ runner.os }}-node-${{ inputs.node-version }}-pnpm-store-
+          ${{ runner.os }}-pnpm-store-
 
     - name: Install dependencies
       id: install-dependencies
@@ -116,4 +116,4 @@ runs:
       if: ${{ steps.pnpm-cache.outputs.cache-hit != 'true' }}
       with:
         path: ${{ steps.pnpm-store.outputs.path }}
-        key: ${{ runner.os }}-node-${{ inputs.node-version }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/.github/actions/zimic-style-check/action.yaml
+++ b/.github/actions/zimic-style-check/action.yaml
@@ -1,11 +1,6 @@
 name: Check zimic formatting style
 description: Check zimic formatting style
 
-inputs:
-  node-version:
-    description: Node.js version to use
-    required: true
-
 runs:
   using: composite
   steps:
@@ -14,7 +9,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: node_modules/.cache/prettier
-        key: ${{ runner.os }}-node-${{ inputs.node-version }}-prettier-${{ github.sha }}
+        key: ${{ runner.os }}-prettier-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-prettier
 
@@ -27,4 +22,4 @@ runs:
       uses: actions/cache/save@v4
       with:
         path: node_modules/.cache/prettier
-        key: ${{ runner.os }}-node-${{ inputs.node-version }}-prettier-${{ github.sha }}
+        key: ${{ runner.os }}-prettier-${{ github.sha }}

--- a/.github/workflows/cache.yaml
+++ b/.github/workflows/cache.yaml
@@ -11,9 +11,9 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  TURBO_LOG_ORDER: stream
   TURBO_TOKEN: ${{ secrets.TURBO_REMOTE_CACHE_TOKEN }}
   TURBO_TEAM: ${{ secrets.TURBO_REMOTE_CACHE_TEAM }}
+  TURBO_LOG_ORDER: stream
 
 jobs:
   cache-canary:
@@ -21,15 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
-    strategy:
-      matrix:
-        node-version:
-          - 18
-          - 20
-          - 22
-
     env:
-      NODE_VERSION: ${{ matrix.node-version }}
+      NODE_VERSION: 20
 
     steps:
       - name: Checkout code
@@ -38,11 +31,9 @@ jobs:
       - name: Set up Zimic
         uses: ./.github/actions/zimic-setup
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ env.NODE_VERSION }}
           turbo-token: ${{ env.TURBO_TOKEN }}
           turbo-team: ${{ env.TURBO_TEAM }}
 
       - name: Check formatting style and save prettier cache
         uses: ./.github/actions/zimic-style-check
-        with:
-          node-version: ${{ matrix.node-version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,15 +15,18 @@ concurrency:
 env:
   CI: true
   NODE_VERSION: 20
+
   IS_PULL_REQUEST_TO_MAIN:
     ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' && 'true' || 'false' }}
-  TURBO_LOG_ORDER: stream
+
   TURBO_TOKEN:
     ${{ !(github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main') &&
     secrets.TURBO_REMOTE_CACHE_TOKEN || '' }}
   TURBO_TEAM:
     ${{ !(github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main') &&
     secrets.TURBO_REMOTE_CACHE_TEAM || '' }}
+  TURBO_LOG_ORDER: stream
+
   INSTALL_OPTIONS:
     ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref != 'main' && '"...[HEAD^1]"' || '' }}
   BUILD_OPTIONS:
@@ -56,8 +59,6 @@ jobs:
 
       - name: Check formatting style
         uses: ./.github/actions/zimic-style-check
-        with:
-          node-version: ${{ env.NODE_VERSION }}
 
       - name: Lint code and check types
         run: |

--- a/.github/workflows/release-npm.yaml
+++ b/.github/workflows/release-npm.yaml
@@ -10,6 +10,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  NODE_VERSION: 20
+
   TURBO_TOKEN: ${{ secrets.TURBO_REMOTE_CACHE_TOKEN }}
   TURBO_TEAM: ${{ secrets.TURBO_REMOTE_CACHE_TEAM }}
   TURBO_LOG_ORDER: stream
@@ -33,7 +35,7 @@ jobs:
       - name: Set up Zimic
         uses: ./.github/actions/zimic-setup
         with:
-          node-version: 20
+          node-version: ${{ env.NODE_VERSION }}
           node-registry-url: https://registry.npmjs.org
           turbo-token: ${{ env.TURBO_TOKEN }}
           turbo-team: ${{ env.TURBO_TEAM }}

--- a/turbo.json
+++ b/turbo.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "ui": "stream",
-  "globalEnv": ["NODE_VERSION", "TYPESCRIPT_VERSION"],
+  "globalEnv": ["NODE_VERSION"],
   "tasks": {
     "dev": {
       "cache": false,
@@ -18,11 +18,13 @@
     },
 
     "lint:turbo": {
+      "env": ["TYPESCRIPT_VERSION"],
       "dependsOn": ["^build"],
       "outputs": [".eslintcache"]
     },
 
     "types:check": {
+      "env": ["TYPESCRIPT_VERSION"],
       "dependsOn": ["^build"],
       "outputs": ["tsconfig.tsbuildinfo"]
     }


### PR DESCRIPTION
### Performance
- [ci] Removed unnecessary references to `NODE_ENV` from cache keys.
- [ci] Moved `TYPESCRIPT_VERSION` from a global turbo env to only the commands `lint:turbo` and `types:check`.