### PR TITLE
fix(ci): disable remote caching in release tasks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,9 +16,6 @@ env:
   CI: true
   NODE_VERSION: 20
 
-  IS_PULL_REQUEST_TO_MAIN:
-    ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' && 'true' || 'false' }}
-
   TURBO_TOKEN:
     ${{ !(github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main') &&
     secrets.TURBO_REMOTE_CACHE_TOKEN || '' }}
@@ -54,7 +51,6 @@ jobs:
           turbo-team: ${{ env.TURBO_TEAM }}
           install: ${{ env.INSTALL_OPTIONS }}
           build: ${{ env.BUILD_OPTIONS }}
-          build-node-env: ${{ env.IS_PULL_REQUEST_TO_MAIN == 'false' && 'development' || 'production' }}
           install-playwright-browsers: true
 
       - name: Check formatting style
@@ -99,7 +95,6 @@ jobs:
           turbo-team: ${{ env.TURBO_TEAM }}
           install: ${{ env.INSTALL_OPTIONS }}
           build: ${{ env.BUILD_OPTIONS }}
-          build-node-env: ${{ env.IS_PULL_REQUEST_TO_MAIN == 'false' && 'development' || 'production' }}
           install-playwright-browsers: true
 
       - name: Run tests
@@ -146,7 +141,6 @@ jobs:
           turbo-team: ${{ env.TURBO_TEAM }}
           install: ${{ env.INSTALL_OPTIONS }}
           build: ${{ env.BUILD_OPTIONS }}
-          build-node-env: ${{ env.IS_PULL_REQUEST_TO_MAIN == 'false' && 'development' || 'production' }}
           install-playwright-browsers: false
 
       - name: Set TypeScript version

--- a/.github/workflows/release-npm.yaml
+++ b/.github/workflows/release-npm.yaml
@@ -36,7 +36,6 @@ jobs:
           node-registry-url: https://registry.npmjs.org
           install: zimic...
           build: zimic^...
-          build-node-env: production
           install-playwright-browsers: true
 
       - name: Build zimic

--- a/.github/workflows/release-npm.yaml
+++ b/.github/workflows/release-npm.yaml
@@ -11,9 +11,6 @@ concurrency:
 
 env:
   NODE_VERSION: 20
-
-  TURBO_TOKEN: ${{ secrets.TURBO_REMOTE_CACHE_TOKEN }}
-  TURBO_TEAM: ${{ secrets.TURBO_REMOTE_CACHE_TEAM }}
   TURBO_LOG_ORDER: stream
 
 jobs:
@@ -37,8 +34,6 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           node-registry-url: https://registry.npmjs.org
-          turbo-token: ${{ env.TURBO_TOKEN }}
-          turbo-team: ${{ env.TURBO_TEAM }}
           install: zimic...
           build: zimic^...
           build-node-env: production


### PR DESCRIPTION
### Fixes
- [ci] Disabled remote turbo caching in NPM release tasks. Building the packages locally and not reading from a remote cache is a security measure.
