### PR TITLE
refactor(#release): remove unnecessary dependencies

### DIFF
--- a/packages/release/package.json
+++ b/packages/release/package.json
@@ -27,13 +27,11 @@
     "types:check": "tsc --noEmit"
   },
   "dependencies": {
-    "fs-extra": "^11.2.0",
     "yargs": "^17.7.2",
     "zod": "^3.23.8",
     "zx": "^4.3.0"
   },
   "devDependencies": {
-    "@types/fs-extra": "^11.0.4",
     "@types/node": "^20.14.0",
     "@types/yargs": "^17.0.32",
     "@vitest/coverage-istanbul": "1.6.0",

--- a/packages/release/src/config/release-config/release-config.ts
+++ b/packages/release/src/config/release-config/release-config.ts
@@ -1,5 +1,6 @@
-import filesystem from 'fs-extra';
 import path from 'path';
+
+import { pathExists } from '@/utils/files';
 
 import { CONFIG_FILENAME, PACKAGE_JSON_FILENAME, importedReleaseConfigSchema } from './constants';
 import { MissingReleaseConfigError, InvalidReleaseConfigError } from './errors';
@@ -10,14 +11,14 @@ async function findConfigFilePath() {
   while (true) {
     const configFilePath = path.join(directory, CONFIG_FILENAME);
 
-    const configFileExists = await filesystem.pathExists(configFilePath);
+    const configFileExists = await pathExists(configFilePath);
     if (configFileExists) {
       return configFilePath;
     }
 
     const packageJSONFilePath = path.join(directory, PACKAGE_JSON_FILENAME);
 
-    const packageJSONExists = await filesystem.pathExists(packageJSONFilePath);
+    const packageJSONExists = await pathExists(packageJSONFilePath);
     if (packageJSONExists) {
       throw new MissingReleaseConfigError();
     }

--- a/packages/release/src/utils/files.ts
+++ b/packages/release/src/utils/files.ts
@@ -1,0 +1,10 @@
+import filesystem from 'fs/promises';
+
+export async function pathExists(path: string) {
+  try {
+    await filesystem.access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -426,9 +426,6 @@ importers:
 
   packages/release:
     dependencies:
-      fs-extra:
-        specifier: ^11.2.0
-        version: 11.2.0
       yargs:
         specifier: ^17.7.2
         version: 17.7.2
@@ -439,9 +436,6 @@ importers:
         specifier: ^4.3.0
         version: 4.3.0
     devDependencies:
-      '@types/fs-extra':
-        specifier: ^11.0.4
-        version: 11.0.4
       '@types/node':
         specifier: ^20.14.0
         version: 20.14.2
@@ -1599,9 +1593,6 @@ packages:
   '@types/estree@1.0.5':
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
 
-  '@types/fs-extra@11.0.4':
-    resolution: {integrity: sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==}
-
   '@types/fs-extra@9.0.13':
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
 
@@ -1622,9 +1613,6 @@ packages:
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
-
-  '@types/jsonfile@6.1.4':
-    resolution: {integrity: sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==}
 
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
@@ -2770,10 +2758,6 @@ packages:
   fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
     engines: {node: '>=12'}
-
-  fs-extra@11.2.0:
-    resolution: {integrity: sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==}
-    engines: {node: '>=14.14'}
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
@@ -5782,6 +5766,23 @@ snapshots:
   '@swc/core-win32-x64-msvc@1.5.27':
     optional: true
 
+  '@swc/core@1.5.27':
+    dependencies:
+      '@swc/counter': 0.1.3
+      '@swc/types': 0.1.8
+    optionalDependencies:
+      '@swc/core-darwin-arm64': 1.5.27
+      '@swc/core-darwin-x64': 1.5.27
+      '@swc/core-linux-arm-gnueabihf': 1.5.27
+      '@swc/core-linux-arm64-gnu': 1.5.27
+      '@swc/core-linux-arm64-musl': 1.5.27
+      '@swc/core-linux-x64-gnu': 1.5.27
+      '@swc/core-linux-x64-musl': 1.5.27
+      '@swc/core-win32-arm64-msvc': 1.5.27
+      '@swc/core-win32-ia32-msvc': 1.5.27
+      '@swc/core-win32-x64-msvc': 1.5.27
+    optional: true
+
   '@swc/core@1.5.27(@swc/helpers@0.5.5)':
     dependencies:
       '@swc/counter': 0.1.3
@@ -5912,11 +5913,6 @@ snapshots:
 
   '@types/estree@1.0.5': {}
 
-  '@types/fs-extra@11.0.4':
-    dependencies:
-      '@types/jsonfile': 6.1.4
-      '@types/node': 20.14.2
-
   '@types/fs-extra@9.0.13':
     dependencies:
       '@types/node': 20.14.2
@@ -5942,10 +5938,6 @@ snapshots:
       parse5: 7.1.2
 
   '@types/json5@0.0.29': {}
-
-  '@types/jsonfile@6.1.4':
-    dependencies:
-      '@types/node': 20.14.2
 
   '@types/mdast@4.0.4':
     dependencies:
@@ -6105,6 +6097,14 @@ snapshots:
       vitest: 1.6.0(@types/node@20.14.2)(@vitest/browser@1.6.0)(jsdom@20.0.3)
     optionalDependencies:
       playwright: 1.44.1
+
+  '@vitest/browser@1.6.0(vitest@1.6.0)':
+    dependencies:
+      '@vitest/utils': 1.6.0
+      magic-string: 0.30.10
+      sirv: 2.0.4
+      vitest: 1.6.0(@types/node@20.14.2)(@vitest/browser@1.6.0)(jsdom@20.0.3)
+    optional: true
 
   '@vitest/coverage-istanbul@1.6.0(vitest@1.6.0(@types/node@20.14.2)(@vitest/browser@1.6.0)(jsdom@20.0.3(bufferutil@4.0.8)))':
     dependencies:
@@ -7325,12 +7325,6 @@ snapshots:
       jsonfile: 6.1.0
       universalify: 2.0.1
 
-  fs-extra@11.2.0:
-    dependencies:
-      graceful-fs: 4.2.11
-      jsonfile: 6.1.0
-      universalify: 2.0.1
-
   fs.realpath@1.0.0: {}
 
   fsevents@2.3.2:
@@ -8051,6 +8045,40 @@ snapshots:
   js-yaml@4.1.0:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@20.0.3:
+    dependencies:
+      abab: 2.0.6
+      acorn: 8.11.3
+      acorn-globals: 7.0.1
+      cssom: 0.5.0
+      cssstyle: 2.3.0
+      data-urls: 3.0.2
+      decimal.js: 10.4.3
+      domexception: 4.0.0
+      escodegen: 2.1.0
+      form-data: 4.0.0
+      html-encoding-sniffer: 3.0.0
+      http-proxy-agent: 5.0.0
+      https-proxy-agent: 5.0.1
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.10
+      parse5: 7.1.2
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 4.1.4
+      w3c-xmlserializer: 4.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 2.0.0
+      whatwg-mimetype: 3.0.0
+      whatwg-url: 11.0.0
+      ws: 8.17.0
+      xml-name-validator: 4.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    optional: true
 
   jsdom@20.0.3(bufferutil@4.0.8):
     dependencies:
@@ -9355,7 +9383,7 @@ snapshots:
       sucrase: 3.35.0
       tree-kill: 1.2.2
     optionalDependencies:
-      '@swc/core': 1.5.27(@swc/helpers@0.5.5)
+      '@swc/core': 1.5.27
       postcss: 8.4.38
       typescript: 5.4.5
     transitivePeerDependencies:
@@ -9573,8 +9601,8 @@ snapshots:
       why-is-node-running: 2.2.2
     optionalDependencies:
       '@types/node': 20.14.2
-      '@vitest/browser': 1.6.0(playwright@1.44.1)(vitest@1.6.0)
-      jsdom: 20.0.3(bufferutil@4.0.8)
+      '@vitest/browser': 1.6.0(vitest@1.6.0)
+      jsdom: 20.0.3
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -9679,6 +9707,9 @@ snapshots:
     dependencies:
       imurmurhash: 0.1.4
       signal-exit: 3.0.7
+
+  ws@8.17.0:
+    optional: true
 
   ws@8.17.0(bufferutil@4.0.8):
     optionalDependencies:


### PR DESCRIPTION
### Refactoring
- [#release] Remove the dependencies `fs-extra` and `@types/fs-extra` because they are not necessary. The native Node.js `fs` module already fulfills our current needs.
