### PR TITLE
chore(ci): latest node 22

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,7 +75,7 @@ jobs:
         node-version:
           - 18
           - 20
-          - '22.2'
+          - 22
 
     env:
       NODE_VERSION: ${{ matrix.node-version }}


### PR DESCRIPTION
### Chore
- [ci] Re-enabled the latest node 22 version on CI, now that 22.4 is out. Previously, we fixed 22.2 because 22.3 had a [bug related to array buffers](https://github.com/nodejs/undici/issues/3337) that was causing some tests to fail.

Closs #239.
