### PR TITLE
fix(#zimic): skip remote clearing if web socket client is not running

### DIFF
--- a/packages/zimic/src/interceptor/http/interceptorWorker/RemoteHttpInterceptorWorker.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/RemoteHttpInterceptorWorker.ts
@@ -1,7 +1,7 @@
 import { HttpResponse } from '@/http/types/requests';
 import { HttpMethod, HttpServiceSchema } from '@/http/types/schema';
 import { HttpHandlerCommit, InterceptorServerWebSocketSchema } from '@/interceptor/server/types/schema';
-import { importCrypto, IsomorphicCrypto } from '@/utils/crypto';
+import { importCrypto } from '@/utils/crypto';
 import { deserializeRequest, serializeResponse } from '@/utils/fetch';
 import { importMSWBrowser, importMSWNode } from '@/utils/msw';
 import { createURL, ensureUniquePathParams, excludeNonPathParams, ExtendedURL } from '@/utils/urls';
@@ -27,8 +27,6 @@ interface HttpHandler {
 class RemoteHttpInterceptorWorker extends HttpInterceptorWorker {
   readonly type: 'remote';
 
-  private _crypto?: IsomorphicCrypto;
-
   private _webSocketClient: WebSocketClient<InterceptorServerWebSocketSchema>;
   private httpHandlers = new Map<HttpHandler['id'], HttpHandler>();
 
@@ -46,13 +44,6 @@ class RemoteHttpInterceptorWorker extends HttpInterceptorWorker {
     const webSocketServerURL = createURL(serverURL);
     webSocketServerURL.protocol = serverURL.protocol.replace(/^http(s)?:$/, 'ws$1:');
     return webSocketServerURL;
-  }
-
-  private async crypto() {
-    if (!this._crypto) {
-      this._crypto = await importCrypto();
-    }
-    return this._crypto;
   }
 
   webSocketClient() {
@@ -132,7 +123,7 @@ class RemoteHttpInterceptorWorker extends HttpInterceptorWorker {
       throw new NotStartedHttpInterceptorError();
     }
 
-    const crypto = await this.crypto();
+    const crypto = await importCrypto();
     const url = excludeNonPathParams(createURL(rawURL)).toString();
     ensureUniquePathParams(url);
 

--- a/packages/zimic/src/webSocket/WebSocketHandler.ts
+++ b/packages/zimic/src/webSocket/WebSocketHandler.ts
@@ -1,7 +1,7 @@
 import ClientSocket from 'isomorphic-ws';
 
 import { Collection } from '@/types/utils';
-import { IsomorphicCrypto, importCrypto } from '@/utils/crypto';
+import { importCrypto } from '@/utils/crypto';
 import { isClientSide } from '@/utils/environment';
 import {
   DEFAULT_WEB_SOCKET_LIFECYCLE_TIMEOUT,
@@ -18,7 +18,6 @@ import { WebSocket } from './types';
 abstract class WebSocketHandler<Schema extends WebSocket.ServiceSchema> {
   private sockets = new Set<ClientSocket>();
 
-  private _crypto?: IsomorphicCrypto;
   private _socketTimeout: number;
   private _messageTimeout: number;
 
@@ -35,13 +34,6 @@ abstract class WebSocketHandler<Schema extends WebSocket.ServiceSchema> {
   }
 
   abstract isRunning(): boolean;
-
-  private async crypto() {
-    if (!this._crypto) {
-      this._crypto = await importCrypto();
-    }
-    return this._crypto;
-  }
 
   socketTimeout() {
     return this._socketTimeout;
@@ -190,7 +182,7 @@ abstract class WebSocketHandler<Schema extends WebSocket.ServiceSchema> {
     channel: Channel,
     eventData: WebSocket.ServiceEventMessage<Schema, Channel>['data'],
   ) {
-    const crypto = await this.crypto();
+    const crypto = await importCrypto();
 
     const eventMessage: WebSocket.ServiceEventMessage<Schema, Channel> = {
       id: crypto.randomUUID(),
@@ -266,7 +258,7 @@ abstract class WebSocketHandler<Schema extends WebSocket.ServiceSchema> {
     request: WebSocket.ServiceEventMessage<Schema, Channel>,
     replyData: WebSocket.ServiceReplyMessage<Schema, Channel>['data'],
   ) {
-    const crypto = await this.crypto();
+    const crypto = await importCrypto();
 
     const replyMessage: WebSocket.ServiceReplyMessage<Schema, Channel> = {
       id: crypto.randomUUID(),


### PR DESCRIPTION
### Fixes
- [#zimic] Added a check to only apply clearing operations to a remote interceptor server if the web socket client is running. Previously, sending Ctrl + C to the `load.ts` scripts in the Playwright and Next.js App Router examples would cause an error. In those cases, the Ctrl + C would already be handled by the interceptor server, which would close all socket connections and prepare to stop. Therefore, it is expected that the web socket client may be already closed when `interceptor.stop()` is called and this should not cause an error.

### Refactoring
- [#zimic] Removed unnecessary `crypto` attributes in some classes.
