### PR TITLE
fix(#zimic): exit process after stopping the interceptor server through CLI

### DIFF
--- a/.github/actions/zimic-setup/action.yaml
+++ b/.github/actions/zimic-setup/action.yaml
@@ -29,10 +29,10 @@ inputs:
 
 outputs:
   install-filters:
-    description: Effective filter flags for installing dependencies
+    description: Filter flags of the packages included in the install step
     value: ${{ steps.install-dependencies.outputs.install-filters }}
   build-filters:
-    description: Effective filter flags for building dependencies
+    description: Filter flags of the packages included in the build step
     value: ${{ steps.build-dependencies.outputs.build-filters }}
 
 runs:
@@ -77,29 +77,27 @@ runs:
         }
 
         if [[ '${{ inputs.install }}' == '' ]]; then
-          workspaceRootInstallFlag=''
-          partialInstallFlag=''
-          installFlag=''
+          installFilters=''
+          fullInstallFilters=''
         else
-          workspaceRootInstallFlag='--filter zimic-root'
-          partialInstallFlag="$(composeFilterOptions ${{ inputs.install }})"
-          installFlag="$workspaceRootInstallFlag $partialInstallFlag"
+          installFilters="$(composeFilterOptions ${{ inputs.install }})"
+          fullInstallFilters="--filter zimic-root --filter zimic $installFilters"
         fi
 
-        echo "install-filters=$partialInstallFlag" >> $GITHUB_OUTPUT
-        pnpm install --prefer-offline --frozen-lockfile --ignore-scripts $installFlag
+        echo "install-filters=$installFilters" >> $GITHUB_OUTPUT
+        pnpm install --prefer-offline --frozen-lockfile --ignore-scripts $fullInstallFilters
 
         if [[ '${{ inputs.build }}' == '' ]]; then
-          buildFlag=''
+          buildFilters=''
         else
-          buildFlag="$(composeFilterOptions ${{ inputs.build }})"
+          buildFilters="$(composeFilterOptions ${{ inputs.build }})"
         fi
 
-        echo "build-filters=$buildFlag" >> $GITHUB_OUTPUT
-        pnpm turbo build $buildFlag
+        echo "build-filters=$buildFilters" >> $GITHUB_OUTPUT
+        pnpm turbo build $buildFilters
 
         # apply the build outputs of the internal packages
-        pnpm install --offline $installFlag
+        pnpm install --offline $fullInstallFilters
 
         if [[ '${{ inputs.install-playwright-browsers }}' == 'true' ]]; then
           pnpm --dir packages/zimic deps:install-playwright

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,9 +22,9 @@ env:
     ${{ !(github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main') && secrets.TURBO_REMOTE_CACHE_TEAM || '' }}
   TURBO_LOG_ORDER: stream
   INSTALL_OPTIONS: |
-    ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref != 'main' && 'zimic "...[HEAD^1]"' || '' }}
+    ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref != 'main' && '"...[HEAD^1]"' || '' }}
   BUILD_OPTIONS: |
-    ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref != 'main' && 'zimic "{./apps/*}[HEAD^1]^..." "{./packages/*} [HEAD^1]..."' || './packages/*' }}
+    ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref != 'main' && '"{./apps/*}[HEAD^1]^..." "{./packages/*}[HEAD^1]..."' || './packages/*' }}
 
 jobs:
   ci-general:
@@ -45,8 +45,8 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           turbo-token: ${{ env.TURBO_TOKEN }}
           turbo-team: ${{ env.TURBO_TEAM }}
-          install: ${{ env.INSTALL_OPTIONS }}
-          build: ${{ env.BUILD_OPTIONS }}
+          install: ${{ env.INSTALL_OPTIONS == '' && '' || format('zimic {0}', env.INSTALL_OPTIONS) }}
+          build: ${{ env.BUILD_OPTIONS == '' && '' || format('zimic {0}', env.BUILD_OPTIONS) }}
           install-playwright-browsers: true
 
       - name: Check formatting style

--- a/README.md
+++ b/README.md
@@ -2750,6 +2750,7 @@ const [command, ...commandArguments] = process.argv.slice(3);
 await runCommand(command, commandArguments);
 
 await server.stop();
+process.exit(0);
 ```
 
 The helper function `runCommand` is useful to run a shell command in server scripts. The

--- a/README.md
+++ b/README.md
@@ -2739,15 +2739,20 @@ should automatically stop after the command finishes.
 The module `zimic/server` exports resources for managing interceptor servers programmatically. Even though we recommend
 using the CLI, this module is a valid alternative for more advanced use cases.
 
-```ts
-import { createInterceptorServer, runCommand } from 'zimic/interceptor/server';
+An example using the programmatic API and [`execa`](https://www.npmjs.com/package/execa) to run a command when the
+server is ready:
 
-const server = createInterceptorServer({ hostname: 'localhost', port: 3000 });
+```ts
+import { execa as $ } from 'execa';
+import { interceptorServer } from 'zimic/interceptor/server';
+
+const server = interceptorServer.create({ hostname: 'localhost', port: 3000 });
 await server.start();
 
-// Run a command when the server is ready
+// Run a command when the server is ready, assuming the following format:
+// node <script> -- <command> [...commandArguments]
 const [command, ...commandArguments] = process.argv.slice(3);
-await runCommand(command, commandArguments);
+await $(command, commandArguments, { stdio: 'inherit' });
 
 await server.stop();
 process.exit(0);
@@ -2898,6 +2903,8 @@ zimic typegen openapi ./schema.yaml \
 
 The module `zimic/typegen` exports resources for generating types programmatically. We recommend using the CLI, but this
 module is a valid alternative for more advanced use cases.
+
+An example using the programmatic API to generate types from an OpenAPI schema:
 
 ```ts
 import { typegen } from 'zimic/typegen';

--- a/apps/zimic-test-client/tests/v0/interceptor/thirdParty/shared/default.ts
+++ b/apps/zimic-test-client/tests/v0/interceptor/thirdParty/shared/default.ts
@@ -1,4 +1,4 @@
-import { beforeAll, beforeEach, afterAll, expect, describe, it, expectTypeOf } from 'vitest';
+import { beforeAll, beforeEach, afterAll, expect, describe, it, expectTypeOf, afterEach } from 'vitest';
 import { JSONSerialized } from 'zimic0';
 import { HttpRequest, HttpResponse, HttpSearchParams } from 'zimic0/http';
 import { httpInterceptor, HttpInterceptorType } from 'zimic0/interceptor/http';
@@ -62,7 +62,7 @@ async function declareDefaultClientTests(options: ClientTestOptionsByWorkerType)
     );
   });
 
-  beforeEach(async () => {
+  afterEach(async () => {
     await Promise.all(
       interceptors.map(async (interceptor) => {
         await interceptor.clear();

--- a/apps/zimic-test-client/tests/v0/interceptor/thirdParty/shared/default.ts
+++ b/apps/zimic-test-client/tests/v0/interceptor/thirdParty/shared/default.ts
@@ -381,8 +381,8 @@ async function declareDefaultClientTests(options: ClientTestOptionsByWorkerType)
       });
 
       it('should list users with ordering', async () => {
-        const orderedUsers = users.sort((user, otherUser) => {
-          return -user.email.localeCompare(otherUser.email);
+        const usersSortedByDescendingEmail = [...users].sort((user, otherUser) => {
+          return otherUser.email.localeCompare(user.email);
         });
 
         const listHandler = await authInterceptor
@@ -392,7 +392,7 @@ async function declareDefaultClientTests(options: ClientTestOptionsByWorkerType)
           })
           .respond({
             status: 200,
-            body: orderedUsers.map(serializeUser),
+            body: usersSortedByDescendingEmail.map(serializeUser),
           });
 
         const response = await listUsers({
@@ -401,7 +401,7 @@ async function declareDefaultClientTests(options: ClientTestOptionsByWorkerType)
         expect(response.status).toBe(200);
 
         const returnedUsers = (await response.json()) as User[];
-        expect(returnedUsers).toEqual(orderedUsers.map(serializeUser));
+        expect(returnedUsers).toEqual(usersSortedByDescendingEmail.map(serializeUser));
 
         const listRequests = await listHandler.requests();
         expect(listRequests).toHaveLength(1);
@@ -420,12 +420,12 @@ async function declareDefaultClientTests(options: ClientTestOptionsByWorkerType)
         expect(await listRequests[0].raw.text()).toBe('');
 
         expectTypeOf(listRequests[0].response.body).toEqualTypeOf<JSONSerialized<User>[]>();
-        expect(listRequests[0].response.body).toEqual(orderedUsers.map(serializeUser));
+        expect(listRequests[0].response.body).toEqual(usersSortedByDescendingEmail.map(serializeUser));
 
         expectTypeOf(listRequests[0].response.raw).toEqualTypeOf<HttpResponse<JSONSerialized<User>[], 200>>();
         expect(listRequests[0].response.raw).toBeInstanceOf(Response);
         expectTypeOf(listRequests[0].response.raw.json).toEqualTypeOf<() => Promise<JSONSerialized<User>[]>>();
-        expect(await listRequests[0].response.raw.json()).toEqual(orderedUsers.map(serializeUser));
+        expect(await listRequests[0].response.raw.json()).toEqual(usersSortedByDescendingEmail.map(serializeUser));
       });
     });
 

--- a/apps/zimic-test-client/tests/v0/interceptor/thirdParty/shared/default.ts
+++ b/apps/zimic-test-client/tests/v0/interceptor/thirdParty/shared/default.ts
@@ -53,8 +53,6 @@ async function declareDefaultClientTests(options: ClientTestOptionsByWorkerType)
   const notificationBaseURL = notificationInterceptor.baseURL();
 
   beforeAll(async () => {
-    console.log();
-
     await Promise.all(
       interceptors.map(async (interceptor) => {
         await interceptor.start();

--- a/apps/zimic-test-client/tests/v0/interceptor/thirdParty/shared/default.ts
+++ b/apps/zimic-test-client/tests/v0/interceptor/thirdParty/shared/default.ts
@@ -53,6 +53,8 @@ async function declareDefaultClientTests(options: ClientTestOptionsByWorkerType)
   const notificationBaseURL = notificationInterceptor.baseURL();
 
   beforeAll(async () => {
+    console.log();
+
     await Promise.all(
       interceptors.map(async (interceptor) => {
         await interceptor.start();

--- a/apps/zimic-test-client/vitest.workspace.mts
+++ b/apps/zimic-test-client/vitest.workspace.mts
@@ -15,7 +15,7 @@ export default defineWorkspace([
   {
     extends: 'vitest.config.mts',
     test: {
-      name: 'browser',
+      name: 'browser-chromium',
       environment: undefined,
       include: ['./{src,tests}/**/*.test.ts', './{src,tests}/**/*.browser.test.ts'],
       exclude: ['**/*.node.test.ts'],

--- a/examples/with-typegen/package.json
+++ b/examples/with-typegen/package.json
@@ -6,7 +6,8 @@
     "test": "vitest",
     "test:turbo": "dotenv -v CI=true -- pnpm run test run",
     "types:check": "tsc --noEmit",
-    "typegen:github": "dotenv -c development -- bash -c 'zimic typegen openapi $GITHUB_OPENAPI_SPEC_URL --output ./src/types/github/typegen/generated.ts --service-name GitHub --filter-file ./src/types/github/typegen/filters.txt --no-comments'"
+    "typegen:github": "dotenv -c development -- pnpm typegen:github-no-env",
+    "typegen:github-no-env": "zimic typegen openapi $GITHUB_OPENAPI_SPEC_URL --output ./src/types/github/typegen/generated.ts --service-name GitHub --filter-file ./src/types/github/typegen/filters.txt --no-comments"
   },
   "dependencies": {
     "fastify": "4.28.1",

--- a/packages/zimic/src/cli/__tests__/server.cli.node.test.ts
+++ b/packages/zimic/src/cli/__tests__/server.cli.node.test.ts
@@ -40,12 +40,14 @@ describe('CLI (server)', async () => {
 
   const processArgvSpy = vi.spyOn(process, 'argv', 'get');
   const processOnSpy = vi.spyOn(process, 'on');
+  const processExitSpy = vi.spyOn(process, 'exit').mockReturnValue(undefined as never);
 
   beforeEach(() => {
     processArgvSpy.mockClear();
     processArgvSpy.mockReturnValue([]);
 
     processOnSpy.mockClear();
+    processExitSpy.mockClear();
   });
 
   const serverHelpOutput = [
@@ -299,6 +301,9 @@ describe('CLI (server)', async () => {
 
         const savedFile = await filesystem.readFile(temporarySaveFile, 'utf-8');
         expect(savedFile).toBe(temporarySaveFileContent);
+
+        expect(processExitSpy).toHaveBeenCalledTimes(1);
+        expect(processExitSpy).toHaveBeenCalledWith(0);
       });
     });
 
@@ -335,6 +340,8 @@ describe('CLI (server)', async () => {
 
           const savedFile = await filesystem.readFile(temporarySaveFile, 'utf-8');
           expect(savedFile).toBe(temporarySaveFileContent);
+
+          expect(processExitSpy).not.toHaveBeenCalled();
         });
       },
     );

--- a/packages/zimic/src/cli/server/start.ts
+++ b/packages/zimic/src/cli/server/start.ts
@@ -38,6 +38,7 @@ async function startInterceptorServer({
 
   if (ephemeral) {
     await server.stop();
+    process.exit(0);
   }
 }
 


### PR DESCRIPTION
### Fixes
- [#zimic] Added a call to `process.exit(0)` after an interceptor server is stopped in ephemeral mode. This is to make sure that the process does not hangs, even though the server has been stopped. It is not clear to me how hanging happens, but it rarely does in the tests of `zimic-test-client`.

### Documentation
- [#zimic] Included `process.exit(0)` to the documentation about interceptor server programmatic usage.
- [#zimic] Fixed a code snippet still using `runCommand`, which is no longer available in >=v0.8.
