### PR TITLE
fix: missing shebang to work with `npm run` and `npx` (#309)

### DIFF
--- a/packages/zimic/src/cli/index.ts
+++ b/packages/zimic/src/cli/index.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import runCLI from './cli';
 
 void runCLI();


### PR DESCRIPTION
### Fixes
- [#zimic] Added the shebang `#!/usr/bin/env node` that was missing in the CLI entry point script. It caused problems only with `npm run` or `npx`, while Yarn, PNPM, and Bun were fine.

Closes #309.