### PR TITLE
chore(ci): remove cache cancellation on conflict

### DIFF
--- a/.github/workflows/cache.yaml
+++ b/.github/workflows/cache.yaml
@@ -8,7 +8,7 @@ on:
 
 concurrency:
   group: cache
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_REMOTE_CACHE_TOKEN }}


### PR DESCRIPTION
### Chore
- [ci] Disabled the cache cancellation when another push to canary is registered.
