### PR TITLE
feat(#zimic): support to URLs in typegen (#247)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2737,8 +2737,8 @@ Generate types from an OpenAPI schema.
 zimic typegen openapi <input>
 
 Positionals:
-  input  The path to a local OpenAPI schema file. YAML and JSON are supported.
-                                                             [string] [required]
+  input  The path to a local OpenAPI schema file or an URL to fetch it. Version
+         3.x is supported as YAML or JSON.                   [string] [required]
 
 Options:
   -o, --output        The path to write the generated types to. If not provided,
@@ -2769,10 +2769,20 @@ Options:
                       `--filter` expressions.                           [string]
 ```
 
-You can use this command to generate the types of a service from an OpenAPI schema file:
+You can use this command to generate types from a local OpenAPI file:
 
 ```bash
-zimic typegen openapi ./schema.yaml -o ./schema.ts --service-name MyService
+zimic typegen openapi ./schema.yaml \
+  --output ./schema.ts \
+  --service-name MyService
+```
+
+Or an URL to fetch it:
+
+```bash
+zimic typegen openapi https://example.com/api/openapi.yaml \
+  --output ./schema.ts \
+  --service-name MyService
 ```
 
 Then, you can use the types in your interceptors:
@@ -2787,35 +2797,33 @@ const interceptor = httpInterceptor.create<MyServiceSchema>({
 });
 ```
 
-> [!IMPORTANT]
->
-> Currently, Zimic only accepts file paths as inputs. If you need to fetch the OpenAPI schema from a URL, we recommend
-> first downloading it and then passing the file path to `zimic typegen`. An example using `curl`:
->
-> ```bash
-> curl https://my-service.com/api/openapi/schema.yaml -o ./schema.yaml
-> 
-> zimic typegen openapi ./schema.yaml -o ./schema.ts --service-name MyService
-> ```
-
 You can generate the types ignoring comments by using `--no-comments` or `--comments false`.
 
 ```bash
-zimic typegen openapi ./schema.yaml -o ./schema.ts --service-name MyService --no-comments
+zimic typegen openapi ./schema.yaml \
+  --output ./schema.ts \
+  --service-name MyService \
+  --no-comments
 ```
 
 By default, pruning is enabled, meaning that unused types are not outputted. If you want all types declared in the
 schema to be generated, you can use `--no-prune` or `--prune false`.
 
 ```bash
-zimic typegen openapi ./schema.yaml -o ./schema.ts --service-name MyService --no-prune
+zimic typegen openapi ./schema.yaml \
+  --output ./schema.ts \
+  --service-name MyService \
+  --no-prune
 ```
 
 You can also filter a subset of paths to generate types for. In conjunction with pruning, this is useful to reduce the
 size of the output file and only generate the types you need.
 
 ```bash
-zimic typegen openapi ./schema.yaml -o ./schema.ts --service-name MyService --filter 'GET /users**'
+zimic typegen openapi ./schema.yaml \
+  --output ./schema.ts \
+  --service-name MyService \
+  --filter 'GET /users**'
 ```
 
 When many filters are used, a filter file can be provided, where each line represents a filter expression and comments
@@ -2838,7 +2846,10 @@ GET,POST,PUT /workspaces
 ```
 
 ```bash
-zimic typegen openapi ./schema.yaml -o ./schema.ts --service-name MyService --filter-file ./filters.txt
+zimic typegen openapi ./schema.yaml \
+  --output ./schema.ts \
+  --service-name MyService \
+  --filter-file ./filters.txt
 ```
 
 #### `zimic typegen` programmatic usage

--- a/packages/zimic/package.json
+++ b/packages/zimic/package.json
@@ -74,7 +74,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "dev": "pnpm build --watch",
+    "dev": "tsup --watch",
     "cli": "node ./dist/cli.js",
     "build": "tsup",
     "lint": "eslint --ext 'ts,tsx' --cache --no-error-on-unmatched-pattern --fix",

--- a/packages/zimic/scripts/dev/typegen/generateFixtureTypes.ts
+++ b/packages/zimic/scripts/dev/typegen/generateFixtureTypes.ts
@@ -7,6 +7,7 @@ import { version } from '@@/package.json';
 
 import typegenFixtures from '@/cli/__tests__/typegen/fixtures/typegenFixtures';
 import { TypegenFixtureCase, TypegenFixtureCaseName, TypegenFixtureType } from '@/cli/__tests__/typegen/fixtures/types';
+import { TYPEGEN_HTTP_IMPORT_MODULE } from '@/typegen/openapi/transform/imports';
 import { runCommand } from '@/utils/processes';
 
 import { usingConsoleTime } from '../utils/console';
@@ -15,7 +16,10 @@ const FIXTURE_TYPEGEN_BATCH_SIZE = 15;
 
 async function normalizeOutputTypeImports(filePath: string) {
   const fileContent = await filesystem.readFile(filePath, 'utf-8');
-  const fileContentWithCorrectImports = fileContent.replace(/ from "zimic";/, " from '@/http';");
+  const fileContentWithCorrectImports = fileContent.replace(
+    new RegExp(` from "${TYPEGEN_HTTP_IMPORT_MODULE}";`),
+    " from '@/http';",
+  );
   await filesystem.writeFile(filePath, fileContentWithCorrectImports);
 }
 

--- a/packages/zimic/src/cli/__tests__/typegen/fixtures/openapiTypegenCases.ts
+++ b/packages/zimic/src/cli/__tests__/typegen/fixtures/openapiTypegenCases.ts
@@ -27,6 +27,12 @@ const openapiTypegenFixtureCases = {
       additionalArguments: ['--no-comments'],
       shouldWriteToStdout: true,
     },
+    {
+      inputFileName: 'simple.yaml',
+      expectedOutputFileName: 'simple.ts',
+      additionalArguments: ['--no-comments'],
+      shouldUseURLAsInput: true,
+    },
   ],
 
   pathParams: [

--- a/packages/zimic/src/cli/__tests__/typegen/fixtures/types.ts
+++ b/packages/zimic/src/cli/__tests__/typegen/fixtures/types.ts
@@ -9,4 +9,5 @@ export interface TypegenFixtureCase {
   expectedOutputFileName: string;
   additionalArguments: string[];
   shouldWriteToStdout?: boolean;
+  shouldUseURLAsInput?: boolean;
 }

--- a/packages/zimic/src/cli/cli.ts
+++ b/packages/zimic/src/cli/cli.ts
@@ -102,7 +102,9 @@ async function runCLI() {
           yargs
             .positional('input', {
               type: 'string',
-              description: 'The path to a local OpenAPI schema file. YAML and JSON are supported.',
+              description:
+                'The path to a local OpenAPI schema file or an URL to fetch it. ' +
+                'Version 3.x is supported as YAML or JSON.',
               demandOption: true,
             })
             .option('output', {

--- a/packages/zimic/src/typegen/openapi/generate.ts
+++ b/packages/zimic/src/typegen/openapi/generate.ts
@@ -76,10 +76,11 @@ function normalizeRawNodes(rawNodes: ts.Node[], context: TypeTransformContext, o
  */
 export interface OpenAPITypegenOptions {
   /**
-   * The path to a local OpenAPI schema file. YAML and JSON are supported.
+   * The path to a local OpenAPI schema file or an URL to fetch it. Version 3.x is supported as YAML or JSON.
    *
    * @example
    *   './schema.yaml';
+   *   'https://example.com/openapi/schema.yaml';
    */
   input: string;
   /**
@@ -131,7 +132,7 @@ export interface OpenAPITypegenOptions {
  * @see {@link https://github.com/zimicjs/zimic#zimic-typegen-programmatic-usage `zimic typegen` programmatic usage}
  */
 async function generateTypesFromOpenAPI({
-  input: inputFilePath,
+  input: inputFilePathOrURL,
   output: outputFilePath,
   serviceName,
   includeComments,
@@ -142,7 +143,7 @@ async function generateTypesFromOpenAPI({
   const filtersFromFile = filterFile ? await readPathFiltersFromFile(filterFile) : [];
   const filters = ignoreEmptyFilters([...filtersFromFile, ...filtersFromArguments]);
 
-  const rawNodes = await importTypesFromOpenAPI(inputFilePath);
+  const rawNodes = await importTypesFromOpenAPI(inputFilePathOrURL);
   const context = createTypeTransformationContext(serviceName, filters);
   const nodes = normalizeRawNodes(rawNodes, context, { prune });
 

--- a/packages/zimic/src/typegen/openapi/transform/imports.ts
+++ b/packages/zimic/src/typegen/openapi/transform/imports.ts
@@ -3,12 +3,13 @@ import { TypeTransformContext } from './context';
 
 /* istanbul ignore next -- @preserve
  * The root import module is defined at build time. The fallback is not expected to be used. */
-export const TYPEGEN_ROOT_IMPORT_MODULE = process.env.TYPEGEN_ROOT_IMPORT_MODULE ?? 'zimic';
+export const TYPEGEN_HTTP_IMPORT_MODULE = process.env.TYPEGEN_HTTP_IMPORT_MODULE ?? 'zimic/http';
 
 export function createImportDeclarations(context: TypeTransformContext) {
-  const rootTypeImports = Array.from(context.typeImports.http).sort().map(createImportSpecifier);
-  const rootImportDeclaration = createImportDeclaration(rootTypeImports, TYPEGEN_ROOT_IMPORT_MODULE, {
+  const httpTypeImports = Array.from(context.typeImports.http).sort().map(createImportSpecifier);
+  const httpImportDeclaration = createImportDeclaration(httpTypeImports, TYPEGEN_HTTP_IMPORT_MODULE, {
     typeOnly: true,
   });
-  return [rootImportDeclaration];
+
+  return [httpImportDeclaration];
 }

--- a/packages/zimic/src/typegen/openapi/transform/io.ts
+++ b/packages/zimic/src/typegen/openapi/transform/io.ts
@@ -2,7 +2,7 @@ import generateTypesFromOpenAPI, { SchemaObject, astToString as convertTypeASTTo
 import path from 'path';
 import ts from 'typescript';
 
-import { createFileURL } from '@/utils/urls';
+import { createFileURL, createURL } from '@/utils/urls';
 
 import { createBlobType, createNullType } from '../utils/types';
 
@@ -19,10 +19,18 @@ function transformSchemaObject(schemaObject: SchemaObject) {
   }
 }
 
-export async function importTypesFromOpenAPI(filePath: string) {
-  const fileURL = createFileURL(path.resolve(filePath));
+function convertFilePathOrURLToURL(filePathOrURL: string) {
+  try {
+    return createURL(filePathOrURL);
+  } catch {
+    return createFileURL(path.resolve(filePathOrURL));
+  }
+}
 
-  const rawNodes = await generateTypesFromOpenAPI(fileURL, {
+export async function importTypesFromOpenAPI(filePathOrURL: string) {
+  const schemaURL = convertFilePathOrURLToURL(filePathOrURL);
+
+  const rawNodes = await generateTypesFromOpenAPI(schemaURL, {
     alphabetize: false,
     additionalProperties: false,
     excludeDeprecated: false,

--- a/packages/zimic/tsup.config.ts
+++ b/packages/zimic/tsup.config.ts
@@ -10,6 +10,8 @@ export function pickKeys<Type, Key extends keyof Type>(object: Type, keys: Key[]
   );
 }
 
+const isDevelopment = process.env.npm_lifecycle_event === 'dev';
+
 const sharedConfig: Options = {
   bundle: true,
   splitting: true,
@@ -19,7 +21,7 @@ const sharedConfig: Options = {
   clean: true,
   env: {
     SERVER_ACCESS_CONTROL_MAX_AGE: '',
-    TYPEGEN_HTTP_IMPORT_MODULE: 'zimic/http',
+    TYPEGEN_HTTP_IMPORT_MODULE: isDevelopment ? '@/http' : 'zimic/http',
   },
 };
 

--- a/packages/zimic/tsup.config.ts
+++ b/packages/zimic/tsup.config.ts
@@ -19,7 +19,7 @@ const sharedConfig: Options = {
   clean: true,
   env: {
     SERVER_ACCESS_CONTROL_MAX_AGE: '',
-    TYPEGEN_ROOT_IMPORT_MODULE: 'zimic',
+    TYPEGEN_HTTP_IMPORT_MODULE: 'zimic/http',
   },
 };
 

--- a/packages/zimic/vitest.config.mts
+++ b/packages/zimic/vitest.config.mts
@@ -37,7 +37,7 @@ export const defaultConfig: UserConfig = {
   },
   define: {
     'process.env.SERVER_ACCESS_CONTROL_MAX_AGE': "'0'",
-    'process.env.TYPEGEN_ROOT_IMPORT_MODULE': "'@/http'",
+    'process.env.TYPEGEN_HTTP_IMPORT_MODULE': "'@/http'",
   },
   resolve: {
     alias: {


### PR DESCRIPTION
### Features
- [#zimic] Added support to an URL as input to `zimic typegen openapi`. If the input could not be parsed as a URL, a file path is assumed.

### Fixes
- [#zimic] Changed the import module from `zimic` to `zimic/http` in generated typescript files.

### Refactoring
- [#zimic] Simplified typegen import logic in development and tests.

Closes #247.