### PR TITLE
build(#zimic): improve build config

### DIFF
--- a/packages/zimic/package.json
+++ b/packages/zimic/package.json
@@ -32,7 +32,8 @@
     "dist",
     "index.d.ts",
     "interceptor.d.ts",
-    "server.d.ts"
+    "server.d.ts",
+    "typegen.d.ts"
   ],
   "types": "index.d.ts",
   "bin": {

--- a/packages/zimic/scripts/postinstall.ts
+++ b/packages/zimic/scripts/postinstall.ts
@@ -1,34 +1,40 @@
 import filesystem from 'fs/promises';
-import mswPackageJSON from 'msw/package.json';
+import type mswPackage from 'msw/package.json';
 import path from 'path';
 
-type MSWExports = typeof mswPackageJSON.exports;
+import { Override } from '@/types/utils';
 
-const browserExports = mswPackageJSON.exports['./browser'] as Omit<MSWExports['./browser'], 'node'> & {
-  node: string | null;
-};
+type MSWPackage = typeof mswPackage;
+type MSWExports = MSWPackage['exports'];
 
-const nodeExports = mswPackageJSON.exports['./node'] as Omit<MSWExports['./node'], 'browser'> & {
-  browser: string | null;
-};
+async function patchMSWExports() {
+  const mswRootPath = path.join(require.resolve('msw'), '..', '..', '..');
+  const mswPackagePath = path.join(mswRootPath, 'package.json');
 
-const nativeExports = mswPackageJSON.exports['./native'] as Omit<MSWExports['./native'], 'browser'> & {
-  browser: string | null;
-};
+  const mswPackageContentAsString = await filesystem.readFile(mswPackagePath, 'utf-8');
+  const mswPackageContent = JSON.parse(mswPackageContentAsString) as MSWPackage;
 
-const MSW_ROOT_PATH = path.join(require.resolve('msw'), '..', '..', '..');
-const MSW_PACKAGE_JSON_PATH = path.join(MSW_ROOT_PATH, 'package.json');
+  const browserExports = mswPackageContent.exports['./browser'] as Override<
+    MSWExports['./browser'],
+    { node: string | null }
+  >;
 
-async function patchMSWExportLimitations() {
+  const nodeExports = mswPackageContent.exports['./node'] as Override<MSWExports['./node'], { browser: string | null }>;
+
+  const nativeExports = mswPackageContent.exports['./native'] as Override<
+    MSWExports['./native'],
+    { browser: string | null }
+  >;
+
   browserExports.node = nodeExports.default;
   nodeExports.browser = browserExports.default;
   nativeExports.browser = browserExports.default;
 
-  await filesystem.writeFile(MSW_PACKAGE_JSON_PATH, JSON.stringify(mswPackageJSON, null, 2));
+  await filesystem.writeFile(mswPackagePath, JSON.stringify(mswPackageContent, null, 2));
 }
 
 async function postinstall() {
-  await patchMSWExportLimitations();
+  await patchMSWExports();
 }
 
 void postinstall();

--- a/packages/zimic/scripts/postinstall.ts
+++ b/packages/zimic/scripts/postinstall.ts
@@ -16,14 +16,17 @@ async function patchMSWExports() {
 
   const browserExports = mswPackageContent.exports['./browser'] as Override<
     MSWExports['./browser'],
-    { node: string | null }
+    { node: MSWExports['./browser']['node'] | string | null }
   >;
 
-  const nodeExports = mswPackageContent.exports['./node'] as Override<MSWExports['./node'], { browser: string | null }>;
+  const nodeExports = mswPackageContent.exports['./node'] as Override<
+    MSWExports['./node'],
+    { browser: MSWExports['./browser']['browser'] | string | null }
+  >;
 
   const nativeExports = mswPackageContent.exports['./native'] as Override<
     MSWExports['./native'],
-    { browser: string | null }
+    { browser: MSWExports['./native']['browser'] | string | null }
   >;
 
   browserExports.node = nodeExports.default;

--- a/packages/zimic/tsup.config.ts
+++ b/packages/zimic/tsup.config.ts
@@ -1,5 +1,15 @@
 import { Options, defineConfig } from 'tsup';
 
+export function pickKeys<Type, Key extends keyof Type>(object: Type, keys: Key[]): Pick<Type, Key> {
+  return keys.reduce(
+    (pickedObject, key) => {
+      pickedObject[key] = object[key];
+      return pickedObject;
+    },
+    {} as Pick<Type, Key>, // eslint-disable-line @typescript-eslint/prefer-reduce-type-parameter
+  );
+}
+
 const sharedConfig: Options = {
   bundle: true,
   splitting: true,
@@ -34,12 +44,7 @@ const nodeConfig = (['cjs', 'esm'] as const).map<Options>((format) => {
     'scripts/postinstall': 'scripts/postinstall.ts',
   };
 
-  const entriesToGenerateTypes: (keyof typeof entry)[] = ['server', 'typegen'];
-
-  const dtsEntry = entriesToGenerateTypes.reduce<Record<string, string>>((dtsEntry, key) => {
-    dtsEntry[key] = entry[key];
-    return dtsEntry;
-  }, {});
+  const dtsEntry = pickKeys(entry, ['server', 'typegen']);
 
   return {
     ...sharedConfig,


### PR DESCRIPTION
### Build
- [#zimic] Improved the build config in `tsup.config.ts`, enabling splitting and generating ESM CLI and postinstall scripts.

### Refactoring
- [#zimic] Improved the postinstall logic to patch MSW exports.