### PR TITLE
fix(#zimic): log connection refused error when starting an interceptor in Node.js

### DIFF
--- a/packages/zimic/src/interceptor/http/interceptorWorker/LocalHttpInterceptorWorker.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/LocalHttpInterceptorWorker.ts
@@ -62,6 +62,7 @@ class LocalHttpInterceptorWorker extends HttpInterceptorWorker {
   async start() {
     await super.sharedStart(async () => {
       const internalWorker = await this.internalWorkerOrLoad();
+
       const sharedOptions: MSWWorkerSharedOptions = {
         onUnhandledRequest: async (request) => {
           await super.handleUnhandledRequest(request);

--- a/packages/zimic/src/interceptor/http/interceptorWorker/__tests__/shared/default.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/__tests__/shared/default.ts
@@ -1,9 +1,11 @@
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import NotStartedHttpInterceptorError from '@/interceptor/http/interceptor/errors/NotStartedHttpInterceptorError';
 import { createURL } from '@/utils/urls';
+import { usingIgnoredConsole } from '@tests/utils/console';
 import { createInternalHttpInterceptor, usingHttpInterceptorWorker } from '@tests/utils/interceptors';
 
+import { createHttpInterceptorWorker } from '../../factory';
 import HttpInterceptorWorker from '../../HttpInterceptorWorker';
 import LocalHttpInterceptorWorker from '../../LocalHttpInterceptorWorker';
 import RemoteHttpInterceptorWorker from '../../RemoteHttpInterceptorWorker';
@@ -12,6 +14,7 @@ import {
   LocalHttpInterceptorWorkerOptions,
   RemoteHttpInterceptorWorkerOptions,
 } from '../../types/options';
+import { BrowserHttpWorker, NodeHttpWorker } from '../../types/requests';
 import { SharedHttpInterceptorWorkerTestOptions } from './types';
 
 export function declareDefaultHttpInterceptorWorkerTests(options: SharedHttpInterceptorWorkerTestOptions) {
@@ -197,6 +200,38 @@ export function declareDefaultHttpInterceptorWorkerTests(options: SharedHttpInte
           const clearPromise = worker.clearInterceptorHandlers(interceptor.client());
           await expect(clearPromise).resolves.not.toThrowError();
         });
+      });
+    }
+
+    if (defaultWorkerOptions.type === 'local') {
+      it('should throw an error after failing to start due to a unknown error', async () => {
+        const interceptorWorker = createHttpInterceptorWorker(defaultWorkerOptions);
+
+        const error = new Error('Unknown error');
+
+        if (platform === 'browser') {
+          const internalBrowserWorker = (await interceptorWorker.internalWorkerOrLoad()) as BrowserHttpWorker;
+          vi.spyOn(internalBrowserWorker, 'start').mockRejectedValueOnce(error);
+        } else {
+          const internalNodeWorker = (await interceptorWorker.internalWorkerOrLoad()) as NodeHttpWorker;
+          vi.spyOn(internalNodeWorker, 'listen').mockImplementationOnce(() => {
+            throw error;
+          });
+        }
+
+        await usingIgnoredConsole(['error'], async (spies) => {
+          const interceptorStartPromise = interceptorWorker.start();
+          await expect(interceptorStartPromise).rejects.toThrowError(error);
+
+          if (platform === 'browser') {
+            expect(spies.error).toHaveBeenCalledTimes(0);
+          } else {
+            expect(spies.error).toHaveBeenCalledTimes(1);
+            expect(spies.error).toHaveBeenCalledWith(error);
+          }
+        });
+
+        expect(interceptorWorker.platform()).toBe(platform);
       });
     }
   });

--- a/packages/zimic/src/interceptor/http/interceptorWorker/errors/UnregisteredBrowserServiceWorkerError.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/errors/UnregisteredBrowserServiceWorkerError.ts
@@ -10,7 +10,7 @@ class UnregisteredBrowserServiceWorkerError extends Error {
     super(
       `Failed to register the browser service worker: ` +
         `script '${window.location.origin}/${SERVICE_WORKER_FILE_NAME}' not found.\n\n` +
-        'Did you forget to run "npx zimic browser init <public-directory>"?\n\n' +
+        'Did you forget to run `zimic browser init <publicDirectory>`?\n\n' +
         'Learn more: https://github.com/zimicjs/zimic#browser-post-install',
     );
     this.name = 'UnregisteredBrowserServiceWorkerError';

--- a/packages/zimic/src/utils/http.ts
+++ b/packages/zimic/src/utils/http.ts
@@ -61,6 +61,10 @@ export async function startHttpServer(
 export async function stopHttpServer(server: HttpServer, options: { timeout?: number } = {}) {
   const { timeout: timeoutDuration = DEFAULT_HTTP_SERVER_LIFECYCLE_TIMEOUT } = options;
 
+  if (!server.listening) {
+    return;
+  }
+
   await new Promise<void>((resolve, reject) => {
     const stopTimeout = setTimeout(() => {
       const timeoutError = new HttpServerStopTimeoutError(timeoutDuration);

--- a/packages/zimic/src/webSocket/WebSocketHandler.ts
+++ b/packages/zimic/src/webSocket/WebSocketHandler.ts
@@ -29,7 +29,7 @@ abstract class WebSocketHandler<Schema extends WebSocket.ServiceSchema> {
   } = {};
 
   private socketListeners = {
-    messageAbort: new Map<ClientSocket, Set<(reason: unknown) => void>>(),
+    messageAbort: new Map<ClientSocket, Set<(error: unknown) => void>>(),
   };
 
   protected constructor(options: { socketTimeout?: number; messageTimeout?: number }) {
@@ -235,13 +235,13 @@ abstract class WebSocketHandler<Schema extends WebSocket.ServiceSchema> {
         reject(timeoutError);
       }, this._messageTimeout);
 
-      const abortListener = this.onAbortSocketMessages(sockets, (reason) => {
+      const abortListener = this.onAbortSocketMessages(sockets, (error) => {
         clearTimeout(replyTimeout);
 
         this.offReply(channel, replyListener); // eslint-disable-line @typescript-eslint/no-use-before-define
         this.offAbortSocketMessages(sockets, abortListener);
 
-        reject(reason);
+        reject(error);
       });
 
       const replyListener = this.onReply(channel, (message) => {
@@ -353,7 +353,7 @@ abstract class WebSocketHandler<Schema extends WebSocket.ServiceSchema> {
     this.channelListeners = {};
   }
 
-  private onAbortSocketMessages(sockets: Collection<ClientSocket>, listener: (reason: unknown) => void) {
+  private onAbortSocketMessages(sockets: Collection<ClientSocket>, listener: (error: unknown) => void) {
     for (const socket of sockets) {
       let listeners = this.socketListeners.messageAbort.get(socket);
       if (!listeners) {
@@ -366,7 +366,7 @@ abstract class WebSocketHandler<Schema extends WebSocket.ServiceSchema> {
     return listener;
   }
 
-  private offAbortSocketMessages(sockets: Collection<ClientSocket>, listener: (reason: unknown) => void) {
+  private offAbortSocketMessages(sockets: Collection<ClientSocket>, listener: (error: unknown) => void) {
     for (const socket of sockets) {
       this.socketListeners.messageAbort.get(socket)?.delete(listener);
     }

--- a/packages/zimic/src/webSocket/__tests__/WebSocketClient.node.test.ts
+++ b/packages/zimic/src/webSocket/__tests__/WebSocketClient.node.test.ts
@@ -134,6 +134,12 @@ describe('Web socket client', async () => {
         delayedClientSocketClose.mockRestore();
       }
     });
+
+    it('should throw an error if started without a running server to connect to', async () => {
+      client = new WebSocketClient({ url: 'ws://localhost:0' });
+
+      await expect(client.start()).rejects.toThrowError('connect ECONNREFUSED 127.0.0.1');
+    });
   });
 
   describe('Messages', () => {

--- a/packages/zimic/src/webSocket/__tests__/WebSocketClient.node.test.ts
+++ b/packages/zimic/src/webSocket/__tests__/WebSocketClient.node.test.ts
@@ -136,9 +136,11 @@ describe('Web socket client', async () => {
     });
 
     it('should throw an error if started without a running server to connect to', async () => {
-      client = new WebSocketClient({ url: 'ws://localhost:0' });
+      await stopHttpServer(httpServer);
 
-      await expect(client.start()).rejects.toThrowError('connect ECONNREFUSED 127.0.0.1');
+      client = new WebSocketClient({ url: `ws://localhost:${port}` });
+
+      await expect(client.start()).rejects.toThrowError(/^(connect ECONNREFUSED .+)?$/);
     });
   });
 


### PR DESCRIPTION
### Fixes
- [#zimic] Added a log when an interceptor could not be started in Node.js. Previously, Node.js would not log any details about the error, such as a connection refused, only that it was an uncaught exception. In browser, the logging happens normally, so we do not need to manually do it.
