### PR TITLE
fix(#zimic): abort waiting for a web socket reply when worker was stopped (#289)

### DIFF
--- a/apps/zimic-test-client/tests/v0/interceptor/thirdParty/shared/default.ts
+++ b/apps/zimic-test-client/tests/v0/interceptor/thirdParty/shared/default.ts
@@ -3,7 +3,7 @@ import { JSONSerialized } from 'zimic0';
 import { HttpRequest, HttpResponse, HttpSearchParams } from 'zimic0/http';
 import { httpInterceptor, HttpInterceptorType } from 'zimic0/interceptor/http';
 
-import { importCrypto } from '@tests/utils/crypto';
+import { importCrypto, IsomorphicCrypto } from '@tests/utils/crypto';
 
 import { ClientTestOptionsByWorkerType, ZIMIC_SERVER_PORT } from '.';
 import {
@@ -18,17 +18,13 @@ import {
   Notification,
 } from './schema';
 
-async function getAuthBaseURL(type: HttpInterceptorType) {
-  const crypto = await importCrypto();
-
+function getAuthBaseURL(type: HttpInterceptorType, crypto: IsomorphicCrypto) {
   return type === 'local'
     ? 'http://localhost:3000'
     : `http://localhost:${ZIMIC_SERVER_PORT}/auth-${crypto.randomUUID()}`;
 }
 
-async function getNotificationsBaseURL(type: HttpInterceptorType) {
-  const crypto = await importCrypto();
-
+function getNotificationsBaseURL(type: HttpInterceptorType, crypto: IsomorphicCrypto) {
   return type === 'local'
     ? 'http://localhost:3001'
     : `http://localhost:${ZIMIC_SERVER_PORT}/notifications-${crypto.randomUUID()}`;
@@ -37,15 +33,17 @@ async function getNotificationsBaseURL(type: HttpInterceptorType) {
 async function declareDefaultClientTests(options: ClientTestOptionsByWorkerType) {
   const { platform, type, fetch } = options;
 
+  const crypto = await importCrypto();
+
   const authInterceptor = httpInterceptor.create<AuthServiceSchema>({
     type,
-    baseURL: await getAuthBaseURL(type),
+    baseURL: getAuthBaseURL(type, crypto),
     saveRequests: true,
   });
 
   const notificationInterceptor = httpInterceptor.create<NotificationServiceSchema>({
     type,
-    baseURL: await getNotificationsBaseURL(type),
+    baseURL: getNotificationsBaseURL(type, crypto),
     saveRequests: true,
   });
 
@@ -88,9 +86,7 @@ async function declareDefaultClientTests(options: ClientTestOptionsByWorkerType)
     };
   }
 
-  describe('Users', async () => {
-    const crypto = await importCrypto();
-
+  describe('Users', () => {
     const user: User = {
       id: crypto.randomUUID(),
       name: 'Name',
@@ -599,9 +595,7 @@ async function declareDefaultClientTests(options: ClientTestOptionsByWorkerType)
     });
   });
 
-  describe('Notifications', async () => {
-    const crypto = await importCrypto();
-
+  describe('Notifications', () => {
     const notification: Notification = {
       id: crypto.randomUUID(),
       userId: crypto.randomUUID(),

--- a/packages/zimic/src/cli/__tests__/server.cli.node.test.ts
+++ b/packages/zimic/src/cli/__tests__/server.cli.node.test.ts
@@ -11,10 +11,12 @@ import { PossiblePromise } from '@/types/utils';
 import { importCrypto } from '@/utils/crypto';
 import { HttpServerStartTimeoutError, HttpServerStopTimeoutError } from '@/utils/http';
 import { CommandError, PROCESS_EXIT_EVENTS } from '@/utils/processes';
+import { waitForDelay } from '@/utils/time';
 import WebSocketClient from '@/webSocket/WebSocketClient';
 import WebSocketServer from '@/webSocket/WebSocketServer';
 import { usingIgnoredConsole } from '@tests/utils/console';
 import { expectFetchError } from '@tests/utils/fetch';
+import { waitFor } from '@tests/utils/time';
 
 import runCLI from '../cli';
 import { serverSingleton as server } from '../server/start';
@@ -458,8 +460,6 @@ describe('CLI (server)', async () => {
     });
 
     it('should stop the server even if a client is connected', async () => {
-      const exitEventListeners = watchExitEventListeners(PROCESS_EXIT_EVENTS[0]);
-
       processArgvSpy.mockReturnValue(['node', './dist/cli.js', 'server', 'start']);
 
       await usingIgnoredConsole(['log'], async (spies) => {
@@ -484,11 +484,7 @@ describe('CLI (server)', async () => {
           await webSocketClient.start();
           expect(webSocketClient.isRunning()).toBe(true);
 
-          expect(exitEventListeners).toHaveLength(1);
-
-          for (const listener of exitEventListeners) {
-            await listener();
-          }
+          await server?.stop();
 
           expect(server!.isRunning()).toBe(false);
           expect(webSocketClient.isRunning()).toBe(false);
@@ -506,8 +502,6 @@ describe('CLI (server)', async () => {
     ])(
       'should show an error if logging is enabled when a request is received and does not match any interceptors: override default $overrideDefault',
       async ({ overrideDefault }) => {
-        const exitEventListeners = watchExitEventListeners(PROCESS_EXIT_EVENTS[0]);
-
         processArgvSpy.mockReturnValue([
           'node',
           './dist/cli.js',
@@ -526,52 +520,45 @@ describe('CLI (server)', async () => {
           });
         }
 
-        try {
-          await usingIgnoredConsole(['log', 'warn', 'error'], async (spies) => {
-            await runCLI();
+        await usingIgnoredConsole(['log', 'warn', 'error'], async (spies) => {
+          await runCLI();
 
-            expect(server).toBeDefined();
-            expect(server!.isRunning()).toBe(true);
-            expect(server!.hostname()).toBe('localhost');
-            expect(server!.port()).toBeGreaterThan(0);
+          expect(server).toBeDefined();
+          expect(server!.isRunning()).toBe(true);
+          expect(server!.hostname()).toBe('localhost');
+          expect(server!.port()).toBeGreaterThan(0);
 
-            expect(spies.log).toHaveBeenCalledTimes(1);
-            expect(spies.warn).toHaveBeenCalledTimes(0);
-            expect(spies.error).toHaveBeenCalledTimes(0);
+          expect(spies.log).toHaveBeenCalledTimes(1);
+          expect(spies.warn).toHaveBeenCalledTimes(0);
+          expect(spies.error).toHaveBeenCalledTimes(0);
 
-            expect(spies.log).toHaveBeenCalledWith(
-              `${chalk.cyan('[zimic]')}`,
-              `Server is running on http://localhost:${server!.port()}`,
-            );
+          expect(spies.log).toHaveBeenCalledWith(
+            `${chalk.cyan('[zimic]')}`,
+            `Server is running on http://localhost:${server!.port()}`,
+          );
 
-            const request = new Request(`http://localhost:${server!.port()}`, { method: 'GET' });
+          const request = new Request(`http://localhost:${server!.port()}`, { method: 'GET' });
 
-            const response = fetch(request);
-            await expectFetchError(response);
+          const response = fetch(request);
+          await expectFetchError(response);
 
-            expect(spies.log).toHaveBeenCalledTimes(1);
-            expect(spies.warn).toHaveBeenCalledTimes(0);
-            expect(spies.error).toHaveBeenCalledTimes(1);
+          expect(spies.log).toHaveBeenCalledTimes(1);
+          expect(spies.warn).toHaveBeenCalledTimes(0);
+          expect(spies.error).toHaveBeenCalledTimes(1);
 
-            const errorMessage = spies.error.mock.calls[0].join(' ');
-            await verifyUnhandledRequestMessage(errorMessage, {
-              type: 'error',
-              platform: 'node',
-              request,
-            });
+          const errorMessage = spies.error.mock.calls[0].join(' ');
+          await verifyUnhandledRequestMessage(errorMessage, {
+            type: 'error',
+            platform: 'node',
+            request,
           });
-        } finally {
-          for (const listener of exitEventListeners) {
-            await listener();
-          }
-        }
+        });
       },
     );
 
     it.each([{ overrideDefault: false }, { overrideDefault: 'static' }, { overrideDefault: 'function' }])(
       'should not show an error if logging is disabled when a request is received and does not match any interceptors: override default $overrideDefault',
       async ({ overrideDefault }) => {
-        const exitEventListeners = watchExitEventListeners(PROCESS_EXIT_EVENTS[0]);
         processArgvSpy.mockReturnValue([
           'node',
           './dist/cli.js',
@@ -586,44 +573,95 @@ describe('CLI (server)', async () => {
           httpInterceptor.default.onUnhandledRequest(vi.fn());
         }
 
-        try {
-          await usingIgnoredConsole(['log', 'warn', 'error'], async (spies) => {
-            await runCLI();
+        await usingIgnoredConsole(['log', 'warn', 'error'], async (spies) => {
+          await runCLI();
 
-            expect(server).toBeDefined();
-            expect(server!.isRunning()).toBe(true);
-            expect(server!.hostname()).toBe('localhost');
-            expect(server!.port()).toBeGreaterThan(0);
+          expect(server).toBeDefined();
+          expect(server!.isRunning()).toBe(true);
+          expect(server!.hostname()).toBe('localhost');
+          expect(server!.port()).toBeGreaterThan(0);
 
-            expect(spies.log).toHaveBeenCalledTimes(1);
-            expect(spies.warn).toHaveBeenCalledTimes(0);
-            expect(spies.error).toHaveBeenCalledTimes(0);
+          expect(spies.log).toHaveBeenCalledTimes(1);
+          expect(spies.warn).toHaveBeenCalledTimes(0);
+          expect(spies.error).toHaveBeenCalledTimes(0);
 
-            expect(spies.log).toHaveBeenCalledWith(
-              `${chalk.cyan('[zimic]')}`,
-              `Server is running on http://localhost:${server!.port()}`,
-            );
+          expect(spies.log).toHaveBeenCalledWith(
+            `${chalk.cyan('[zimic]')}`,
+            `Server is running on http://localhost:${server!.port()}`,
+          );
 
-            const request = new Request(`http://localhost:${server!.port()}`, { method: 'GET' });
+          const request = new Request(`http://localhost:${server!.port()}`, { method: 'GET' });
 
-            const response = fetch(request);
-            await expectFetchError(response);
+          const response = fetch(request);
+          await expectFetchError(response);
 
-            expect(spies.log).toHaveBeenCalledTimes(1);
-            expect(spies.warn).toHaveBeenCalledTimes(0);
-            expect(spies.error).toHaveBeenCalledTimes(0);
-          });
-        } finally {
-          for (const listener of exitEventListeners) {
-            await listener();
-          }
-        }
+          expect(spies.log).toHaveBeenCalledTimes(1);
+          expect(spies.warn).toHaveBeenCalledTimes(0);
+          expect(spies.error).toHaveBeenCalledTimes(0);
+        });
       },
     );
 
     it('should log an error and reject the request if it could not be handled due to an error', async () => {
-      const exitEventListeners = watchExitEventListeners(PROCESS_EXIT_EVENTS[0]);
+      processArgvSpy.mockReturnValue([
+        'node',
+        './dist/cli.js',
+        'server',
+        'start',
+        '--port',
+        '5001',
+        '--log-unhandled-requests',
+      ]);
 
+      const interceptor = createHttpInterceptor<{
+        '/users': {
+          GET: { response: { 204: {} } };
+        };
+      }>({
+        type: 'remote',
+        baseURL: 'http://localhost:5001',
+      });
+
+      const webSocketServerRequestSpy = vi.spyOn(WebSocketServer.prototype, 'request');
+
+      try {
+        await usingIgnoredConsole(['error', 'log'], async (spies) => {
+          await runCLI();
+
+          expect(server).toBeDefined();
+          expect(server!.isRunning()).toBe(true);
+          expect(server!.hostname()).toBe('localhost');
+          expect(server!.port()).toBe(5001);
+
+          await interceptor.start();
+          await interceptor.get('/users').respond({ status: 204 });
+
+          const error = new Error('An error ocurred.');
+          webSocketServerRequestSpy.mockRejectedValueOnce(error);
+
+          const request = new Request('http://localhost:5001/users', { method: 'GET' });
+          const fetchPromise = fetch(request);
+          await expectFetchError(fetchPromise);
+
+          expect(server!.isRunning()).toBe(true);
+
+          expect(spies.error).toHaveBeenCalledTimes(2);
+          expect(spies.error.mock.calls[0]).toEqual([error]);
+
+          const errorMessage = spies.error.mock.calls[1].join(' ');
+          await verifyUnhandledRequestMessage(errorMessage, {
+            type: 'error',
+            platform: 'node',
+            request,
+          });
+        });
+      } finally {
+        webSocketServerRequestSpy.mockRestore();
+        await interceptor.stop();
+      }
+    });
+
+    it('should abort pending requests if a worker is reset while waiting for a response', async () => {
       processArgvSpy.mockReturnValue([
         'node',
         './dist/cli.js',
@@ -653,33 +691,42 @@ describe('CLI (server)', async () => {
           expect(server!.port()).toBe(5001);
 
           await interceptor.start();
-          await interceptor.get('/users').respond({ status: 204 });
+          expect(interceptor.isRunning()).toBe(true);
 
-          const error = new Error('An error ocurred.');
-          vi.spyOn(WebSocketServer.prototype, 'request').mockRejectedValue(error);
+          let wasResponseFactoryCalled = false;
 
-          const request = new Request('http://localhost:5001/users', { method: 'GET' });
-          const fetchPromise = fetch(request);
-          await expectFetchError(fetchPromise);
+          const responseFactory = vi.fn(async () => {
+            wasResponseFactoryCalled = true;
 
-          expect(server!.isRunning()).toBe(true);
+            await waitForDelay(5000);
 
-          expect(spies.error).toHaveBeenCalledTimes(2);
-          expect(spies.error.mock.calls[0]).toEqual([error]);
-
-          const errorMessage = spies.error.mock.calls[1].join(' ');
-          await verifyUnhandledRequestMessage(errorMessage, {
-            type: 'error',
-            platform: 'node',
-            request,
+            /* istanbul ignore next -- @preserve
+             * This code is unreachable because the request is aborted before the response is sent. */
+            return { status: 204 } as const;
           });
+
+          await interceptor.get('/users').respond(responseFactory);
+
+          const onFetchError = vi.fn();
+          const fetchPromise = fetch('http://localhost:5001/users', { method: 'GET' }).catch(onFetchError);
+
+          await waitFor(() => {
+            expect(wasResponseFactoryCalled).toBe(true);
+          });
+
+          await interceptor.stop();
+          expect(interceptor.isRunning()).toBe(false);
+
+          await fetchPromise;
+
+          await waitFor(() => {
+            expect(onFetchError).toHaveBeenCalled();
+          });
+
+          expect(spies.error).not.toHaveBeenCalled();
         });
       } finally {
         await interceptor.stop();
-
-        for (const listener of exitEventListeners) {
-          await listener();
-        }
       }
     });
   });

--- a/packages/zimic/src/interceptor/server/InterceptorServer.ts
+++ b/packages/zimic/src/interceptor/server/InterceptorServer.ts
@@ -156,7 +156,7 @@ class InterceptorServer implements PublicInterceptorServer {
     if (isWorkerNoLongerCommitted) {
       // When a worker is no longer committed, we should abort all requests that were using it.
       // This ensures that we only wait for responses from committed worker sockets.
-      this.webSocketServer().abortRequests([socket]);
+      this.webSocketServer().abortSocketMessages([socket]);
     } else {
       for (const handler of handlersToResetTo) {
         this.registerHttpHandlerGroup(handler, socket);
@@ -193,9 +193,9 @@ class InterceptorServer implements PublicInterceptorServer {
     this.knownWorkerSockets.add(socket);
   }
 
-  private removeHttpHandlerGroupsBySocket(socketToRemove: Socket) {
+  private removeHttpHandlerGroupsBySocket(socket: Socket) {
     for (const [method, handlerGroups] of Object.entries(this.httpHandlerGroups)) {
-      this.httpHandlerGroups[method] = handlerGroups.filter((handlerGroup) => handlerGroup.socket !== socketToRemove);
+      this.httpHandlerGroups[method] = handlerGroups.filter((handlerGroup) => handlerGroup.socket !== socket);
     }
   }
 

--- a/packages/zimic/src/interceptor/server/InterceptorServer.ts
+++ b/packages/zimic/src/interceptor/server/InterceptorServer.ts
@@ -10,6 +10,7 @@ import { deserializeResponse, serializeRequest } from '@/utils/fetch';
 import { getHttpServerPort, startHttpServer, stopHttpServer } from '@/utils/http';
 import { PROCESS_EXIT_EVENTS } from '@/utils/processes';
 import { createRegexFromURL, createURL, excludeNonPathParams } from '@/utils/urls';
+import { WebSocketMessageAbortError } from '@/utils/webSocket';
 import { WebSocket } from '@/webSocket/types';
 import WebSocketServer from '@/webSocket/WebSocketServer';
 
@@ -147,11 +148,19 @@ class InterceptorServer implements PublicInterceptorServer {
     message: WebSocket.ServiceEventMessage<InterceptorServerWebSocketSchema, 'interceptors/workers/use/reset'>,
     socket: Socket,
   ) => {
-    this.removeWorkerSocket(socket);
+    this.removeHttpHandlerGroupsBySocket(socket);
 
-    const resetCommits = message.data ?? [];
-    for (const commit of resetCommits) {
-      this.registerHttpHandlerGroup(commit, socket);
+    const handlersToResetTo = message.data;
+    const isWorkerNoLongerCommitted = handlersToResetTo === undefined;
+
+    if (isWorkerNoLongerCommitted) {
+      // When a worker is no longer committed, we should abort all requests that were using it.
+      // This ensures that we only wait for responses from committed worker sockets.
+      this.webSocketServer().abortRequests([socket]);
+    } else {
+      for (const handler of handlersToResetTo) {
+        this.registerHttpHandlerGroup(handler, socket);
+      }
     }
 
     this.registerWorkerSocketIfUnknown(socket);
@@ -177,14 +186,14 @@ class InterceptorServer implements PublicInterceptorServer {
     }
 
     socket.addEventListener('close', () => {
-      this.removeWorkerSocket(socket);
+      this.removeHttpHandlerGroupsBySocket(socket);
       this.knownWorkerSockets.delete(socket);
     });
 
     this.knownWorkerSockets.add(socket);
   }
 
-  private removeWorkerSocket(socketToRemove: Socket) {
+  private removeHttpHandlerGroupsBySocket(socketToRemove: Socket) {
     for (const [method, handlerGroups] of Object.entries(this.httpHandlerGroups)) {
       this.httpHandlerGroups[method] = handlerGroups.filter((handlerGroup) => handlerGroup.socket !== socketToRemove);
     }
@@ -249,8 +258,12 @@ class InterceptorServer implements PublicInterceptorServer {
 
       nodeResponse.destroy();
     } catch (error) {
-      console.error(error);
-      await this.logUnhandledRequest(request);
+      const isMessageAbortError = error instanceof WebSocketMessageAbortError;
+
+      if (!isMessageAbortError) {
+        console.error(error);
+        await this.logUnhandledRequest(request);
+      }
 
       nodeResponse.destroy();
     }

--- a/packages/zimic/src/utils/webSocket.ts
+++ b/packages/zimic/src/utils/webSocket.ts
@@ -33,7 +33,7 @@ export class WebSocketCloseTimeoutError extends WebSocketTimeoutError {
 }
 
 export const DEFAULT_WEB_SOCKET_LIFECYCLE_TIMEOUT = 60 * 1000;
-export const DEFAULT_WEB_SOCKET_MESSAGE_TIMEOUT = 5 * 60 * 1000;
+export const DEFAULT_WEB_SOCKET_MESSAGE_TIMEOUT = 3 * 60 * 1000;
 
 export async function waitForOpenClientSocket(
   socket: ClientSocket,

--- a/packages/zimic/src/utils/webSocket.ts
+++ b/packages/zimic/src/utils/webSocket.ts
@@ -18,6 +18,13 @@ export class WebSocketMessageTimeoutError extends WebSocketTimeoutError {
   }
 }
 
+export class WebSocketMessageAbortError extends WebSocketTimeoutError {
+  constructor() {
+    super('Web socket message was aborted.');
+    this.name = 'WebSocketMessageAbortError';
+  }
+}
+
 export class WebSocketCloseTimeoutError extends WebSocketTimeoutError {
   constructor(reachedTimeout: number) {
     super(`Web socket close timed out after ${reachedTimeout}ms.`);

--- a/packages/zimic/src/webSocket/WebSocketClient.ts
+++ b/packages/zimic/src/webSocket/WebSocketClient.ts
@@ -45,7 +45,12 @@ class WebSocketClient<Schema extends WebSocket.ServiceSchema> extends WebSocketH
   }
 
   async stop() {
-    await super.closeClientSockets(this.socket ? [this.socket] : []);
+    super.removeAllChannelListeners();
+
+    const sockets = this.socket ? [this.socket] : [];
+    super.abortRequests(sockets);
+    await super.closeClientSockets(sockets);
+
     this.socket = undefined;
   }
 }

--- a/packages/zimic/src/webSocket/WebSocketClient.ts
+++ b/packages/zimic/src/webSocket/WebSocketClient.ts
@@ -48,7 +48,7 @@ class WebSocketClient<Schema extends WebSocket.ServiceSchema> extends WebSocketH
     super.removeAllChannelListeners();
 
     const sockets = this.socket ? [this.socket] : [];
-    super.abortRequests(sockets);
+    super.abortSocketMessages(sockets);
     await super.closeClientSockets(sockets);
 
     this.socket = undefined;

--- a/packages/zimic/src/webSocket/WebSocketServer.ts
+++ b/packages/zimic/src/webSocket/WebSocketServer.ts
@@ -59,7 +59,7 @@ class WebSocketServer<Schema extends WebSocket.ServiceSchema> extends WebSocketH
     }
 
     super.removeAllChannelListeners();
-    super.abortRequests();
+    super.abortSocketMessages();
     await super.closeClientSockets();
 
     await closeServerSocket(this.webSocketServer, { timeout: this.socketTimeout() });

--- a/packages/zimic/src/webSocket/WebSocketServer.ts
+++ b/packages/zimic/src/webSocket/WebSocketServer.ts
@@ -58,8 +58,9 @@ class WebSocketServer<Schema extends WebSocket.ServiceSchema> extends WebSocketH
       return;
     }
 
+    super.removeAllChannelListeners();
+    super.abortRequests();
     await super.closeClientSockets();
-    super.removeAllListeners();
 
     await closeServerSocket(this.webSocketServer, { timeout: this.socketTimeout() });
     this.webSocketServer.removeAllListeners();

--- a/packages/zimic/src/webSocket/__tests__/WebSocketClient.node.test.ts
+++ b/packages/zimic/src/webSocket/__tests__/WebSocketClient.node.test.ts
@@ -18,7 +18,7 @@ import InvalidWebSocketMessage from '../errors/InvalidWebSocketMessage';
 import NotStartedWebSocketHandlerError from '../errors/NotStartedWebSocketHandlerError';
 import { WebSocket } from '../types';
 import WebSocketClient from '../WebSocketClient';
-import { delayClientSocketClose, delayClientSocketOpen, delayClientSocketSend } from './utils';
+import { delayClientSocketClose, delayClientSocketOpen } from './utils';
 
 const { WebSocketServer: ServerSocket } = ClientSocket;
 
@@ -170,23 +170,6 @@ describe('Web socket client', async () => {
         channel: 'no-reply',
         data: eventMessage,
       });
-    });
-
-    it('should log an error if a socket message sending timeout is reached', async () => {
-      const delayedClientSocketSend = delayClientSocketSend(300);
-
-      try {
-        const messageTimeout = 100;
-        client = new WebSocketClient({ url: `ws://localhost:${port}`, messageTimeout });
-        expect(client.messageTimeout()).toBe(messageTimeout);
-        await client.start();
-
-        await expect(client.send('no-reply', { message: 'test' })).rejects.toThrowError(
-          new WebSocketMessageTimeoutError(messageTimeout),
-        );
-      } finally {
-        delayedClientSocketSend.mockRestore();
-      }
     });
 
     it('should support receiving event messages from servers', async () => {

--- a/packages/zimic/src/webSocket/__tests__/WebSocketServer.node.test.ts
+++ b/packages/zimic/src/webSocket/__tests__/WebSocketServer.node.test.ts
@@ -22,7 +22,6 @@ import WebSocketServer from '../WebSocketServer';
 import {
   delayClientSocketOpen,
   delayClientSocketClose,
-  delayClientSocketSend,
   delayServerSocketConnection,
   delayServerSocketClose,
 } from './utils';
@@ -217,26 +216,6 @@ describe('Web socket server', async () => {
         channel: 'no-reply',
         data: eventMessage,
       });
-    });
-
-    it('should throw an error if a socket message sending timeout is reached', async () => {
-      const delayedClientSocketSend = delayClientSocketSend(300);
-
-      try {
-        const messageTimeout = 100;
-        server = new WebSocketServer({ httpServer, messageTimeout });
-        expect(server.messageTimeout()).toBe(messageTimeout);
-        server.start();
-
-        rawClient = new ClientSocket(`ws://localhost:${port}`);
-        await waitForOpenClientSocket(rawClient);
-
-        await expect(server.send('no-reply', { message: 'test' })).rejects.toThrowError(
-          new WebSocketMessageTimeoutError(messageTimeout),
-        );
-      } finally {
-        delayedClientSocketSend.mockRestore();
-      }
     });
 
     it('should support receiving event messages from clients', async () => {

--- a/packages/zimic/src/webSocket/__tests__/utils.ts
+++ b/packages/zimic/src/webSocket/__tests__/utils.ts
@@ -46,22 +46,6 @@ export function delayServerSocketConnection() {
   return delayedServerSocketOnSpy;
 }
 
-export function delayClientSocketSend(delayDuration: number) {
-  // eslint-disable-next-line @typescript-eslint/unbound-method
-  const originalClientSocketSend = ClientSocket.prototype.send;
-
-  const delayedClientSocketSend = vi.spyOn(ClientSocket.prototype, 'send').mockImplementationOnce(function (
-    this: void,
-    ...parameters
-  ) {
-    void waitForDelay(delayDuration).then(() => {
-      originalClientSocketSend.apply(this, parameters);
-    });
-  });
-
-  return delayedClientSocketSend;
-}
-
 export function delayClientSocketClose(delayDuration: number) {
   // eslint-disable-next-line @typescript-eslint/unbound-method
   const originalClientSocketClose = ClientSocket.prototype.close;


### PR DESCRIPTION
### Fixes
- [#zimic] Added an implementation to abort waiting for a web socket RPC reply if the worker was stopped. This was related to a very uncommon scenario where:
  1. A worker was registered to the interceptor server;
  2. The interceptor server received a response and sent an RPC to the worker to get the response;
  3. The worker was stopped before it could reply with the response;
  4. The interceptor server would wait for a reply until timing out after 5 minutes.
  This PR changes the behavior so that interceptor workers can know immediately which workers are no longer committed to generate responses and abort waiting for their replies. In that case, the pending requests will be rejected as if they had no associated worker.

### Refactoring
- [#zimic] Improved the structure of web socket clients, servers and tests.
- [#zimic] Removed an unnecessary message timeout when sending web socket messages. The API `socket.send(message)` is synchronous and there is no way to really wait for the message to be sent both in browser and Node.js.

### Chore
- [#zimic] Decreased the web socket message timeout to 3 minutes.

Closes #289.