### PR TITLE
docs(#zimic): v0.8.0 (#88)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2772,16 +2772,16 @@ Options:
 You can use this command to generate the types of a service from an OpenAPI schema file:
 
 ```bash
-zimic typegen openapi ./schema.yaml -o schema.ts --service-name MyService
+zimic typegen openapi ./schema.yaml -o ./schema.ts --service-name MyService
 ```
 
 Then, you can use the types in your interceptors:
 
 ```ts
-import { http } from 'zimic/interceptor';
+import { httpInterceptor } from 'zimic/interceptor/http';
 import { MyServiceSchema } from './schema';
 
-const interceptor = http.createInterceptor<MyServiceSchema>({
+const interceptor = httpInterceptor.create<MyServiceSchema>({
   type: 'local',
   baseURL: 'http://localhost:3000',
 });
@@ -2793,29 +2793,29 @@ const interceptor = http.createInterceptor<MyServiceSchema>({
 > first downloading it and then passing the file path to `zimic typegen`. An example using `curl`:
 >
 > ```bash
-> curl https://my-service.com/api/openapi/schema.yaml -o schema.yaml
-
-> zimic typegen openapi ./schema.yaml -o schema.ts --service-name MyService
+> curl https://my-service.com/api/openapi/schema.yaml -o ./schema.yaml
+> 
+> zimic typegen openapi ./schema.yaml -o ./schema.ts --service-name MyService
 > ```
 
 You can generate the types ignoring comments by using `--no-comments` or `--comments false`.
 
 ```bash
-zimic typegen openapi ./schema.yaml -o schema.ts --service-name MyService --no-comments
+zimic typegen openapi ./schema.yaml -o ./schema.ts --service-name MyService --no-comments
 ```
 
 By default, pruning is enabled, meaning that unused types are not outputted. If you want all types declared in the
 schema to be generated, you can use `--no-prune` or `--prune false`.
 
 ```bash
-zimic typegen openapi ./schema.yaml -o schema.ts --service-name MyService --no-prune
+zimic typegen openapi ./schema.yaml -o ./schema.ts --service-name MyService --no-prune
 ```
 
 You can also filter a subset of paths to generate types for. In conjunction with pruning, this is useful to reduce the
 size of the output file and only generate the types you need.
 
 ```bash
-zimic typegen openapi ./schema.yaml -o schema.ts --service-name MyService --filter 'GET /users**'
+zimic typegen openapi ./schema.yaml -o ./schema.ts --service-name MyService --filter 'GET /users**'
 ```
 
 When many filters are used, a filter file can be provided, where each line represents a filter expression and comments
@@ -2838,7 +2838,7 @@ GET,POST,PUT /workspaces
 ```
 
 ```bash
-zimic typegen openapi ./schema.yaml -o schema.ts --service-name MyService --filter-file ./filters.txt
+zimic typegen openapi ./schema.yaml -o ./schema.ts --service-name MyService --filter-file ./filters.txt
 ```
 
 #### `zimic typegen` programmatic usage

--- a/README.md
+++ b/README.md
@@ -2599,16 +2599,37 @@ console.log(request.response.raw); // Response{}
 ### `zimic`
 
 ```
-zimic <command>
+zimic [command]
 
 Commands:
   zimic browser  Browser
   zimic server   Interceptor server
+  zimic typegen  Type generation
 
 Options:
-  --help     Show help                                                 [boolean]
-  --version  Show version number                                       [boolean]
+  --help     Show help                                                                     [boolean]
+  --version  Show version number                                                           [boolean]
 ```
+
+> [!TIP]
+>
+> All boolean options in Zimic's CLI can be prefixed with `--no-` to negate them.
+>
+> For example, all of the options below are equivalent and indicate that comments are **disabled**:
+>
+> ```bash
+> --no-comments
+> --comments false
+> --comments=false
+> ```
+>
+> On the other hand, all of the options below are also equivalent and indicate that comments are **enabled**:
+>
+> ```bash
+> --comments
+> --comments true
+> --comments=true
+> ```
 
 ### `zimic browser`
 
@@ -2647,25 +2668,19 @@ Start an interceptor server.
 zimic server start [-- onReady]
 
 Positionals:
-  onReady  A command to run when the server is ready to accept connections.
-                                                                        [string]
+  onReady  A command to run when the server is ready to accept connections.                 [string]
 
 Options:
-      --help                    Show help                              [boolean]
-      --version                 Show version number                    [boolean]
-  -h, --hostname                The hostname to start the server on.
-                                                 [string] [default: "localhost"]
-  -p, --port                    The port to start the server on.        [number]
-  -e, --ephemeral               Whether the server should stop automatically
-                                after the on-ready command finishes. If no
-                                on-ready command is provided and ephemeral is
-                                true, the server will stop immediately after
-                                starting.             [boolean] [default: false]
-  -l, --log-unhandled-requests  Whether to log a warning when no interceptors
-                                were found for the base URL of a request. If an
-                                interceptor was matched, the logging behavior
-                                for that base URL is configured in the
-                                interceptor itself.                    [boolean]
+  -h, --hostname                The hostname to start the server on. [string] [default: "localhost"]
+  -p, --port                    The port to start the server on.                            [number]
+  -e, --ephemeral               Whether the server should stop automatically after the on-ready
+                                command finishes. If no on-ready command is provided and ephemeral
+                                is true, the server will stop immediately after starting.
+                                                                          [boolean] [default: false]
+  -l, --log-unhandled-requests  Whether to log a warning when no interceptors were found for the
+                                base URL of a request. If an interceptor was matched, the logging
+                                behavior for that base URL is configured in the interceptor itself.
+                                                                                           [boolean]
 ```
 
 You can use this command to start an independent server:
@@ -2704,6 +2719,113 @@ await server.stop();
 The helper function `runCommand` is useful to run a shell command in server scripts. The
 [Next.js App Router](./examples/README.md#nextjs) and the [Playwright](./examples/README.md#playwright) examples use
 this function to run the application after the interceptor server is ready and all mocks are set up.
+
+### `zimic typegen`
+
+#### `zimic typegen openapi`
+
+Generate types from an OpenAPI schema.
+
+```
+zimic typegen openapi <input>
+
+Positionals:
+  input  The path to a local OpenAPI schema file. YAML and JSON are supported.   [string] [required]
+
+Options:
+      --help          Show help                                                            [boolean]
+      --version       Show version number                                                  [boolean]
+  -o, --output        The path to write the generated types to. If not provided, the types will be
+                      written to stdout.                                                    [string]
+  -s, --service-name  The name of the service to use in the generated types.     [string] [required]
+  -c, --comments      Whether to include comments in the generated types.  [boolean] [default: true]
+  -p, --prune         Whether to remove unused operations and components from the generated types.
+                      This is useful for reducing the size of the output file.
+                                                                           [boolean] [default: true]
+  -f, --filter        One or more expressions to filter the types to generate. Filters must follow
+                      the format `<method> <path>`, where `<method>` is an HTTP method or `*`, and
+                      `<path>` is a literal path or a glob. Filters are case-sensitive regarding
+                      paths. If more than one filter is provided, they will be combined with OR. For
+                      example, `GET /users`, `* /users`, `GET /users/*`, and `GET /users/**/*` are
+                      valid filters. Negative filters can be created by prefixing the expression
+                      with `!`. For example, `!GET /users` will exclude paths matching `GET /users`.
+                                                                                             [array]
+  -F, --filter-file   A path to a file containing filter expressions. One expression is expected per
+                      line and the format is the same as used in a `--filter` option. Comments are
+                      prefixed with `#`. A filter file can be used alongside additional `--filter`
+                      expressions.                                                          [string]
+```
+
+You can use this command to generate a service types from an OpenAPI schema file:
+
+```bash
+zimic typegen openapi ./schema.yaml -o schema.ts --service-name MyService
+```
+
+Then, you can import and use the types in your interceptors:
+
+```ts
+import { http } from 'zimic/interceptor';
+import { MyServiceSchema } from './schema';
+
+const interceptor = http.createInterceptor<MyServiceSchema>({
+  type: 'local',
+  baseURL: 'http://localhost:3000',
+});
+```
+
+> [!IMPORTANT]
+>
+> Currently, Zimic only accepts file paths as inputs. If you need to fetch the OpenAPI schema from a URL, we recommend
+> first downloading it and then passing the file path to `zimic typegen`. An example using `curl`:
+>
+> ```bash
+> curl https://my-service.com/api/openapi/schema.yaml -o schema.yaml
+> zimic typegen openapi ./schema.yaml -o schema.ts --service-name MyService
+> ```
+
+You can generate the types ignoring comments by using `--no-comments` or `--comments false`.
+
+```bash
+zimic typegen openapi ./schema.yaml -o schema.ts --service-name MyService --no-comments
+```
+
+By default, pruning is enabled, meaning that unused types are not outputted. If you want all types declared in the
+schema to be generated, you can use `--no-prune` or `--prune false`.
+
+```bash
+zimic typegen openapi ./schema.yaml -o schema.ts --service-name MyService --no-prune
+```
+
+You can also filter a subset of paths to generate types for. In conjunction with pruning, this is useful to reduce the
+size of the output file and only generate the types you need.
+
+```bash
+zimic typegen openapi ./schema.yaml -o schema.ts --service-name MyService --filter 'GET /users**'
+```
+
+When many filters are used, a filter file can be provided, where each line represent a filter expression and comments
+are marked with `#`:
+
+`filters.txt`
+
+```
+# Include any endpoint starting with /users and having any HTTP method
+* /users**
+
+# Include any sub-endpoints of /posts with method GET.
+GET /posts/**/*
+
+# Include the endpoints /workspaces with methods GET, POST, or PUT.
+GET,POST,PUT /workspaces
+
+# Exclude endpoints to get user notifications
+!GET /users/*/notifications/**/*
+```
+
+```bash
+zimic typegen openapi ./schema.yaml -o schema.ts --service-name MyService --filter-file ./filters.txt
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2741,8 +2741,6 @@ Positionals:
                                                              [string] [required]
 
 Options:
-      --help          Show help                                        [boolean]
-      --version       Show version number                              [boolean]
   -o, --output        The path to write the generated types to. If not provided,
                       the types will be written to stdout.              [string]
   -s, --service-name  The name of the service to use in the generated types.
@@ -2771,13 +2769,13 @@ Options:
                       `--filter` expressions.                           [string]
 ```
 
-You can use this command to generate a service types from an OpenAPI schema file:
+You can use this command to generate the types of a service from an OpenAPI schema file:
 
 ```bash
 zimic typegen openapi ./schema.yaml -o schema.ts --service-name MyService
 ```
 
-Then, you can import and use the types in your interceptors:
+Then, you can use the types in your interceptors:
 
 ```ts
 import { http } from 'zimic/interceptor';
@@ -2796,6 +2794,7 @@ const interceptor = http.createInterceptor<MyServiceSchema>({
 >
 > ```bash
 > curl https://my-service.com/api/openapi/schema.yaml -o schema.yaml
+
 > zimic typegen openapi ./schema.yaml -o schema.ts --service-name MyService
 > ```
 
@@ -2819,7 +2818,7 @@ size of the output file and only generate the types you need.
 zimic typegen openapi ./schema.yaml -o schema.ts --service-name MyService --filter 'GET /users**'
 ```
 
-When many filters are used, a filter file can be provided, where each line represent a filter expression and comments
+When many filters are used, a filter file can be provided, where each line represents a filter expression and comments
 are marked with `#`:
 
 `filters.txt`

--- a/README.md
+++ b/README.md
@@ -2610,8 +2610,8 @@ Commands:
   zimic typegen  Type generation
 
 Options:
-  --help     Show help                                                                     [boolean]
-  --version  Show version number                                                           [boolean]
+  --help     Show help                                                 [boolean]
+  --version  Show version number                                       [boolean]
 ```
 
 > [!TIP]
@@ -2671,19 +2671,23 @@ Start an interceptor server.
 zimic server start [-- onReady]
 
 Positionals:
-  onReady  A command to run when the server is ready to accept connections.                 [string]
+  onReady  A command to run when the server is ready to accept connections.
+                                                                        [string]
 
 Options:
-  -h, --hostname                The hostname to start the server on. [string] [default: "localhost"]
-  -p, --port                    The port to start the server on.                            [number]
-  -e, --ephemeral               Whether the server should stop automatically after the on-ready
-                                command finishes. If no on-ready command is provided and ephemeral
-                                is true, the server will stop immediately after starting.
-                                                                          [boolean] [default: false]
-  -l, --log-unhandled-requests  Whether to log a warning when no interceptors were found for the
-                                base URL of a request. If an interceptor was matched, the logging
-                                behavior for that base URL is configured in the interceptor itself.
-                                                                                           [boolean]
+  -h, --hostname                The hostname to start the server on.
+                                                 [string] [default: "localhost"]
+  -p, --port                    The port to start the server on.        [number]
+  -e, --ephemeral               Whether the server should stop automatically
+                                after the on-ready command finishes. If no
+                                on-ready command is provided and ephemeral is
+                                true, the server will stop immediately after
+                                starting.             [boolean] [default: false]
+  -l, --log-unhandled-requests  Whether to log a warning when no interceptors
+                                were found for the base URL of a request. If an
+                                interceptor was matched, the logging behavior
+                                for that base URL is configured in the
+                                interceptor itself.                    [boolean]
 ```
 
 You can use this command to start an independent server:
@@ -2733,30 +2737,38 @@ Generate types from an OpenAPI schema.
 zimic typegen openapi <input>
 
 Positionals:
-  input  The path to a local OpenAPI schema file. YAML and JSON are supported.   [string] [required]
+  input  The path to a local OpenAPI schema file. YAML and JSON are supported.
+                                                             [string] [required]
 
 Options:
-      --help          Show help                                                            [boolean]
-      --version       Show version number                                                  [boolean]
-  -o, --output        The path to write the generated types to. If not provided, the types will be
-                      written to stdout.                                                    [string]
-  -s, --service-name  The name of the service to use in the generated types.     [string] [required]
-  -c, --comments      Whether to include comments in the generated types.  [boolean] [default: true]
-  -p, --prune         Whether to remove unused operations and components from the generated types.
-                      This is useful for reducing the size of the output file.
-                                                                           [boolean] [default: true]
-  -f, --filter        One or more expressions to filter the types to generate. Filters must follow
-                      the format `<method> <path>`, where `<method>` is an HTTP method or `*`, and
-                      `<path>` is a literal path or a glob. Filters are case-sensitive regarding
-                      paths. If more than one filter is provided, they will be combined with OR. For
-                      example, `GET /users`, `* /users`, `GET /users/*`, and `GET /users/**/*` are
-                      valid filters. Negative filters can be created by prefixing the expression
-                      with `!`. For example, `!GET /users` will exclude paths matching `GET /users`.
-                                                                                             [array]
-  -F, --filter-file   A path to a file containing filter expressions. One expression is expected per
-                      line and the format is the same as used in a `--filter` option. Comments are
-                      prefixed with `#`. A filter file can be used alongside additional `--filter`
-                      expressions.                                                          [string]
+      --help          Show help                                        [boolean]
+      --version       Show version number                              [boolean]
+  -o, --output        The path to write the generated types to. If not provided,
+                      the types will be written to stdout.              [string]
+  -s, --service-name  The name of the service to use in the generated types.
+                                                             [string] [required]
+  -c, --comments      Whether to include comments in the generated types.
+                                                       [boolean] [default: true]
+  -p, --prune         Whether to remove unused operations and components from
+                      the generated types. This is useful for reducing the size
+                      of the output file.              [boolean] [default: true]
+  -f, --filter        One or more expressions to filter the types to generate.
+                      Filters must follow the format `<method> <path>`, where
+                      `<method>` is an HTTP method or `*`, and `<path>` is a
+                      literal path or a glob. Filters are case-sensitive
+                      regarding paths. For example, `GET /users`, `* /users`,
+                      `GET /users/*`, and `GET /users/**/*` are valid filters.
+                      Negative filters can be created by prefixing the
+                      expression with `!`. For example, `!GET /users` will
+                      exclude paths matching `GET /users`. If more than one
+                      positive filter is provided, they will be combined with
+                      OR, while negative filters will be combined with AND.
+                                                                         [array]
+  -F, --filter-file   A path to a file containing filter expressions. One
+                      expression is expected per line and the format is the same
+                      as used in a `--filter` option. Comments are prefixed with
+                      `#`. A filter file can be used alongside additional
+                      `--filter` expressions.                           [string]
 ```
 
 You can use this command to generate a service types from an OpenAPI schema file:

--- a/README.md
+++ b/README.md
@@ -106,7 +106,10 @@ Zimic provides a flexible and type-safe way to mock HTTP requests.
     - [`zimic browser init`](#zimic-browser-init)
   - [`zimic server`](#zimic-server)
     - [`zimic server start`](#zimic-server-start)
-    - [Programmatic usage](#programmatic-usage)
+    - [`zimic server` programmatic usage](#zimic-server-programmatic-usage)
+  - [`zimic typegen`](#zimic-typegen)
+    - [`zimic typegen openapi`](#zimic-typegen-openapi)
+    - [`zimic typegen` programmatic usage](#zimic-typegen-programmatic-usage)
 - [Changelog](#changelog)
 
 ## Getting started
@@ -2698,7 +2701,7 @@ zimic server start --port 4000 --ephemeral -- npm run test
 The command after `--` will be executed when the server is ready. The flag `--ephemeral` indicates that the server
 should automatically stop after the command finishes.
 
-#### Programmatic usage
+#### `zimic server` programmatic usage
 
 The module `zimic/server` exports resources for managing interceptor servers programmatically. Even though we recommend
 using the CLI, this module is a valid alternative for more advanced use cases.
@@ -2826,6 +2829,26 @@ GET,POST,PUT /workspaces
 ```bash
 zimic typegen openapi ./schema.yaml -o schema.ts --service-name MyService --filter-file ./filters.txt
 ```
+
+#### `zimic typegen` programmatic usage
+
+The module `zimic/typegen` exports resources for generating types programmatically. We recommend using the CLI, but this
+module is a valid alternative for more advanced use cases.
+
+```ts
+import { typegen } from 'zimic/typegen';
+
+await typegen.generateFromOpenAPI({
+  input: './schema.yaml',
+  output: './schema.ts',
+  serviceName: 'MyService',
+  filters: ['* /users**'],
+  includeComments: true,
+  prune: true,
+});
+```
+
+The parameters of `typegen.generateFromOpenAPI` are the same as the CLI options for the `zimic typegen openapi` command.
 
 ---
 

--- a/packages/zimic/src/cli/browser/init.ts
+++ b/packages/zimic/src/cli/browser/init.ts
@@ -15,12 +15,12 @@ interface BrowserServiceWorkerInitOptions {
 
 async function initializeBrowserServiceWorker({ publicDirectory }: BrowserServiceWorkerInitOptions) {
   const absolutePublicDirectory = path.resolve(publicDirectory);
-
   await filesystem.mkdir(absolutePublicDirectory, { recursive: true });
-  const serviceWorkerDestinationPath = path.join(absolutePublicDirectory, SERVICE_WORKER_FILE_NAME);
-  await filesystem.copyFile(MOCK_SERVICE_WORKER_PATH, serviceWorkerDestinationPath);
 
-  logWithPrefix(`Service worker script saved to ${chalk.green(serviceWorkerDestinationPath)}!`);
+  const destinationPath = path.join(absolutePublicDirectory, SERVICE_WORKER_FILE_NAME);
+  await filesystem.copyFile(MOCK_SERVICE_WORKER_PATH, destinationPath);
+
+  logWithPrefix(`Service worker script saved to ${chalk.green(destinationPath)}!`);
   logWithPrefix('You can now use browser interceptors!');
 }
 

--- a/packages/zimic/src/errors/InvalidJSONError.ts
+++ b/packages/zimic/src/errors/InvalidJSONError.ts
@@ -1,3 +1,4 @@
+/** Error thrown when a value is not valid JSON. */
 class InvalidJSONError extends SyntaxError {
   constructor(value: string) {
     super(`Failed to parse value as JSON: ${value}`);

--- a/packages/zimic/src/http/headers/types.ts
+++ b/packages/zimic/src/http/headers/types.ts
@@ -20,4 +20,9 @@ export type HttpHeadersInit<Schema extends HttpHeadersSchema = HttpHeadersSchema
   | HttpHeaders<Schema>
   | HttpHeadersSchemaTuple<Schema>[];
 
+/**
+ * Recursively converts a type to its HTTP headers-serialized version. Numbers and booleans are converted to `${number}`
+ * and `${boolean}` respectively, null becomes undefined and not serializable values are excluded, such as functions and
+ * dates.
+ */
 export type HttpHeadersSerialized<Type> = HttpSearchParamsSerialized<Type>;

--- a/packages/zimic/src/http/searchParams/types.ts
+++ b/packages/zimic/src/http/searchParams/types.ts
@@ -30,6 +30,11 @@ type PrimitiveHttpSearchParamsSerialized<Type> = Type extends HttpSearchParamsSc
         ? undefined
         : never;
 
+/**
+ * Recursively converts a type to its URLSearchParams-serialized version. Numbers and booleans are converted to
+ * `${number}` and `${boolean}` respectively, null becomes undefined and not serializable values are excluded, such as
+ * functions and dates.
+ */
 export type HttpSearchParamsSerialized<Type> =
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   Type extends Date | ((...parameters: any[]) => any)

--- a/packages/zimic/src/http/types/requests.ts
+++ b/packages/zimic/src/http/types/requests.ts
@@ -7,11 +7,9 @@ import { HttpHeadersSchema } from '../headers/types';
 import HttpSearchParams from '../searchParams/HttpSearchParams';
 import { HttpSearchParamsSchema } from '../searchParams/types';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type HttpBodyValue = JSONValue | HttpFormData<any> | HttpSearchParams<any> | Blob | ArrayBuffer;
-
 /** The body type for HTTP requests and responses. */
-export type HttpBody<Type extends HttpBodyValue = HttpBodyValue> = Type;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type HttpBody = JSONValue | HttpFormData<any> | HttpSearchParams<any> | Blob | ArrayBuffer;
 
 /**
  * An HTTP headers object with a strictly-typed schema. Fully compatible with the built-in

--- a/packages/zimic/src/interceptor/server/factory.ts
+++ b/packages/zimic/src/interceptor/server/factory.ts
@@ -7,7 +7,7 @@ import { InterceptorServer as PublicInterceptorServer } from './types/public';
  *
  * @param options The options to create the server.
  * @returns The created server.
- * @see {@link https://github.com/zimicjs/zimic#zimic-server `zimic server` API reference}
+ * @see {@link https://github.com/zimicjs/zimic#zimic-server-programmatic-usage `zimic server` programmatic usage}
  * @see {@link https://github.com/zimicjs/zimic#remote-http-interceptors Remote HTTP Interceptors} .
  */
 export function createInterceptorServer(options: InterceptorServerOptions = {}): PublicInterceptorServer {

--- a/packages/zimic/src/interceptor/server/namespace/InterceptorServerNamespace.ts
+++ b/packages/zimic/src/interceptor/server/namespace/InterceptorServerNamespace.ts
@@ -3,7 +3,7 @@ import { createInterceptorServer } from '../factory';
 /**
  * A namespace of interceptor server resources for handling HTTP requests.
  *
- * @see {@link https://github.com/zimicjs/zimic#zimic-server `zimic server` API reference}
+ * @see {@link https://github.com/zimicjs/zimic#zimic-server-programmatic-usage `zimic server` programmatic usage}
  * @see {@link https://github.com/zimicjs/zimic#remote-http-interceptors Remote HTTP Interceptors} .
  */
 class InterceptorServerNamespace {
@@ -12,7 +12,7 @@ class InterceptorServerNamespace {
    *
    * @param options The options to create the server.
    * @returns The created server.
-   * @see {@link https://github.com/zimicjs/zimic#zimic-server `zimic server` API reference}
+   * @see {@link https://github.com/zimicjs/zimic#zimic-server-programmatic-usage `zimic server` programmatic usage}
    * @see {@link https://github.com/zimicjs/zimic#remote-http-interceptors Remote HTTP Interceptors} .
    */
   create = createInterceptorServer;

--- a/packages/zimic/src/typegen/index.ts
+++ b/packages/zimic/src/typegen/index.ts
@@ -2,7 +2,11 @@ import TypegenNamespace from './namespace/TypegenNamespace';
 
 export type { OpenAPITypegenOptions } from './openapi/generate';
 
-/** A namespace of type generation resources. */
+/**
+ * A namespace of type generation resources.
+ *
+ * @see {@link https://github.com/zimicjs/zimic#zimic-typegen `zimic typegen` API reference}
+ */
 export const typegen = Object.freeze(new TypegenNamespace());
 
 export type { TypegenNamespace };

--- a/packages/zimic/src/typegen/namespace/TypegenNamespace.ts
+++ b/packages/zimic/src/typegen/namespace/TypegenNamespace.ts
@@ -1,7 +1,17 @@
 import generateTypesFromOpenAPI from '../openapi/generate';
 
-/** A namespace of type generation resources. */
+/**
+ * A namespace of type generation resources.
+ *
+ * @see {@link https://github.com/zimicjs/zimic#zimic-typegen `zimic typegen` API reference}
+ */
 class TypegenNamespace {
+  /**
+   * Generates TypeScript types from an OpenAPI schema.
+   *
+   * @param options The options to use when generating the types.
+   * @see {@link https://github.com/zimicjs/zimic#zimic-typegen-programmatic-usage `zimic typegen` programmatic usage}
+   */
   generateFromOpenAPI = generateTypesFromOpenAPI;
 }
 

--- a/packages/zimic/src/typegen/openapi/generate.ts
+++ b/packages/zimic/src/typegen/openapi/generate.ts
@@ -68,6 +68,7 @@ function normalizeRawNodes(rawNodes: ts.Node[], context: TypeTransformContext, o
   return normalizedNodes;
 }
 
+/** The options to use when generating types from an OpenAPI schema. */
 export interface OpenAPITypegenOptions {
   /** The path to a local OpenAPI schema file. YAML and JSON are supported. */
   input: string;
@@ -100,6 +101,11 @@ export interface OpenAPITypegenOptions {
   filterFile?: string;
 }
 
+/**
+ * Generates TypeScript types from an OpenAPI schema.
+ *
+ * @param options The options to use when generating the types.
+ */
 async function generateTypesFromOpenAPI({
   input: inputFilePath,
   output: outputFilePath,

--- a/packages/zimic/src/typegen/openapi/generate.ts
+++ b/packages/zimic/src/typegen/openapi/generate.ts
@@ -68,13 +68,33 @@ function normalizeRawNodes(rawNodes: ts.Node[], context: TypeTransformContext, o
   return normalizedNodes;
 }
 
-/** The options to use when generating types from an OpenAPI schema. */
+/**
+ * The options to use when generating types from an OpenAPI schema.
+ *
+ * @see {@link https://github.com/zimicjs/zimic#zimic-typegen-programmatic-usage `zimic typegen` programmatic usage}
+ * @see {@link https://github.com/zimicjs/zimic#zimic-typegen-openapi` `zimic typegen openapi` API reference}
+ */
 export interface OpenAPITypegenOptions {
-  /** The path to a local OpenAPI schema file. YAML and JSON are supported. */
+  /**
+   * The path to a local OpenAPI schema file. YAML and JSON are supported.
+   *
+   * @example
+   *   './schema.yaml';
+   */
   input: string;
-  /** The path to write the generated types to. If not provided, the types will be written to stdout. */
+  /**
+   * The path to write the generated types to. If not provided, the types will be written to stdout.
+   *
+   * @example
+   *   './schema.ts';
+   */
   output?: string;
-  /** The name of the service to use in the generated types. */
+  /**
+   * The name of the service to use in the generated types.
+   *
+   * @example
+   *   'MyService';
+   */
   serviceName: string;
   /** Whether to include comments in the generated types. */
   includeComments: boolean;
@@ -90,13 +110,16 @@ export interface OpenAPITypegenOptions {
    * provided, they will be combined with OR, while negative filters will be combined with AND.
    *
    * @example
-   *   `GET /users`, `* /users`, `GET /users/*`, `GET /users/**\/*`, `!GET /users`;
+   *   ['GET /users', '* /users', 'GET,POST /users/*', 'DELETE /users/**\\/*', '!GET /notifications'];
    */
   filters?: string[];
   /**
    * A path to a file containing filter expressions. One expression is expected per line and the format is the same as
    * used in a `--filter` option. Comments are prefixed with `#`. A filter file can be used alongside additional
    * `--filter` expressions.
+   *
+   * @example
+   *   './filters.txt';
    */
   filterFile?: string;
 }
@@ -105,6 +128,7 @@ export interface OpenAPITypegenOptions {
  * Generates TypeScript types from an OpenAPI schema.
  *
  * @param options The options to use when generating the types.
+ * @see {@link https://github.com/zimicjs/zimic#zimic-typegen-programmatic-usage `zimic typegen` programmatic usage}
  */
 async function generateTypesFromOpenAPI({
   input: inputFilePath,


### PR DESCRIPTION
### Documentation
- [#zimic] Added a new section `zimic typegen openapi` to describe how to use the new typegen CLI being introduced in v0.8.
- [#zimic] Documented some resources that had no JSDoc comments before.

Closes #88.