### PR TITLE
chore(#zimic): support to typescript 5.5

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -134,6 +134,7 @@ jobs:
           - '5.2'
           - '5.3'
           - '5.4'
+          - '5.5'
 
     env:
       TYPESCRIPT_VERSION: ${{ matrix.typescript-version }}

--- a/packages/zimic/src/interceptor/http/interceptor/factory.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/factory.ts
@@ -9,11 +9,11 @@ import {
   RemoteHttpInterceptor as PublicRemoteHttpInterceptor,
 } from './types/public';
 
-function matchLocalHttpInterceptorOptions(options: HttpInterceptorOptions): options is LocalHttpInterceptorOptions {
+function isLocalHttpInterceptorOptions(options: HttpInterceptorOptions) {
   return options.type === 'local';
 }
 
-function matchRemoteHttpInterceptorOptions(options: HttpInterceptorOptions): options is RemoteHttpInterceptorOptions {
+function isRemoteHttpInterceptorOptions(options: HttpInterceptorOptions) {
   return options.type === 'remote';
 }
 
@@ -40,9 +40,9 @@ export function createHttpInterceptor<Schema extends HttpServiceSchema>(
 ): PublicLocalHttpInterceptor<Schema> | PublicRemoteHttpInterceptor<Schema> {
   const type = options.type;
 
-  if (matchLocalHttpInterceptorOptions(options)) {
+  if (isLocalHttpInterceptorOptions(options)) {
     return new LocalHttpInterceptor<Schema>(options);
-  } else if (matchRemoteHttpInterceptorOptions(options)) {
+  } else if (isRemoteHttpInterceptorOptions(options)) {
     return new RemoteHttpInterceptor<Schema>(options);
   }
 

--- a/packages/zimic/src/interceptor/http/interceptorWorker/LocalHttpInterceptorWorker.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/LocalHttpInterceptorWorker.ts
@@ -123,7 +123,7 @@ class LocalHttpInterceptorWorker extends HttpInterceptorWorker {
     internalWorker.close();
   }
 
-  private isInternalBrowserWorker(worker: HttpWorker): worker is BrowserHttpWorker {
+  private isInternalBrowserWorker(worker: HttpWorker) {
     return 'start' in worker && 'stop' in worker;
   }
 

--- a/packages/zimic/src/interceptor/http/interceptorWorker/errors/UnregisteredBrowserServiceWorkerError.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/errors/UnregisteredBrowserServiceWorkerError.ts
@@ -16,7 +16,7 @@ class UnregisteredBrowserServiceWorkerError extends Error {
     this.name = 'UnregisteredBrowserServiceWorkerError';
   }
 
-  static matchesRawError(error: unknown): error is UnregisteredBrowserServiceWorkerError {
+  static matchesRawError(error: unknown) {
     return (
       error instanceof Error &&
       error.message.toLowerCase().startsWith('[msw] failed to register a service worker for scope')

--- a/packages/zimic/src/interceptor/http/requestHandler/HttpRequestHandlerClient.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/HttpRequestHandlerClient.ts
@@ -16,11 +16,7 @@ import DisabledRequestSavingError from './errors/DisabledRequestSavingError';
 import NoResponseDefinitionError from './errors/NoResponseDefinitionError';
 import LocalHttpRequestHandler from './LocalHttpRequestHandler';
 import RemoteHttpRequestHandler from './RemoteHttpRequestHandler';
-import {
-  HttpRequestHandlerRestriction,
-  HttpRequestHandlerComputedRestriction,
-  HttpRequestHandlerStaticRestriction,
-} from './types/public';
+import { HttpRequestHandlerRestriction, HttpRequestHandlerStaticRestriction } from './types/public';
 import {
   HttpInterceptorRequest,
   HttpInterceptorResponse,
@@ -95,7 +91,7 @@ class HttpRequestHandlerClient<
     declaration:
       | HttpRequestHandlerResponseDeclaration<Default<Schema[Path][Method]>, StatusCode>
       | HttpRequestHandlerResponseDeclarationFactory<Path, Default<Schema[Path][Method]>, StatusCode>,
-  ): declaration is HttpRequestHandlerResponseDeclarationFactory<Path, Default<Schema[Path][Method]>, StatusCode> {
+  ) {
     return typeof declaration === 'function';
   }
 
@@ -204,9 +200,7 @@ class HttpRequestHandlerClient<
       : jsonContains(request.body, restriction.body);
   }
 
-  private isComputedRequestRestriction(
-    restriction: HttpRequestHandlerRestriction<Schema, Method, Path>,
-  ): restriction is HttpRequestHandlerComputedRestriction<Schema, Method, Path> {
+  private isComputedRequestRestriction(restriction: HttpRequestHandlerRestriction<Schema, Method, Path>) {
     return typeof restriction === 'function';
   }
 

--- a/packages/zimic/src/types/arrays.d.ts
+++ b/packages/zimic/src/types/arrays.d.ts
@@ -1,5 +1,4 @@
 interface ArrayConstructor {
-  // Using the original method signature style to correctly apply the overload.
   // eslint-disable-next-line @typescript-eslint/method-signature-style
   isArray<Item>(value: unknown): value is Item[];
 }

--- a/packages/zimic/src/types/objects.d.ts
+++ b/packages/zimic/src/types/objects.d.ts
@@ -1,7 +1,14 @@
+type ObjectKey<Type> = keyof Type & string;
+type ObjectValue<Type> = Type[ObjectKey<Type>];
+type ObjectEntry<Type> = [ObjectKey<Type>, ObjectValue<Type>];
+
 interface ObjectConstructor {
   // eslint-disable-next-line @typescript-eslint/method-signature-style
-  keys<Type>(object: Type): (keyof Type & string)[];
+  keys<Type>(object: Type): ObjectKey<Type>[];
 
   // eslint-disable-next-line @typescript-eslint/method-signature-style
-  entries<Type>(object: Type): [keyof Type & string, Type[keyof Type]][];
+  values<Type>(object: Type): ObjectValue<Type>[];
+
+  // eslint-disable-next-line @typescript-eslint/method-signature-style
+  entries<Type>(object: Type): ObjectEntry<Type>[];
 }

--- a/packages/zimic/src/utils/http.ts
+++ b/packages/zimic/src/utils/http.ts
@@ -96,9 +96,11 @@ export function getHttpServerPort(server: HttpServer) {
 }
 
 export function methodCanHaveRequestBody(method: HttpMethod): method is HttpMethodWithRequestBody {
-  return HTTP_METHODS_WITH_REQUEST_BODY.includes(method as HttpMethodWithRequestBody);
+  const methodsToCompare: readonly string[] = HTTP_METHODS_WITH_REQUEST_BODY;
+  return methodsToCompare.includes(method);
 }
 
 export function methodCanHaveResponseBody(method: HttpMethod): method is HttpMethodWithResponseBody {
-  return HTTP_METHODS_WITH_RESPONSE_BODY.includes(method as HttpMethodWithResponseBody);
+  const methodsToCompare: readonly string[] = HTTP_METHODS_WITH_RESPONSE_BODY;
+  return methodsToCompare.includes(method);
 }

--- a/packages/zimic/src/webSocket/WebSocketHandler.ts
+++ b/packages/zimic/src/webSocket/WebSocketHandler.ts
@@ -247,7 +247,7 @@ abstract class WebSocketHandler<Schema extends WebSocket.ServiceSchema> {
 
   private isReplyMessage<Channel extends WebSocket.EventWithReplyServiceChannel<Schema>>(
     message: WebSocket.ServiceMessage<Schema, Channel>,
-  ): message is WebSocket.ServiceReplyMessage<Schema, Channel> {
+  ) {
     return 'requestId' in message;
   }
 

--- a/packages/zimic/tests/utils/fetch.ts
+++ b/packages/zimic/tests/utils/fetch.ts
@@ -14,7 +14,7 @@ export async function expectFetchError(fetchPromise: Promise<Response>, options:
     'Failed to fetch',
     canBeAborted && 'This operation was aborted',
     canBeAborted && 'signal is aborted without reason',
-  ].filter((option): option is string => typeof option === 'string');
+  ].filter((option) => option !== false);
 
   const errorMessageExpression = new RegExp(`^${errorMessageOptions.join('|')}$`);
   await expect(fetchPromise).rejects.toThrowError(errorMessageExpression);


### PR DESCRIPTION
### Refactoring
- [#zimic] Improved some types and removed type predicates that are now inferred in TypeScript 5.5.

### Chore
- [ci] Included TypeScript 5.5 in the matrix checking types.
