### PR TITLE
fix(ci): continue release comments on error

### DIFF
--- a/.github/workflows/release-npm.yaml
+++ b/.github/workflows/release-npm.yaml
@@ -106,7 +106,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const DELAY_BETWEEN_COMMENTS = 1000;
+            const DELAY_BETWEEN_COMMENTS = 2000;
             const PER_PAGE = 100;
 
             const tag = context.ref.replace(/^refs\/tags\//, '');

--- a/.github/workflows/release-npm.yaml
+++ b/.github/workflows/release-npm.yaml
@@ -152,20 +152,25 @@ jobs:
                 for (const issue of issues.data) {
                   console.log(`Creating release comment on #${issue.number}...`);
 
-                  await github.rest.issues.createComment({
-                    owner,
-                    repo: repository,
-                    issue_number: issue.number,
-                    body: [
-                      `### Released in [${tag}](https://github.com/${owner}/${repository}/releases/tag/${tag}) :tada:\n`,
-                      `- [**:pushpin: Release notes**](https://github.com/${owner}/${repository}/releases/tag/${tag})`,
-                      `- [**:package: NPM package**](https://www.npmjs.com/package/${repository}/v/${version})`,
-                    ].join('\n'),
-                  });
+                  try {
+                    await github.rest.issues.createComment({
+                      owner,
+                      repo: repository,
+                      issue_number: issue.number,
+                      body: [
+                        `### Released in [${tag}](https://github.com/${owner}/${repository}/releases/tag/${tag}) :tada:\n`,
+                        `- [**:pushpin: Release notes**](https://github.com/${owner}/${repository}/releases/tag/${tag})`,
+                        `- [**:package: NPM package**](https://www.npmjs.com/package/${repository}/v/${version})`,
+                      ].join('\n'),
+                    });
 
-                  console.log(`Release comment created on #${issue.number}.`);
+                    console.log(`Release comment created on #${issue.number}.`);
 
-                  await new Promise((resolve) => setTimeout(resolve, DELAY_BETWEEN_COMMENTS));
+                    await new Promise((resolve) => setTimeout(resolve, DELAY_BETWEEN_COMMENTS));
+                  } catch (error) {
+                    console.error(`Could not create release comment on #${issue.number}.`);
+                    console.error(error);
+                  }
                 }
 
                 if (issues.data.length < PER_PAGE) {


### PR DESCRIPTION
### Fixes
- [ci] Added a `try..catch` so that an error when creating a comment release does not stop the action.

### Chore
- [ci] Increased the delay between release comments to 2 seconds.