### PR TITLE
docs(#zimic): document breaking change guidelines (#266)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,22 @@ Zimic provides a flexible and type-safe way to mock HTTP requests.
 - :bulb: **Simplicity**. Zimic was designed from scratch to encourage clarity, simplicity and developer experience in
   your mocks. Check our [getting started guide](#getting-started) and starting mocking!
 
+> [!NOTE]
+>
+> Zimic has gone a long way in v0, but we're not yet v1!
+>
+> Reviews and improvements to the public API are possible, so breaking changes may **_exceptionally_** land without a
+> major release during v0. Despite of that, we do not expect big mental model shifts. Usually, migrating to a new Zimic
+> release requires minimal to no refactoring. During v0, we will follow these guidelines:
+>
+> - Breaking changes, if any, will be delivered in the next **_minor_** version.
+> - Breaking changes, if any, will be documented in the [version release](https://github.com/zimicjs/zimic/releases),
+>   along with a migration guide detailing the introduced changes and suggesting steps to migrate.
+>
+> From v0.8 onwards, we expect Zimic's public API to become more stable. If you'd like to share any feedback, please
+> feel free to [open an issue](https://github.com/zimicjs/zimic/issues/new) or
+> [create a discussion](https://github.com/zimicjs/zimic/discussions/new/choose)!
+
 ---
 
 ## Table of contents


### PR DESCRIPTION
### Documentation
- [#zimic] Added a section to `README.md` detailing how breaking changes will be handled during v0.

Closes #266.
