### PR TITLE
docs(#zimic): add readme badges (#265)

### DIFF
--- a/.github/workflows/release-npm.yaml
+++ b/.github/workflows/release-npm.yaml
@@ -104,7 +104,8 @@ jobs:
             const tag = context.ref.replace(/^refs\/tags\//, '');
             const version = tag.replace(/^v/, '');
 
-            const { owner, repo: repository } = context.repo.owner;
+            const { owner, repo: repository } = context.repo;
+            const perPage = 100;
 
             let milestone = undefined;
 
@@ -116,14 +117,14 @@ jobs:
                 repo: repository,
                 state: 'open',
                 page,
-                per_page: 100,
+                per_page: perPage,
               });
 
-              if (milestones.data.length === 0) {
+              milestone = milestones.data.find((milestone) => milestone.title === tag);
+
+              if (milestones.data.length < perPage) {
                 break;
               }
-
-              milestone = milestones.data.find((milestone) => milestone.title === tag);
             }
 
             if (milestone) {
@@ -136,12 +137,8 @@ jobs:
                   milestone: milestone.number,
                   state: 'all',
                   page,
-                  per_page: 100,
+                  per_page: perPage,
                 });
-
-                if (issues.data.length === 0) {
-                  break;
-                }
 
                 for (const issue of issues.data) {
                   console.log(`Creating release comment on issue #${issue.number}...`);
@@ -156,6 +153,10 @@ jobs:
                       `- [**:package: NPM package**](https://www.npmjs.com/package/${repository}/v/${version})`,
                     ].join('\n'),
                   });
+                }
+
+                if (issues.data.length < perPage) {
+                  break;
                 }
               }
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@
   <a href="https://github.com/zimicjs/zimic/issues/new">Issues</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
   <a href="https://github.com/orgs/zimicjs/projects/1/views/5">Roadmap</a>
+
+  <br>
+
+[![Latest](https://img.shields.io/github/v/release/zimicjs/zimic?label=Latest&color=0E69BE&labelColor=353C43)](https://github.com/zimicjs/zimic/releases)&nbsp;
+[![Canary](https://img.shields.io/github/v/release/zimicjs/zimic?include_prereleases&label=Canary&color=0E69BE&labelColor=353C43)](https://github.com/zimicjs/zimic/releases)&nbsp;
+[![NPM Downloads](https://img.shields.io/npm/dm/zimic?style=flat&logo=npm&color=0E69BE&label=Downloads&labelColor=353C43)](https://www.npmjs.com/package/zimic)&nbsp;
+[![Stars](https://img.shields.io/github/stars/zimicjs/zimic)](https://github.com/zimicjs/zimic)
+
+[![CI](https://github.com/zimicjs/zimic/actions/workflows/ci.yaml/badge.svg?branch=canary)](https://github.com/zimicjs/zimic/actions/workflows/ci.yaml)&nbsp;
+[![Coverage](https://img.shields.io/badge/Coverage-100%25-31C654?labelColor=353C43)](https://github.com/zimicjs/zimic/actions)&nbsp;
+[![License](https://img.shields.io/github/license/zimicjs/zimic?color=0E69BE&label=License&labelColor=353C43)](https://github.com/zimicjs/zimic/blob/canary/LICENSE.md)
+
 </div>
 
 ---

--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@
 
 <div align="center">
 
-[![Latest](https://img.shields.io/github/v/release/zimicjs/zimic?label=Latest&color=0E69BE&labelColor=353C43)](https://github.com/zimicjs/zimic/releases)&nbsp;
-[![Canary](https://img.shields.io/github/v/release/zimicjs/zimic?include_prereleases&label=Canary&color=0E69BE&labelColor=353C43)](https://github.com/zimicjs/zimic/releases)&nbsp;
 [![CI](https://github.com/zimicjs/zimic/actions/workflows/ci.yaml/badge.svg?branch=canary)](https://github.com/zimicjs/zimic/actions/workflows/ci.yaml)&nbsp;
 [![Coverage](https://img.shields.io/badge/Coverage-100%25-31C654?labelColor=353C43)](https://github.com/zimicjs/zimic/actions)&nbsp;
 [![License](https://img.shields.io/github/license/zimicjs/zimic?color=0E69BE&label=License&labelColor=353C43)](https://github.com/zimicjs/zimic/blob/canary/LICENSE.md)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   TypeScript-first HTTP request mocking
 </p>
 
-<div align="center">
+<p align="center">
   <a href="https://www.npmjs.com/package/zimic">npm</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
   <a href="#table-of-contents">Docs</a>
@@ -20,8 +20,9 @@
   <a href="https://github.com/zimicjs/zimic/issues/new">Issues</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
   <a href="https://github.com/orgs/zimicjs/projects/1/views/5">Roadmap</a>
+</p>
 
-<br/>
+<div align="center">
 
 [![Latest](https://img.shields.io/github/v/release/zimicjs/zimic?label=Latest&color=0E69BE&labelColor=353C43)](https://github.com/zimicjs/zimic/releases)&nbsp;
 [![Canary](https://img.shields.io/github/v/release/zimicjs/zimic?include_prereleases&label=Canary&color=0E69BE&labelColor=353C43)](https://github.com/zimicjs/zimic/releases)&nbsp;

--- a/README.md
+++ b/README.md
@@ -21,16 +21,15 @@
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
   <a href="https://github.com/orgs/zimicjs/projects/1/views/5">Roadmap</a>
 
-  <br>
+<br/>
 
 [![Latest](https://img.shields.io/github/v/release/zimicjs/zimic?label=Latest&color=0E69BE&labelColor=353C43)](https://github.com/zimicjs/zimic/releases)&nbsp;
 [![Canary](https://img.shields.io/github/v/release/zimicjs/zimic?include_prereleases&label=Canary&color=0E69BE&labelColor=353C43)](https://github.com/zimicjs/zimic/releases)&nbsp;
-[![NPM Downloads](https://img.shields.io/npm/dm/zimic?style=flat&logo=npm&color=0E69BE&label=Downloads&labelColor=353C43)](https://www.npmjs.com/package/zimic)&nbsp;
-[![Stars](https://img.shields.io/github/stars/zimicjs/zimic)](https://github.com/zimicjs/zimic)
-
 [![CI](https://github.com/zimicjs/zimic/actions/workflows/ci.yaml/badge.svg?branch=canary)](https://github.com/zimicjs/zimic/actions/workflows/ci.yaml)&nbsp;
 [![Coverage](https://img.shields.io/badge/Coverage-100%25-31C654?labelColor=353C43)](https://github.com/zimicjs/zimic/actions)&nbsp;
 [![License](https://img.shields.io/github/license/zimicjs/zimic?color=0E69BE&label=License&labelColor=353C43)](https://github.com/zimicjs/zimic/blob/canary/LICENSE.md)
+[![NPM Downloads](https://img.shields.io/npm/dm/zimic?style=flat&logo=npm&color=0E69BE&label=Downloads&labelColor=353C43)](https://www.npmjs.com/package/zimic)&nbsp;
+[![Stars](https://img.shields.io/github/stars/zimicjs/zimic)](https://github.com/zimicjs/zimic)&nbsp;
 
 </div>
 


### PR DESCRIPTION
### Documentation
- [#zimic] Added badges to `README.md`.

### Fixes
- [#zimic] Corrected the logic to get the owner and repository names in the NPM release action.

Closes #265.