### PR TITLE
feat(#zimic): opt-in request saving (#210)

### DIFF
--- a/README.md
+++ b/README.md
@@ -782,8 +782,8 @@ http.default.onUnhandledRequest((request, context) => {
 
 ##### Saving intercepted requests
 
-The option `saveRequests` represents whether [request handlers](#httprequesthandler) should save their intercepted
-requests and make them accessible through [`handler.requests()`](#http-handlerrequests).
+The option `saveRequests` indicates whether [request handlers](#httprequesthandler) should save their intercepted
+requests in memory and make them accessible through [`handler.requests()`](#http-handlerrequests).
 
 This setting is configured per interceptor and is `false` by default. If set to `true`, each handler will keep track of
 their intercepted requests in memory.
@@ -811,8 +811,8 @@ const interceptor = http.createInterceptor<Schema>({
 
 > [!TIP]
 >
-> If you use an interceptor both in tests and as a standalone mock server, consider setting `saveRequests` based on some
-> environment variable. This allows you to access the requests in tests while preventing memory leaks in long-running
+> If you use an interceptor both in tests and as a standalone mock server, consider setting `saveRequests` based on an
+> environment variable. This allows you to access the requests in tests, while preventing memory leaks in long-running
 > mock servers.
 
 ```ts
@@ -2499,8 +2499,8 @@ useful for testing that the correct requests were made by your application. Lear
 
 > [!IMPORTANT]
 >
-> The intercepted requests are only accessible through this method if `saveRequests` is set to `true` when creating the
-> interceptor. See [Saving intercepted requests](#saving-intercepted-requests) for more information.
+> This method can only be used if `saveRequests` was set to `true` when creating the interceptor. See
+> [Saving intercepted requests](#saving-intercepted-requests) for more information.
 
 <table><tr><td width="900px" valign="top"><details open><summary><b>Local</b></summary>
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Zimic provides a flexible and type-safe way to mock HTTP requests.
       - [Creating a local HTTP interceptor](#creating-a-local-http-interceptor)
       - [Creating a remote HTTP interceptor](#creating-a-remote-http-interceptor)
       - [Unhandled requests](#unhandled-requests)
+      - [Saving intercepted requests](#saving-intercepted-requests)
     - [Declaring HTTP service schemas](#declaring-http-service-schemas)
       - [Declaring HTTP paths](#declaring-http-paths)
       - [Declaring HTTP methods](#declaring-http-methods)
@@ -343,7 +344,7 @@ beforeAll(async () => {
 });
 
 // Clear all interceptors so that no tests affect each other
-beforeEach(() => {
+afterEach(() => {
   for (const interceptor of interceptors) {
     interceptor.clear();
   }
@@ -371,7 +372,7 @@ beforeAll(async () => {
 });
 
 // Clear all interceptors so that no tests affect each other
-beforeEach(async () => {
+afterEach(async () => {
   for (const interceptor of interceptors) {
     await interceptor.clear();
   }
@@ -778,6 +779,31 @@ http.default.onUnhandledRequest((request, context) => {
   }
 });
 ```
+
+##### Saving intercepted requests
+
+The option `saveRequests` represents whether [request handlers](#httprequesthandler) should save their intercepted
+requests and make them accessible through [`handler.requests()`](#http-handlerrequests). This setting is configured per
+interceptor and is `false` by default.
+
+```ts
+import { http } from 'zimic/interceptor';
+
+const interceptor = http.createInterceptor<Schema>({
+  type: 'local',
+  baseURL: 'http://localhost:3000',
+  saveRequests: true,
+});
+```
+
+> [!IMPORTANT]
+>
+> If you plan on accessing the intercepted requests, such as to assert them in your tests, set this `saveRequests` to
+> `true` and make sure to regularly clear the interceptor. A common practice is to call
+> [`interceptor.clear()`](#http-interceptorclear) after each test. This avoids leaking memory from the accumulated
+> requests.
+>
+> See [Testing](#testing) for an example of how to manage the lifecycle of interceptors in your tests.
 
 #### Declaring HTTP service schemas
 

--- a/apps/zimic-test-client/tests/v0/interceptor/exports/exports.test.ts
+++ b/apps/zimic-test-client/tests/v0/interceptor/exports/exports.test.ts
@@ -69,6 +69,7 @@ import {
   UnknownHttpInterceptorTypeError,
   NotStartedHttpInterceptorError,
   UnregisteredBrowserServiceWorkerError,
+  DisabledRequestSavingError,
 } from 'zimic0/interceptor';
 
 describe('Exports', () => {
@@ -181,5 +182,7 @@ describe('Exports', () => {
     expect(typeof NotStartedHttpInterceptorError).toBe('function');
     expectTypeOf<UnregisteredBrowserServiceWorkerError>().not.toBeAny();
     expect(typeof UnregisteredBrowserServiceWorkerError).toBe('function');
+    expectTypeOf<DisabledRequestSavingError>().not.toBeAny();
+    expect(typeof DisabledRequestSavingError).toBe('function');
   });
 });

--- a/apps/zimic-test-client/tests/v0/interceptor/thirdParty/shared/default.ts
+++ b/apps/zimic-test-client/tests/v0/interceptor/thirdParty/shared/default.ts
@@ -39,11 +39,13 @@ async function declareDefaultClientTests(options: ClientTestOptionsByWorkerType)
   const authInterceptor = http.createInterceptor<AuthServiceSchema>({
     type,
     baseURL: await getAuthBaseURL(type),
+    saveRequests: true,
   });
 
   const notificationInterceptor = http.createInterceptor<NotificationServiceSchema>({
     type,
     baseURL: await getNotificationsBaseURL(type),
+    saveRequests: true,
   });
 
   const interceptors = [authInterceptor, notificationInterceptor];

--- a/examples/with-jest-jsdom/tests/interceptors/github.ts
+++ b/examples/with-jest-jsdom/tests/interceptors/github.ts
@@ -14,6 +14,7 @@ const githubInterceptor = http.createInterceptor<{
 }>({
   type: 'local',
   baseURL: GITHUB_API_BASE_URL,
+  saveRequests: true,
 });
 
 export default githubInterceptor;

--- a/examples/with-jest-jsdom/tests/setup.ts
+++ b/examples/with-jest-jsdom/tests/setup.ts
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom/jest-globals';
 
-import { beforeAll, beforeEach, afterAll } from '@jest/globals';
+import { beforeAll, afterEach, afterAll } from '@jest/globals';
 
 import githubInterceptor from './interceptors/github';
 
@@ -8,7 +8,7 @@ beforeAll(async () => {
   await githubInterceptor.start();
 });
 
-beforeEach(() => {
+afterEach(() => {
   githubInterceptor.clear();
 });
 

--- a/examples/with-jest-node/tests/interceptors/github.ts
+++ b/examples/with-jest-node/tests/interceptors/github.ts
@@ -14,6 +14,7 @@ const githubInterceptor = http.createInterceptor<{
 }>({
   type: 'local',
   baseURL: GITHUB_API_BASE_URL,
+  saveRequests: true,
 });
 
 export default githubInterceptor;

--- a/examples/with-jest-node/tests/setup.ts
+++ b/examples/with-jest-node/tests/setup.ts
@@ -1,4 +1,4 @@
-import { beforeAll, beforeEach, afterAll } from '@jest/globals';
+import { beforeAll, afterEach, afterAll } from '@jest/globals';
 import { http } from 'zimic/interceptor';
 
 import githubInterceptor from './interceptors/github';
@@ -9,7 +9,7 @@ beforeAll(async () => {
   await githubInterceptor.start();
 });
 
-beforeEach(() => {
+afterEach(() => {
   githubInterceptor.clear();
 });
 

--- a/examples/with-vitest-browser/tests/interceptors/github.ts
+++ b/examples/with-vitest-browser/tests/interceptors/github.ts
@@ -14,6 +14,7 @@ const githubInterceptor = http.createInterceptor<{
 }>({
   type: 'local',
   baseURL: GITHUB_API_BASE_URL,
+  saveRequests: true,
 });
 
 export default githubInterceptor;

--- a/examples/with-vitest-browser/tests/setup.ts
+++ b/examples/with-vitest-browser/tests/setup.ts
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom/vitest';
 
-import { beforeAll, beforeEach, afterAll } from 'vitest';
+import { beforeAll, afterEach, afterAll } from 'vitest';
 
 import githubInterceptor from './interceptors/github';
 
@@ -8,7 +8,7 @@ beforeAll(async () => {
   await githubInterceptor.start();
 });
 
-beforeEach(() => {
+afterEach(() => {
   githubInterceptor.clear();
 });
 

--- a/examples/with-vitest-jsdom/tests/interceptors/github.ts
+++ b/examples/with-vitest-jsdom/tests/interceptors/github.ts
@@ -14,6 +14,7 @@ const githubInterceptor = http.createInterceptor<{
 }>({
   type: 'local',
   baseURL: GITHUB_API_BASE_URL,
+  saveRequests: true,
 });
 
 export default githubInterceptor;

--- a/examples/with-vitest-jsdom/tests/setup.ts
+++ b/examples/with-vitest-jsdom/tests/setup.ts
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom/vitest';
 
-import { beforeAll, beforeEach, afterAll } from 'vitest';
+import { beforeAll, afterEach, afterAll } from 'vitest';
 
 import githubInterceptor from './interceptors/github';
 
@@ -8,7 +8,7 @@ beforeAll(async () => {
   await githubInterceptor.start();
 });
 
-beforeEach(() => {
+afterEach(() => {
   githubInterceptor.clear();
 });
 

--- a/examples/with-vitest-node/tests/interceptors/github.ts
+++ b/examples/with-vitest-node/tests/interceptors/github.ts
@@ -14,6 +14,7 @@ const githubInterceptor = http.createInterceptor<{
 }>({
   type: 'local',
   baseURL: GITHUB_API_BASE_URL,
+  saveRequests: true,
 });
 
 export default githubInterceptor;

--- a/examples/with-vitest-node/tests/setup.ts
+++ b/examples/with-vitest-node/tests/setup.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, beforeEach } from 'vitest';
+import { afterAll, beforeAll, afterEach } from 'vitest';
 import { http } from 'zimic/interceptor';
 
 import githubInterceptor from './interceptors/github';
@@ -9,7 +9,7 @@ beforeAll(async () => {
   await githubInterceptor.start();
 });
 
-beforeEach(() => {
+afterEach(() => {
   githubInterceptor.clear();
 });
 

--- a/packages/zimic/src/interceptor/http/interceptor/HttpInterceptorClient.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/HttpInterceptorClient.ts
@@ -33,7 +33,7 @@ class HttpInterceptorClient<
   private _baseURL: ExtendedURL;
   private _isRunning = false;
   private onUnhandledRequest?: UnhandledRequestStrategy;
-  private shouldSaveRequests = false;
+  private _shouldSaveRequests = false;
 
   private Handler: HandlerConstructor;
 
@@ -62,7 +62,7 @@ class HttpInterceptorClient<
     this._baseURL = options.baseURL;
     this.Handler = options.Handler;
     this.onUnhandledRequest = options.onUnhandledRequest;
-    this.shouldSaveRequests = options.saveRequests ?? false;
+    this._shouldSaveRequests = options.saveRequests ?? false;
   }
 
   baseURL() {
@@ -75,6 +75,10 @@ class HttpInterceptorClient<
 
   isRunning() {
     return this.worker.isRunning() && this._isRunning;
+  }
+
+  shouldSaveRequests() {
+    return this._shouldSaveRequests;
   }
 
   async start() {
@@ -210,7 +214,7 @@ class HttpInterceptorClient<
     const responseDeclaration = await matchedHandler.applyResponseDeclaration(parsedRequest);
     const response = HttpInterceptorWorker.createResponseFromDeclaration(request, responseDeclaration);
 
-    if (this.shouldSaveRequests) {
+    if (this.shouldSaveRequests()) {
       const responseClone = response.clone();
 
       const parsedResponse = await HttpInterceptorWorker.parseRawResponse<

--- a/packages/zimic/src/interceptor/http/interceptor/LocalHttpInterceptor.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/LocalHttpInterceptor.ts
@@ -30,6 +30,7 @@ class LocalHttpInterceptor<Schema extends HttpServiceSchema> implements PublicLo
       baseURL,
       Handler: LocalHttpRequestHandler,
       onUnhandledRequest: options.onUnhandledRequest,
+      saveRequests: options.saveRequests,
     });
   }
 

--- a/packages/zimic/src/interceptor/http/interceptor/RemoteHttpInterceptor.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/RemoteHttpInterceptor.ts
@@ -35,6 +35,7 @@ class RemoteHttpInterceptor<Schema extends HttpServiceSchema> implements PublicR
       baseURL,
       Handler: RemoteHttpRequestHandler,
       onUnhandledRequest: options.onUnhandledRequest,
+      saveRequests: options.saveRequests,
     });
   }
 

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/handlers.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/handlers.ts
@@ -508,5 +508,80 @@ export function declareHandlerHttpInterceptorTests(options: RuntimeSharedHttpInt
         });
       });
     }
+
+    describe('Request saving', () => {
+      it.each([false, undefined])(
+        `should not save intercepted ${method} requests if disabled: %s`,
+        async (saveRequests) => {
+          await usingHttpInterceptor<{
+            '/users': {
+              GET: MethodSchema;
+              POST: MethodSchema;
+              PUT: MethodSchema;
+              PATCH: MethodSchema;
+              DELETE: MethodSchema;
+              HEAD: MethodSchema;
+              OPTIONS: MethodSchema;
+            };
+          }>({ ...interceptorOptions, saveRequests }, async (interceptor) => {
+            const handler = await promiseIfRemote(
+              interceptor[lowerMethod]('/users').respond({
+                status: 200,
+                headers: DEFAULT_ACCESS_CONTROL_HEADERS,
+              }),
+              interceptor,
+            );
+
+            let requests = await promiseIfRemote(handler.requests(), interceptor);
+            expect(requests).toHaveLength(0);
+
+            const numberOfRequests = 5;
+
+            for (let index = 0; index < numberOfRequests; index++) {
+              const response = await fetch(joinURL(baseURL, '/users'), { method });
+              expect(response.status).toBe(200);
+            }
+
+            requests = await promiseIfRemote(handler.requests(), interceptor);
+            expect(requests).toHaveLength(0);
+          });
+        },
+      );
+
+      it.each([true])(`should not save intercepted ${method} requests if disabled: %s`, async (saveRequests) => {
+        await usingHttpInterceptor<{
+          '/users': {
+            GET: MethodSchema;
+            POST: MethodSchema;
+            PUT: MethodSchema;
+            PATCH: MethodSchema;
+            DELETE: MethodSchema;
+            HEAD: MethodSchema;
+            OPTIONS: MethodSchema;
+          };
+        }>({ ...interceptorOptions, saveRequests }, async (interceptor) => {
+          const handler = await promiseIfRemote(
+            interceptor[lowerMethod]('/users').respond({
+              status: 200,
+              headers: DEFAULT_ACCESS_CONTROL_HEADERS,
+            }),
+            interceptor,
+          );
+
+          let requests = await promiseIfRemote(handler.requests(), interceptor);
+          expect(requests).toHaveLength(0);
+
+          const numberOfRequests = 5;
+
+          for (let index = 0; index < numberOfRequests; index++) {
+            const response = await fetch(joinURL(baseURL, '/users'), { method });
+            expect(response.status).toBe(200);
+          }
+
+          requests = await promiseIfRemote(handler.requests(), interceptor);
+          expect(requests).toHaveLength(numberOfRequestsIncludingPreflight * numberOfRequests);
+        });
+      });
+    });
   });
 }

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/handlers.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/handlers.ts
@@ -512,7 +512,7 @@ export function declareHandlerHttpInterceptorTests(options: RuntimeSharedHttpInt
 
     describe('Request saving', () => {
       it.each([false, undefined])(
-        `should not save intercepted ${method} requests if disabled: %s`,
+        `should not save intercepted ${method} requests if disabled with: %s`,
         async (saveRequests) => {
           await usingHttpInterceptor<{
             '/users': {
@@ -561,7 +561,7 @@ export function declareHandlerHttpInterceptorTests(options: RuntimeSharedHttpInt
         },
       );
 
-      it.each([true])(`should not save intercepted ${method} requests if disabled: %s`, async (saveRequests) => {
+      it.each([true])(`should save intercepted ${method} requests if enabled with: %s`, async (saveRequests) => {
         await usingHttpInterceptor<{
           '/users': {
             GET: MethodSchema;

--- a/packages/zimic/src/interceptor/http/interceptor/types/options.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/types/options.ts
@@ -88,6 +88,8 @@ export interface SharedHttpInterceptorOptions {
    * The strategy to handle unhandled requests. If a request starts with the base URL of the interceptor, but no
    * matching handler exists, this strategy will be used. If a function is provided, it will be called with the
    * unhandled request.
+   *
+   * @see {@link https://github.com/zimicjs/zimic#unhandled-requests Unhandled requests}
    */
   onUnhandledRequest?: UnhandledRequestStrategy;
 }

--- a/packages/zimic/src/interceptor/http/interceptor/types/options.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/types/options.ts
@@ -85,6 +85,22 @@ export interface SharedHttpInterceptorOptions {
   baseURL: string | URL;
 
   /**
+   * Whether {@link https://github.com/zimicjs/zimic#httprequesthandler request handlers} should save their intercepted
+   * requests and make them accessible through
+   * {@link https://github.com/zimicjs/zimic#http-handlerrequests `handler.requests()`}.
+   *
+   * **IMPORTANT**: Handlers won't save their intercepted requests by default. If you plan on accessing those requests,
+   * such as to assert them in your tests, set this option to `true` and make sure to regularly clear the interceptor. A
+   * common practice is to call {@link https://github.com/zimicjs/zimic#http-interceptorclear `interceptor.clear()`}
+   * after each test. This avoids leaking memory from the accumulated requests.
+   *
+   * @default false
+   * @see {@link https://github.com/zimicjs/zimic#saving-intercepted-requests Saving intercepted requests}
+   * @see {@link https://github.com/zimicjs/zimic#testing Testing}
+   */
+  saveRequests?: boolean;
+
+  /**
    * The strategy to handle unhandled requests. If a request starts with the base URL of the interceptor, but no
    * matching handler exists, this strategy will be used. If a function is provided, it will be called with the
    * unhandled request.

--- a/packages/zimic/src/interceptor/http/interceptor/types/options.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/types/options.ts
@@ -89,10 +89,11 @@ export interface SharedHttpInterceptorOptions {
    * requests and make them accessible through
    * {@link https://github.com/zimicjs/zimic#http-handlerrequests `handler.requests()`}.
    *
-   * **IMPORTANT**: Handlers won't save their intercepted requests by default. If you plan on accessing those requests,
-   * such as to assert them in your tests, set this option to `true` and make sure to regularly clear the interceptor. A
-   * common practice is to call {@link https://github.com/zimicjs/zimic#http-interceptorclear `interceptor.clear()`}
-   * after each test. This avoids leaking memory from the accumulated requests.
+   * **IMPORTANT**: Saving the intercepted requests will lead to a memory leak if not accompanied by clearing of the
+   * interceptor or disposal of the handlers (i.e. garbage collection). If you plan on accessing those requests, such as
+   * to assert them in your tests, set this option to `true` and make sure to regularly clear the interceptor. A common
+   * practice is to call {@link https://github.com/zimicjs/zimic#http-interceptorclear `interceptor.clear()`} after each
+   * test. This prevents leaking memory from the accumulated requests.
    *
    * @default false
    * @see {@link https://github.com/zimicjs/zimic#saving-intercepted-requests Saving intercepted requests}

--- a/packages/zimic/src/interceptor/http/interceptor/types/options.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/types/options.ts
@@ -25,7 +25,7 @@ export type HttpInterceptorPlatform = 'node' | 'browser';
  */
 export namespace UnhandledRequestStrategy {
   /**
-   * A static declaration of the strategy to handle unhandled requests.
+   * A static declaration of the strategy to use for unhandled requests.
    *
    * @see {@link https://github.com/zimicjs/zimic#unhandled-requests Unhandled requests}
    */
@@ -86,7 +86,7 @@ export interface SharedHttpInterceptorOptions {
 
   /**
    * Whether {@link https://github.com/zimicjs/zimic#httprequesthandler request handlers} should save their intercepted
-   * requests and make them accessible through
+   * requests in memory and make them accessible through
    * {@link https://github.com/zimicjs/zimic#http-handlerrequests `handler.requests()`}.
    *
    * **IMPORTANT**: Saving the intercepted requests will lead to a memory leak if not accompanied by clearing of the
@@ -102,7 +102,7 @@ export interface SharedHttpInterceptorOptions {
   saveRequests?: boolean;
 
   /**
-   * The strategy to handle unhandled requests. If a request starts with the base URL of the interceptor, but no
+   * The strategy to use for unhandled requests. If a request starts with the base URL of the interceptor, but no
    * matching handler exists, this strategy will be used. If a function is provided, it will be called with the
    * unhandled request.
    *

--- a/packages/zimic/src/interceptor/http/interceptorWorker/HttpInterceptorWorker.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/HttpInterceptorWorker.ts
@@ -432,7 +432,7 @@ abstract class HttpInterceptorWorker {
         await formatObjectToLog(Object.fromEntries(request.searchParams)),
         '\n    Body:',
         await formatObjectToLog(request.body),
-        '\n\nLearn more about unhandled requests: https://github.com/zimicjs/zimic#unhandled-requests',
+        '\n\nLearn more: https://github.com/zimicjs/zimic#unhandled-requests',
       ],
       { method: action === 'bypass' ? 'warn' : 'error' },
     );

--- a/packages/zimic/src/interceptor/http/interceptorWorker/errors/UnregisteredBrowserServiceWorkerError.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/errors/UnregisteredBrowserServiceWorkerError.ts
@@ -11,7 +11,7 @@ class UnregisteredBrowserServiceWorkerError extends Error {
       `Failed to register the browser service worker: ` +
         `script '${window.location.origin}/${SERVICE_WORKER_FILE_NAME}' not found.\n\n` +
         'Did you forget to run "npx zimic browser init <public-directory>"?\n\n' +
-        'Learn more at https://github.com/zimicjs/zimic#browser-post-install.',
+        'Learn more: https://github.com/zimicjs/zimic#browser-post-install',
     );
     this.name = 'UnregisteredBrowserServiceWorkerError';
   }

--- a/packages/zimic/src/interceptor/http/namespace/HttpInterceptorNamespace.ts
+++ b/packages/zimic/src/interceptor/http/namespace/HttpInterceptorNamespace.ts
@@ -13,6 +13,7 @@ export class HttpInterceptorNamespaceDefault {
    * {@link https://github.com/zimicjs/zimic#httpcreateinterceptor `http.createInterceptor()`}.
    *
    * @param strategy The default strategy to be set.
+   * @see {@link https://github.com/zimicjs/zimic#unhandled-requests Unhandled requests}
    */
   onUnhandledRequest(strategy: UnhandledRequestStrategy) {
     this.store.setDefaultUnhandledRequestStrategy(strategy);

--- a/packages/zimic/src/interceptor/http/requestHandler/HttpRequestHandlerClient.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/HttpRequestHandlerClient.ts
@@ -219,7 +219,7 @@ class HttpRequestHandlerClient<
     return appliedDeclaration;
   }
 
-  registerInterceptedRequest(
+  saveInterceptedRequest(
     request: HttpInterceptorRequest<Path, Default<Schema[Path][Method]>>,
     response: HttpInterceptorResponse<Default<Schema[Path][Method]>, StatusCode>,
   ) {

--- a/packages/zimic/src/interceptor/http/requestHandler/HttpRequestHandlerClient.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/HttpRequestHandlerClient.ts
@@ -12,6 +12,7 @@ import { blobContains, blobEquals } from '@/utils/data';
 import { jsonContains, jsonEquals } from '@/utils/json';
 
 import HttpInterceptorClient from '../interceptor/HttpInterceptorClient';
+import DisabledRequestSavingError from './errors/DisabledRequestSavingError';
 import NoResponseDefinitionError from './errors/NoResponseDefinitionError';
 import LocalHttpRequestHandler from './LocalHttpRequestHandler';
 import RemoteHttpRequestHandler from './RemoteHttpRequestHandler';
@@ -245,6 +246,10 @@ class HttpRequestHandlerClient<
   }
 
   requests(): readonly TrackedHttpInterceptorRequest<Path, Default<Schema[Path][Method]>, StatusCode>[] {
+    if (!this.interceptor.shouldSaveRequests()) {
+      throw new DisabledRequestSavingError();
+    }
+
     const interceptedRequestsCopy = [...this.interceptedRequests];
     Object.freeze(interceptedRequestsCopy);
     return interceptedRequestsCopy;

--- a/packages/zimic/src/interceptor/http/requestHandler/LocalHttpRequestHandler.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/LocalHttpRequestHandler.ts
@@ -95,7 +95,7 @@ class LocalHttpRequestHandler<
     request: HttpInterceptorRequest<Path, Default<Schema[Path][Method]>>,
     response: HttpInterceptorResponse<Default<Schema[Path][Method]>, StatusCode>,
   ) {
-    this._client.registerInterceptedRequest(request, response);
+    this._client.saveInterceptedRequest(request, response);
   }
 }
 

--- a/packages/zimic/src/interceptor/http/requestHandler/RemoteHttpRequestHandler.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/RemoteHttpRequestHandler.ts
@@ -126,7 +126,7 @@ class RemoteHttpRequestHandler<
     request: HttpInterceptorRequest<Path, Default<Schema[Path][Method]>>,
     response: HttpInterceptorResponse<Default<Schema[Path][Method]>, StatusCode>,
   ) {
-    this._client.registerInterceptedRequest(request, response);
+    this._client.saveInterceptedRequest(request, response);
   }
 
   registerSyncPromise(promise: Promise<unknown>) {

--- a/packages/zimic/src/interceptor/http/requestHandler/RemoteHttpRequestHandler.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/RemoteHttpRequestHandler.ts
@@ -109,7 +109,13 @@ class RemoteHttpRequestHandler<
   }
 
   requests(): Promise<readonly TrackedHttpInterceptorRequest<Path, Default<Schema[Path][Method]>, StatusCode>[]> {
-    return Promise.resolve(this._client.requests());
+    return new Promise((resolve, reject) => {
+      try {
+        resolve(this._client.requests());
+      } catch (error) {
+        reject(error);
+      }
+    });
   }
 
   matchesRequest(request: HttpInterceptorRequest<Path, Default<Schema[Path][Method]>>): Promise<boolean> {

--- a/packages/zimic/src/interceptor/http/requestHandler/errors/DisabledRequestSavingError.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/errors/DisabledRequestSavingError.ts
@@ -1,0 +1,12 @@
+class DisabledRequestSavingError extends TypeError {
+  constructor() {
+    super(
+      'Intercepted requests are not saved by default. ' +
+        'Did you forget to use `saveRequests: true` when creating the interceptor?\n\n' +
+        'Learn more: https://github.com/zimicjs/zimic#saving-intercepted-requests',
+    );
+    this.name = 'DisabledRequestSavingError';
+  }
+}
+
+export default DisabledRequestSavingError;

--- a/packages/zimic/src/interceptor/http/requestHandler/types/public.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/types/public.ts
@@ -237,8 +237,16 @@ export interface HttpRequestHandler<
   clear: () => HttpRequestHandler<Schema, Method, Path, StatusCode>;
 
   /**
-   * @returns The intercepted requests that matched this handler, along with the responses returned to each of them.
-   *   This is useful for testing that the correct requests were made by your application.
+   * Returns the intercepted requests that matched this handler, along with the responses returned to each of them. This
+   * is useful for testing that the correct requests were made by your application.
+   *
+   * **IMPORTANT**: The intercepted requests are only accessible through this method if `saveRequests` is set to `true`
+   * when creating> The interceptor. See
+   * {@link https://github.com/zimicjs/zimic#saving-intercepted-requests Saving intercepted requests} for more
+   * information.
+   *
+   * @returns The intercepted requests.
+   * @throws {DisabledRequestSavingError} If the interceptor was not created with `saveRequests: true`.
    * @see {@link https://github.com/zimicjs/zimic#http-handlerrequests `handler.requests()` API reference}
    */
   requests:

--- a/packages/zimic/src/interceptor/http/requestHandler/types/public.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/types/public.ts
@@ -240,8 +240,7 @@ export interface HttpRequestHandler<
    * Returns the intercepted requests that matched this handler, along with the responses returned to each of them. This
    * is useful for testing that the correct requests were made by your application.
    *
-   * **IMPORTANT**: The intercepted requests are only accessible through this method if `saveRequests` is set to `true`
-   * when creating> The interceptor. See
+   * **IMPORTANT**: This method can only be used if `saveRequests` was set to `true` when creating the interceptor. See
    * {@link https://github.com/zimicjs/zimic#saving-intercepted-requests Saving intercepted requests} for more
    * information.
    *

--- a/packages/zimic/src/interceptor/index.ts
+++ b/packages/zimic/src/interceptor/index.ts
@@ -3,12 +3,14 @@ import UnknownHttpInterceptorPlatformError from './http/interceptor/errors/Unkno
 import UnknownHttpInterceptorTypeError from './http/interceptor/errors/UnknownHttpInterceptorTypeError';
 import UnregisteredBrowserServiceWorkerError from './http/interceptorWorker/errors/UnregisteredBrowserServiceWorkerError';
 import HttpInterceptorNamespace from './http/namespace/HttpInterceptorNamespace';
+import DisabledRequestSavingError from './http/requestHandler/errors/DisabledRequestSavingError';
 
 export {
   UnknownHttpInterceptorPlatformError,
   UnknownHttpInterceptorTypeError,
   NotStartedHttpInterceptorError,
   UnregisteredBrowserServiceWorkerError,
+  DisabledRequestSavingError,
 };
 
 export type {

--- a/packages/zimic/src/interceptor/server/types/options.ts
+++ b/packages/zimic/src/interceptor/server/types/options.ts
@@ -14,7 +14,11 @@ export interface InterceptorServerOptions {
   /** The port to start the server on. If no port is provided, a random one is chosen. */
   port?: number;
 
-  /** The strategy to handle unhandled requests. */
+  /**
+   * The strategy to handle unhandled requests.
+   *
+   * - @see {@link https://github.com/zimicjs/zimic#unhandled-requests Unhandled requests}
+   */
   onUnhandledRequest?: {
     /**
      * Whether to log unhandled requests.

--- a/packages/zimic/src/interceptor/server/types/options.ts
+++ b/packages/zimic/src/interceptor/server/types/options.ts
@@ -15,9 +15,9 @@ export interface InterceptorServerOptions {
   port?: number;
 
   /**
-   * The strategy to handle unhandled requests.
+   * The strategy to use for unhandled requests.
    *
-   * - @see {@link https://github.com/zimicjs/zimic#unhandled-requests Unhandled requests}
+   * @see {@link https://github.com/zimicjs/zimic#unhandled-requests Unhandled requests}
    */
   onUnhandledRequest?: {
     /**

--- a/packages/zimic/tests/utils/interceptors.ts
+++ b/packages/zimic/tests/utils/interceptors.ts
@@ -62,9 +62,10 @@ export function createInternalHttpInterceptor<Schema extends HttpServiceSchema>(
   options: HttpInterceptorOptions,
 ): LocalHttpInterceptor<Schema> | RemoteHttpInterceptor<Schema>;
 export function createInternalHttpInterceptor<Schema extends HttpServiceSchema>(options: HttpInterceptorOptions) {
-  return http.createInterceptor<Schema>(options) satisfies HttpInterceptor<Schema> as
-    | LocalHttpInterceptor<Schema>
-    | RemoteHttpInterceptor<Schema>;
+  return http.createInterceptor<Schema>({
+    saveRequests: true,
+    ...options,
+  }) satisfies HttpInterceptor<Schema> as LocalHttpInterceptor<Schema> | RemoteHttpInterceptor<Schema>;
 }
 
 type UsingInterceptorCallback<Schema extends HttpServiceSchema> = (


### PR DESCRIPTION
### Features
- [#zimic] Added the new interceptor boolean option `saveRequests`, which is `false` by default. This option indicates whether request handler should save their intercepted requests in memory and make them accessible through `handler.requests()`. This is an opt-in feature because it would cause a memory leak in long-running mock servers, if not accompanied by `interceptor.clear()` calls or disposal of the handlers by garbage collection.

Closes #210, closes #28.
