### PR TITLE
fix(#zimic): prevent using headers or search params when no schema is defined (#311)

### DIFF
--- a/apps/zimic-test-client/tests/v0/exports/exports.test.ts
+++ b/apps/zimic-test-client/tests/v0/exports/exports.test.ts
@@ -6,16 +6,18 @@ import {
   type HttpBody,
   type HttpRequest,
   type HttpResponse,
-  HttpSearchParams,
-  type HttpSearchParamsInit,
-  type HttpSearchParamsSchema,
-  type HttpSearchParamsSchemaTuple,
-  type StrictURLSearchParams,
   HttpHeaders,
   type HttpHeadersInit,
   type HttpHeadersSchema,
   type HttpHeadersSchemaTuple,
+  type HttpHeadersSchemaName,
   type StrictHeaders,
+  HttpSearchParams,
+  type HttpSearchParamsInit,
+  type HttpSearchParamsSchema,
+  type HttpSearchParamsSchemaTuple,
+  type HttpSearchParamsSchemaName,
+  type StrictURLSearchParams,
   HttpFormData,
   type HttpFormDataSchema,
   type StrictFormData,
@@ -91,6 +93,7 @@ describe('Exports', () => {
     expectTypeOf<HttpHeadersInit<never>>().not.toBeAny();
     expectTypeOf<HttpHeadersSchema>().not.toBeAny();
     expectTypeOf<HttpHeadersSchemaTuple<never>>().not.toBeAny();
+    expectTypeOf<HttpHeadersSchemaName<never>>().not.toBeAny();
     expectTypeOf<StrictHeaders<never>>().not.toBeAny();
 
     expectTypeOf<HttpSearchParams>().not.toBeAny();
@@ -98,6 +101,9 @@ describe('Exports', () => {
     expectTypeOf<HttpSearchParamsInit<never>>().not.toBeAny();
     expectTypeOf<HttpSearchParamsSchema>().not.toBeAny();
     expectTypeOf<HttpSearchParamsSchemaTuple<never>>().not.toBeAny();
+    expectTypeOf<HttpSearchParamsSchemaName<never>>().not.toBeAny();
+    expectTypeOf<HttpSearchParamsSchemaName.Array<never>>().not.toBeAny();
+    expectTypeOf<HttpSearchParamsSchemaName.NonArray<never>>().not.toBeAny();
     expectTypeOf<StrictURLSearchParams<never>>().not.toBeAny();
 
     expectTypeOf<HttpFormData>().not.toBeAny();

--- a/apps/zimic-test-client/tests/v0/interceptor/thirdParty/shared/default.ts
+++ b/apps/zimic-test-client/tests/v0/interceptor/thirdParty/shared/default.ts
@@ -154,7 +154,7 @@ async function declareDefaultClientTests(options: ClientTestOptionsByWorkerType)
 
         expectTypeOf(creationRequests[0].headers).toEqualTypeOf<HttpHeaders<{ 'content-type'?: string }>>();
 
-        expectTypeOf(creationRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<{}>>();
+        expectTypeOf(creationRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
         expect(creationRequests[0].searchParams.size).toBe(0);
 
         expect(response.headers.get('x-user-id')).toBe(createdUser.id);
@@ -203,7 +203,7 @@ async function declareDefaultClientTests(options: ClientTestOptionsByWorkerType)
 
         expectTypeOf(creationRequests[0].headers).toEqualTypeOf<HttpHeaders<{ 'content-type'?: string }>>();
 
-        expectTypeOf(creationRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<{}>>();
+        expectTypeOf(creationRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
         expect(creationRequests[0].searchParams.size).toBe(0);
 
         expectTypeOf(creationRequests[0].body).toEqualTypeOf<UserCreationPayload>();
@@ -248,7 +248,7 @@ async function declareDefaultClientTests(options: ClientTestOptionsByWorkerType)
 
         expectTypeOf(creationRequests[0].headers).toEqualTypeOf<HttpHeaders<{ 'content-type'?: string }>>();
 
-        expectTypeOf(creationRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<{}>>();
+        expectTypeOf(creationRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
         expect(creationRequests[0].searchParams.size).toBe(0);
 
         expectTypeOf(creationRequests[0].body).toEqualTypeOf<UserCreationPayload>();
@@ -465,7 +465,7 @@ async function declareDefaultClientTests(options: ClientTestOptionsByWorkerType)
 
         expectTypeOf(getRequests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
 
-        expectTypeOf(getRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<{}>>();
+        expectTypeOf(getRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
         expect(getRequests[0].searchParams.size).toBe(0);
 
         expectTypeOf(getRequests[0].body).toEqualTypeOf<null>();
@@ -507,7 +507,7 @@ async function declareDefaultClientTests(options: ClientTestOptionsByWorkerType)
 
         expectTypeOf(getRequests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
 
-        expectTypeOf(getRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<{}>>();
+        expectTypeOf(getRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
         expect(getRequests[0].searchParams.size).toBe(0);
 
         expectTypeOf(getRequests[0].body).toEqualTypeOf<null>();
@@ -551,7 +551,7 @@ async function declareDefaultClientTests(options: ClientTestOptionsByWorkerType)
 
         expectTypeOf(deleteRequests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
 
-        expectTypeOf(deleteRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<{}>>();
+        expectTypeOf(deleteRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
         expect(deleteRequests[0].searchParams.size).toBe(0);
 
         expectTypeOf(deleteRequests[0].body).toEqualTypeOf<null>();
@@ -593,7 +593,7 @@ async function declareDefaultClientTests(options: ClientTestOptionsByWorkerType)
 
         expectTypeOf(deleteRequests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
 
-        expectTypeOf(deleteRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<{}>>();
+        expectTypeOf(deleteRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
         expect(deleteRequests[0].searchParams.size).toBe(0);
 
         expectTypeOf(deleteRequests[0].body).toEqualTypeOf<null>();
@@ -658,7 +658,7 @@ async function declareDefaultClientTests(options: ClientTestOptionsByWorkerType)
 
         expectTypeOf(listRequests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
 
-        expectTypeOf(listRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<{}>>();
+        expectTypeOf(listRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
         expect(listRequests[0].searchParams.size).toBe(0);
 
         expectTypeOf(listRequests[0].body).toEqualTypeOf<null>();

--- a/apps/zimic-test-client/tests/v0/interceptor/thirdParty/shared/default.ts
+++ b/apps/zimic-test-client/tests/v0/interceptor/thirdParty/shared/default.ts
@@ -1,6 +1,6 @@
 import { beforeAll, beforeEach, afterAll, expect, describe, it, expectTypeOf, afterEach } from 'vitest';
 import { JSONSerialized } from 'zimic0';
-import { HttpRequest, HttpResponse, HttpSearchParams } from 'zimic0/http';
+import { HttpHeaders, HttpRequest, HttpResponse, HttpSearchParams } from 'zimic0/http';
 import { httpInterceptor, HttpInterceptorType } from 'zimic0/interceptor/http';
 
 import { importCrypto, IsomorphicCrypto } from '@tests/utils/crypto';
@@ -152,6 +152,8 @@ async function declareDefaultClientTests(options: ClientTestOptionsByWorkerType)
         const creationRequests = await creationHandler.requests();
         expect(creationRequests).toHaveLength(1);
 
+        expectTypeOf(creationRequests[0].headers).toEqualTypeOf<HttpHeaders<{ 'content-type'?: string }>>();
+
         expectTypeOf(creationRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<{}>>();
         expect(creationRequests[0].searchParams.size).toBe(0);
 
@@ -199,6 +201,8 @@ async function declareDefaultClientTests(options: ClientTestOptionsByWorkerType)
         const creationRequests = await creationHandler.requests();
         expect(creationRequests).toHaveLength(1);
 
+        expectTypeOf(creationRequests[0].headers).toEqualTypeOf<HttpHeaders<{ 'content-type'?: string }>>();
+
         expectTypeOf(creationRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<{}>>();
         expect(creationRequests[0].searchParams.size).toBe(0);
 
@@ -241,6 +245,8 @@ async function declareDefaultClientTests(options: ClientTestOptionsByWorkerType)
 
         const creationRequests = await creationHandler.requests();
         expect(creationRequests).toHaveLength(1);
+
+        expectTypeOf(creationRequests[0].headers).toEqualTypeOf<HttpHeaders<{ 'content-type'?: string }>>();
 
         expectTypeOf(creationRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<{}>>();
         expect(creationRequests[0].searchParams.size).toBe(0);
@@ -315,6 +321,8 @@ async function declareDefaultClientTests(options: ClientTestOptionsByWorkerType)
         const listRequests = await listHandler.requests();
         expect(listRequests).toHaveLength(1);
 
+        expectTypeOf(listRequests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
+
         expectTypeOf(listRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<UserListSearchParams>>();
         expect(listRequests[0].searchParams.get('name')).toBe(null);
         expect(listRequests[0].searchParams.getAll('orderBy')).toEqual([]);
@@ -357,6 +365,8 @@ async function declareDefaultClientTests(options: ClientTestOptionsByWorkerType)
 
         const listRequests = await listHandler.requests();
         expect(listRequests).toHaveLength(1);
+
+        expectTypeOf(listRequests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
 
         expectTypeOf(listRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<UserListSearchParams>>();
         expect(listRequests[0].searchParams.size).toBe(1);
@@ -406,6 +416,8 @@ async function declareDefaultClientTests(options: ClientTestOptionsByWorkerType)
         const listRequests = await listHandler.requests();
         expect(listRequests).toHaveLength(1);
 
+        expectTypeOf(listRequests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
+
         expectTypeOf(listRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<UserListSearchParams>>();
         expect(listRequests[0].searchParams.size).toBe(1);
         expect(listRequests[0].searchParams.get('name')).toBe(null);
@@ -451,6 +463,8 @@ async function declareDefaultClientTests(options: ClientTestOptionsByWorkerType)
         expect(getRequests).toHaveLength(1);
         expect(getRequests[0].url).toBe(`${authBaseURL}/users/${user.id}`);
 
+        expectTypeOf(getRequests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
+
         expectTypeOf(getRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<{}>>();
         expect(getRequests[0].searchParams.size).toBe(0);
 
@@ -490,6 +504,8 @@ async function declareDefaultClientTests(options: ClientTestOptionsByWorkerType)
 
         expectTypeOf(getRequests[0].pathParams).toEqualTypeOf<{ id: string }>();
         expect(getRequests[0].pathParams).toEqual({ id: user.id });
+
+        expectTypeOf(getRequests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
 
         expectTypeOf(getRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<{}>>();
         expect(getRequests[0].searchParams.size).toBe(0);
@@ -533,6 +549,8 @@ async function declareDefaultClientTests(options: ClientTestOptionsByWorkerType)
         expectTypeOf(deleteRequests[0].pathParams).toEqualTypeOf<{ id: string }>();
         expect(deleteRequests[0].pathParams).toEqual({});
 
+        expectTypeOf(deleteRequests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
+
         expectTypeOf(deleteRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<{}>>();
         expect(deleteRequests[0].searchParams.size).toBe(0);
 
@@ -572,6 +590,8 @@ async function declareDefaultClientTests(options: ClientTestOptionsByWorkerType)
 
         expectTypeOf(deleteRequests[0].pathParams).toEqualTypeOf<{ id: string }>();
         expect(deleteRequests[0].pathParams).toEqual({ id: user.id });
+
+        expectTypeOf(deleteRequests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
 
         expectTypeOf(deleteRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<{}>>();
         expect(deleteRequests[0].searchParams.size).toBe(0);
@@ -635,6 +655,8 @@ async function declareDefaultClientTests(options: ClientTestOptionsByWorkerType)
 
         expectTypeOf(listRequests[0].pathParams).toEqualTypeOf<{ userId: string }>();
         expect(listRequests[0].pathParams).toEqual({ userId: notification.userId });
+
+        expectTypeOf(listRequests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
 
         expectTypeOf(listRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<{}>>();
         expect(listRequests[0].searchParams.size).toBe(0);

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "style": "prettier --log-level warn --ignore-unknown --no-error-on-unmatched-pattern --cache",
     "style:check": "pnpm style --check .",
     "style:format": "pnpm style --write .",
-    "test": "turbo test:turbo --continue",
+    "test": "turbo test:turbo --concurrency 20% --continue",
     "types:check": "turbo types:check --continue",
     "pre:commit": "lint-staged",
     "pre:push": "concurrently --names style,lint 'pnpm style:check' 'turbo types:check lint:turbo --filter ...[${PARENT_REF:-origin/canary}...HEAD] --concurrency 50% --continue'",

--- a/packages/release/.eslintignore
+++ b/packages/release/.eslintignore
@@ -7,6 +7,7 @@ node_modules
 
 # Build
 /dist
+/*.d.ts
 
 # Tests
 /tests/coverage

--- a/packages/release/tsconfig.json
+++ b/packages/release/tsconfig.json
@@ -10,5 +10,5 @@
     }
   },
   "include": ["**/*.ts", "**/*.mts"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "*.d.ts"]
 }

--- a/packages/zimic/.eslintignore
+++ b/packages/zimic/.eslintignore
@@ -7,6 +7,7 @@ node_modules
 
 # Build
 /dist
+/*.d.ts
 /public/mockServiceWorker.js
 
 # Tests

--- a/packages/zimic/src/http/headers/HttpHeaders.ts
+++ b/packages/zimic/src/http/headers/HttpHeaders.ts
@@ -1,6 +1,6 @@
 import { Default, Defined, ReplaceBy } from '@/types/utils';
 
-import { HttpHeadersSchema, HttpHeadersInit } from './types';
+import { HttpHeadersSchema, HttpHeadersInit, HttpHeadersSchemaName } from './types';
 
 function pickPrimitiveProperties<Schema extends HttpHeadersSchema>(schema: Schema) {
   return Object.entries(schema).reduce<Record<string, string>>((accumulated, [key, value]) => {
@@ -27,17 +27,17 @@ class HttpHeaders<Schema extends HttpHeadersSchema = HttpHeadersSchema> extends 
   }
 
   /** @see {@link https://developer.mozilla.org/docs/Web/API/Headers/set MDN Reference} */
-  set<Name extends keyof Schema & string>(name: Name, value: Defined<Schema[Name]>): void {
+  set<Name extends HttpHeadersSchemaName<Schema>>(name: Name, value: Defined<Schema[Name]>): void {
     super.set(name, value);
   }
 
   /** @see {@link https://developer.mozilla.org/docs/Web/API/Headers/append MDN Reference} */
-  append<Name extends keyof Schema & string>(name: Name, value: Defined<Schema[Name]>): void {
+  append<Name extends HttpHeadersSchemaName<Schema>>(name: Name, value: Defined<Schema[Name]>): void {
     super.append(name, value);
   }
 
   /** @see {@link https://developer.mozilla.org/docs/Web/API/Headers/get MDN Reference} */
-  get<Name extends keyof Schema & string>(name: Name): ReplaceBy<Schema[Name], undefined, null> {
+  get<Name extends HttpHeadersSchemaName<Schema>>(name: Name): ReplaceBy<Schema[Name], undefined, null> {
     return super.get(name) as ReplaceBy<Schema[Name], undefined, null>;
   }
 
@@ -47,40 +47,48 @@ class HttpHeaders<Schema extends HttpHeadersSchema = HttpHeadersSchema> extends 
   }
 
   /** @see {@link https://developer.mozilla.org/docs/Web/API/Headers/has MDN Reference} */
-  has<Name extends keyof Schema & string>(name: Name): boolean {
+  has<Name extends HttpHeadersSchemaName<Schema>>(name: Name): boolean {
     return super.has(name);
   }
 
   /** @see {@link https://developer.mozilla.org/docs/Web/API/Headers/delete MDN Reference} */
-  delete<Name extends keyof Schema & string>(name: Name): void {
+  delete<Name extends HttpHeadersSchemaName<Schema>>(name: Name): void {
     super.delete(name);
   }
 
   forEach<This extends HttpHeaders<Schema>>(
-    callback: <Key extends keyof Schema & string>(value: Defined<Schema[Key]>, key: Key, parent: Headers) => void,
+    callback: <Key extends HttpHeadersSchemaName<Schema>>(
+      value: Defined<Schema[Key]>,
+      key: Key,
+      parent: Headers,
+    ) => void,
     thisArg?: This,
   ): void {
     super.forEach(callback as (value: string, key: string, parent: Headers) => void, thisArg);
   }
 
   /** @see {@link https://developer.mozilla.org/docs/Web/API/Headers/keys MDN Reference} */
-  keys(): IterableIterator<keyof Schema & string> {
-    return super.keys() as IterableIterator<keyof Schema & string>;
+  keys(): IterableIterator<HttpHeadersSchemaName<Schema>> {
+    return super.keys() as IterableIterator<HttpHeadersSchemaName<Schema>>;
   }
 
   /** @see {@link https://developer.mozilla.org/docs/Web/API/Headers/values MDN Reference} */
-  values(): IterableIterator<Defined<Schema[keyof Schema & string]>> {
-    return super.values() as IterableIterator<Defined<Schema[keyof Schema & string]>>;
+  values(): IterableIterator<Defined<Schema[HttpHeadersSchemaName<Schema>]>> {
+    return super.values() as IterableIterator<Defined<Schema[HttpHeadersSchemaName<Schema>]>>;
   }
 
   /** @see {@link https://developer.mozilla.org/docs/Web/API/Headers/entries MDN Reference} */
-  entries(): IterableIterator<[keyof Schema & string, Defined<Schema[keyof Schema & string]>]> {
-    return super.entries() as IterableIterator<[keyof Schema & string, Defined<Schema[keyof Schema & string]>]>;
+  entries(): IterableIterator<[HttpHeadersSchemaName<Schema>, Defined<Schema[HttpHeadersSchemaName<Schema>]>]> {
+    return super.entries() as IterableIterator<
+      [HttpHeadersSchemaName<Schema>, Defined<Schema[HttpHeadersSchemaName<Schema>]>]
+    >;
   }
 
-  [Symbol.iterator](): IterableIterator<[keyof Schema & string, Defined<Schema[keyof Schema & string]>]> {
+  [Symbol.iterator](): IterableIterator<
+    [HttpHeadersSchemaName<Schema>, Defined<Schema[HttpHeadersSchemaName<Schema>]>]
+  > {
     return super[Symbol.iterator]() as IterableIterator<
-      [keyof Schema & string, Defined<Schema[keyof Schema & string]>]
+      [HttpHeadersSchemaName<Schema>, Defined<Schema[HttpHeadersSchemaName<Schema>]>]
     >;
   }
 

--- a/packages/zimic/src/http/headers/__tests__/HttpHeaders.test.ts
+++ b/packages/zimic/src/http/headers/__tests__/HttpHeaders.test.ts
@@ -490,6 +490,18 @@ describe('HttpHeaders', () => {
     // @ts-expect-error
     emptySchemaHeaders.delete('unknown');
 
+    const neverSchemaHeaders = new HttpHeaders<never>();
+    // @ts-expect-error
+    neverSchemaHeaders.set('unknown', '*/*');
+    // @ts-expect-error
+    neverSchemaHeaders.append('unknown', '*/*');
+    // @ts-expect-error
+    neverSchemaHeaders.get('unknown');
+    // @ts-expect-error
+    neverSchemaHeaders.has('unknown');
+    // @ts-expect-error
+    neverSchemaHeaders.delete('unknown');
+
     // @ts-expect-error
     new HttpHeaders<string>();
   });

--- a/packages/zimic/src/http/headers/types.ts
+++ b/packages/zimic/src/http/headers/types.ts
@@ -1,4 +1,4 @@
-import { Defined } from '@/types/utils';
+import { Defined, IfNever } from '@/types/utils';
 
 import { HttpSearchParamsSerialized } from '../searchParams/types';
 import HttpHeaders from './HttpHeaders';
@@ -19,6 +19,8 @@ export type HttpHeadersInit<Schema extends HttpHeadersSchema = HttpHeadersSchema
   | Schema
   | HttpHeaders<Schema>
   | HttpHeadersSchemaTuple<Schema>[];
+
+export type HttpHeadersSchemaName<Schema extends HttpHeadersSchema> = IfNever<Schema, never, keyof Schema & string>;
 
 /**
  * Recursively converts a type to its HTTP headers-serialized version. Numbers and booleans are converted to `${number}`

--- a/packages/zimic/src/http/headers/types.ts
+++ b/packages/zimic/src/http/headers/types.ts
@@ -20,6 +20,7 @@ export type HttpHeadersInit<Schema extends HttpHeadersSchema = HttpHeadersSchema
   | HttpHeaders<Schema>
   | HttpHeadersSchemaTuple<Schema>[];
 
+/** Extracts the names of the headers defined in a {@link HttpHeadersSchema}. Each key is considered a header name. */
 export type HttpHeadersSchemaName<Schema extends HttpHeadersSchema> = IfNever<Schema, never, keyof Schema & string>;
 
 /**

--- a/packages/zimic/src/http/index.ts
+++ b/packages/zimic/src/http/index.ts
@@ -6,9 +6,19 @@ export { default as HttpSearchParams } from './searchParams/HttpSearchParams';
 export type { HttpSearchParamsSerialized } from './searchParams/types';
 export type { HttpHeadersSerialized } from './headers/types';
 
-export type { HttpHeadersInit, HttpHeadersSchema, HttpHeadersSchemaTuple } from './headers/types';
+export type {
+  HttpHeadersInit,
+  HttpHeadersSchema,
+  HttpHeadersSchemaTuple,
+  HttpHeadersSchemaName,
+} from './headers/types';
 
-export type { HttpSearchParamsInit, HttpSearchParamsSchema, HttpSearchParamsSchemaTuple } from './searchParams/types';
+export type {
+  HttpSearchParamsInit,
+  HttpSearchParamsSchema,
+  HttpSearchParamsSchemaTuple,
+  HttpSearchParamsSchemaName,
+} from './searchParams/types';
 
 export type { HttpFormDataSchema } from './formData/types';
 

--- a/packages/zimic/src/http/searchParams/HttpSearchParams.ts
+++ b/packages/zimic/src/http/searchParams/HttpSearchParams.ts
@@ -1,6 +1,12 @@
-import { ReplaceBy, Defined, ArrayItemIfArray, NonArrayKey, ArrayKey } from '@/types/utils';
+import { ReplaceBy, Defined, ArrayItemIfArray } from '@/types/utils';
 
-import { HttpSearchParamsSchema, HttpSearchParamsInit } from './types';
+import {
+  HttpSearchParamsSchema,
+  HttpSearchParamsInit,
+  HttpSearchParamsSchemaName,
+  HttpSearchParamsSchemaNonArrayName,
+  HttpSearchParamsSchemaArrayName,
+} from './types';
 
 function pickPrimitiveProperties<Schema extends HttpSearchParamsSchema>(schema: Schema) {
   const schemaWithPrimitiveProperties = Object.entries(schema).reduce<Record<string, string>>(
@@ -42,12 +48,18 @@ class HttpSearchParams<Schema extends HttpSearchParamsSchema = HttpSearchParamsS
   }
 
   /** @see {@link https://developer.mozilla.org/docs/Web/API/URLSearchParams/set MDN Reference} */
-  set<Name extends keyof Schema & string>(name: Name, value: ArrayItemIfArray<Defined<Schema[Name]>>): void {
+  set<Name extends HttpSearchParamsSchemaName<Schema>>(
+    name: Name,
+    value: ArrayItemIfArray<Defined<Schema[Name]>>,
+  ): void {
     super.set(name, value);
   }
 
   /** @see {@link https://developer.mozilla.org/docs/Web/API/URLSearchParams/append MDN Reference} */
-  append<Name extends keyof Schema & string>(name: Name, value: ArrayItemIfArray<Defined<Schema[Name]>>): void {
+  append<Name extends HttpSearchParamsSchemaName<Schema>>(
+    name: Name,
+    value: ArrayItemIfArray<Defined<Schema[Name]>>,
+  ): void {
     super.append(name, value);
   }
 
@@ -60,7 +72,7 @@ class HttpSearchParams<Schema extends HttpSearchParamsSchema = HttpSearchParamsS
    * @returns The value associated with the key name, or `null` if the key does not exist.
    * @see {@link https://developer.mozilla.org/docs/Web/API/URLSearchParams/get MDN Reference}
    */
-  get<Name extends NonArrayKey<Schema> & string>(
+  get<Name extends HttpSearchParamsSchemaNonArrayName<Schema>>(
     name: Name,
   ): ReplaceBy<ArrayItemIfArray<Schema[Name]>, undefined, null> {
     return super.get(name) as ReplaceBy<ArrayItemIfArray<Schema[Name]>, undefined, null>;
@@ -75,22 +87,28 @@ class HttpSearchParams<Schema extends HttpSearchParamsSchema = HttpSearchParamsS
    * @returns An array of values associated with the key name, or an empty array if the key does not exist.
    * @see {@link https://developer.mozilla.org/docs/Web/API/URLSearchParams/getAll MDN Reference}
    */
-  getAll<Name extends ArrayKey<Schema> & string>(name: Name): ArrayItemIfArray<Defined<Schema[Name]>>[] {
+  getAll<Name extends HttpSearchParamsSchemaArrayName<Schema>>(name: Name): ArrayItemIfArray<Defined<Schema[Name]>>[] {
     return super.getAll(name) as ArrayItemIfArray<Defined<Schema[Name]>>[];
   }
 
   /** @see {@link https://developer.mozilla.org/docs/Web/API/URLSearchParams/has MDN Reference} */
-  has<Name extends keyof Schema & string>(name: Name, value?: ArrayItemIfArray<Defined<Schema[Name]>>): boolean {
+  has<Name extends HttpSearchParamsSchemaName<Schema>>(
+    name: Name,
+    value?: ArrayItemIfArray<Defined<Schema[Name]>>,
+  ): boolean {
     return super.has(name, value);
   }
 
   /** @see {@link https://developer.mozilla.org/docs/Web/API/URLSearchParams/delete MDN Reference} */
-  delete<Name extends keyof Schema & string>(name: Name, value?: ArrayItemIfArray<Defined<Schema[Name]>>): void {
+  delete<Name extends HttpSearchParamsSchemaName<Schema>>(
+    name: Name,
+    value?: ArrayItemIfArray<Defined<Schema[Name]>>,
+  ): void {
     super.delete(name, value);
   }
 
   forEach<This extends HttpSearchParams<Schema>>(
-    callback: <Key extends keyof Schema & string>(
+    callback: <Key extends HttpSearchParamsSchemaName<Schema>>(
       value: ArrayItemIfArray<Defined<Schema[Key]>>,
       key: Key,
       parent: HttpSearchParams<Schema>,
@@ -101,27 +119,29 @@ class HttpSearchParams<Schema extends HttpSearchParamsSchema = HttpSearchParamsS
   }
 
   /** @see {@link https://developer.mozilla.org/docs/Web/API/URLSearchParams/keys MDN Reference} */
-  keys(): IterableIterator<keyof Schema & string> {
-    return super.keys() as IterableIterator<keyof Schema & string>;
+  keys(): IterableIterator<HttpSearchParamsSchemaName<Schema>> {
+    return super.keys() as IterableIterator<HttpSearchParamsSchemaName<Schema>>;
   }
 
   /** @see {@link https://developer.mozilla.org/docs/Web/API/URLSearchParams/values MDN Reference} */
-  values(): IterableIterator<ArrayItemIfArray<Defined<Schema[keyof Schema & string]>>> {
-    return super.values() as IterableIterator<ArrayItemIfArray<Defined<Schema[keyof Schema & string]>>>;
+  values(): IterableIterator<ArrayItemIfArray<Defined<Schema[HttpSearchParamsSchemaName<Schema>]>>> {
+    return super.values() as IterableIterator<ArrayItemIfArray<Defined<Schema[HttpSearchParamsSchemaName<Schema>]>>>;
   }
 
   /** @see {@link https://developer.mozilla.org/docs/Web/API/URLSearchParams/entries MDN Reference} */
-  entries(): IterableIterator<[keyof Schema & string, ArrayItemIfArray<Defined<Schema[keyof Schema & string]>>]> {
+  entries(): IterableIterator<
+    [HttpSearchParamsSchemaName<Schema>, ArrayItemIfArray<Defined<Schema[HttpSearchParamsSchemaName<Schema>]>>]
+  > {
     return super.entries() as IterableIterator<
-      [keyof Schema & string, ArrayItemIfArray<Defined<Schema[keyof Schema & string]>>]
+      [HttpSearchParamsSchemaName<Schema>, ArrayItemIfArray<Defined<Schema[HttpSearchParamsSchemaName<Schema>]>>]
     >;
   }
 
   [Symbol.iterator](): IterableIterator<
-    [keyof Schema & string, ArrayItemIfArray<Defined<Schema[keyof Schema & string]>>]
+    [HttpSearchParamsSchemaName<Schema>, ArrayItemIfArray<Defined<Schema[HttpSearchParamsSchemaName<Schema>]>>]
   > {
     return super[Symbol.iterator]() as IterableIterator<
-      [keyof Schema & string, ArrayItemIfArray<Defined<Schema[keyof Schema & string]>>]
+      [HttpSearchParamsSchemaName<Schema>, ArrayItemIfArray<Defined<Schema[HttpSearchParamsSchemaName<Schema>]>>]
     >;
   }
 

--- a/packages/zimic/src/http/searchParams/HttpSearchParams.ts
+++ b/packages/zimic/src/http/searchParams/HttpSearchParams.ts
@@ -1,12 +1,6 @@
 import { ReplaceBy, Defined, ArrayItemIfArray } from '@/types/utils';
 
-import {
-  HttpSearchParamsSchema,
-  HttpSearchParamsInit,
-  HttpSearchParamsSchemaName,
-  HttpSearchParamsSchemaNonArrayName,
-  HttpSearchParamsSchemaArrayName,
-} from './types';
+import { HttpSearchParamsSchema, HttpSearchParamsInit, HttpSearchParamsSchemaName } from './types';
 
 function pickPrimitiveProperties<Schema extends HttpSearchParamsSchema>(schema: Schema) {
   const schemaWithPrimitiveProperties = Object.entries(schema).reduce<Record<string, string>>(
@@ -72,7 +66,7 @@ class HttpSearchParams<Schema extends HttpSearchParamsSchema = HttpSearchParamsS
    * @returns The value associated with the key name, or `null` if the key does not exist.
    * @see {@link https://developer.mozilla.org/docs/Web/API/URLSearchParams/get MDN Reference}
    */
-  get<Name extends HttpSearchParamsSchemaNonArrayName<Schema>>(
+  get<Name extends HttpSearchParamsSchemaName.NonArray<Schema>>(
     name: Name,
   ): ReplaceBy<ArrayItemIfArray<Schema[Name]>, undefined, null> {
     return super.get(name) as ReplaceBy<ArrayItemIfArray<Schema[Name]>, undefined, null>;
@@ -87,7 +81,7 @@ class HttpSearchParams<Schema extends HttpSearchParamsSchema = HttpSearchParamsS
    * @returns An array of values associated with the key name, or an empty array if the key does not exist.
    * @see {@link https://developer.mozilla.org/docs/Web/API/URLSearchParams/getAll MDN Reference}
    */
-  getAll<Name extends HttpSearchParamsSchemaArrayName<Schema>>(name: Name): ArrayItemIfArray<Defined<Schema[Name]>>[] {
+  getAll<Name extends HttpSearchParamsSchemaName.Array<Schema>>(name: Name): ArrayItemIfArray<Defined<Schema[Name]>>[] {
     return super.getAll(name) as ArrayItemIfArray<Defined<Schema[Name]>>[];
   }
 

--- a/packages/zimic/src/http/searchParams/__tests__/HttpSearchParams.test.ts
+++ b/packages/zimic/src/http/searchParams/__tests__/HttpSearchParams.test.ts
@@ -480,6 +480,22 @@ describe('HttpSearchParams', () => {
     // @ts-expect-error
     emptySchemaSearchParams.delete('unknown');
 
+    const neverSchemaSearchParams = new HttpSearchParams<never>();
+    // @ts-expect-error
+    neverSchemaSearchParams.set('unknown', 'value');
+    // @ts-expect-error
+    neverSchemaSearchParams.append('unknown', 'value');
+    // @ts-expect-error
+    neverSchemaSearchParams.get('unknown');
+    // @ts-expect-error
+    neverSchemaSearchParams.getAll('unknown');
+    // @ts-expect-error
+    neverSchemaSearchParams.has('unknown');
+    // @ts-expect-error
+    neverSchemaSearchParams.has('unknown', 'value');
+    // @ts-expect-error
+    neverSchemaSearchParams.delete('unknown');
+
     // @ts-expect-error
     new HttpSearchParams<string>();
   });

--- a/packages/zimic/src/http/searchParams/types.ts
+++ b/packages/zimic/src/http/searchParams/types.ts
@@ -1,4 +1,4 @@
-import { Defined, ArrayItemIfArray } from '@/types/utils';
+import { Defined, ArrayItemIfArray, IfNever, NonArrayKey, ArrayKey } from '@/types/utils';
 
 import HttpSearchParams from './HttpSearchParams';
 
@@ -19,6 +19,24 @@ export type HttpSearchParamsInit<Schema extends HttpSearchParamsSchema = HttpSea
   | Schema
   | HttpSearchParams<Schema>
   | HttpSearchParamsSchemaTuple<Schema>[];
+
+export type HttpSearchParamsSchemaName<Schema extends HttpSearchParamsSchema> = IfNever<
+  Schema,
+  never,
+  keyof Schema & string
+>;
+
+export type HttpSearchParamsSchemaNonArrayName<Schema extends HttpSearchParamsSchema> = IfNever<
+  Schema,
+  never,
+  NonArrayKey<Schema> & string
+>;
+
+export type HttpSearchParamsSchemaArrayName<Schema extends HttpSearchParamsSchema> = IfNever<
+  Schema,
+  never,
+  ArrayKey<Schema> & string
+>;
 
 type PrimitiveHttpSearchParamsSerialized<Type> = Type extends HttpSearchParamsSchema[string]
   ? Type

--- a/packages/zimic/src/http/searchParams/types.ts
+++ b/packages/zimic/src/http/searchParams/types.ts
@@ -20,22 +20,23 @@ export type HttpSearchParamsInit<Schema extends HttpSearchParamsSchema = HttpSea
   | HttpSearchParams<Schema>
   | HttpSearchParamsSchemaTuple<Schema>[];
 
+export namespace HttpSearchParamsSchemaName {
+  /** Extracts the names of the search params defined in a {@link HttpSearchParamsSchema} that are arrays. */
+  export type Array<Schema extends HttpSearchParamsSchema> = IfNever<Schema, never, ArrayKey<Schema> & string>;
+
+  /** Extracts the names of the search params defined in a {@link HttpSearchParamsSchema} that are not arrays. */
+  export type NonArray<Schema extends HttpSearchParamsSchema> = IfNever<Schema, never, NonArrayKey<Schema> & string>;
+}
+
+/**
+ * Extracts the names of the search params defined in a {@link HttpSearchParamsSchema}. Each key is considered a search
+ * param name.
+ */
+// eslint-disable-next-line @typescript-eslint/no-redeclare
 export type HttpSearchParamsSchemaName<Schema extends HttpSearchParamsSchema> = IfNever<
   Schema,
   never,
   keyof Schema & string
->;
-
-export type HttpSearchParamsSchemaNonArrayName<Schema extends HttpSearchParamsSchema> = IfNever<
-  Schema,
-  never,
-  NonArrayKey<Schema> & string
->;
-
-export type HttpSearchParamsSchemaArrayName<Schema extends HttpSearchParamsSchema> = IfNever<
-  Schema,
-  never,
-  ArrayKey<Schema> & string
 >;
 
 type PrimitiveHttpSearchParamsSerialized<Type> = Type extends HttpSearchParamsSchema[string]

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/typescript.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/typescript.ts
@@ -108,7 +108,7 @@ export function declareTypeHttpInterceptorTests(options: RuntimeSharedHttpInterc
       };
     }>({ type, baseURL }, async (interceptor) => {
       const listHandler = await interceptor.get('/users').respond((request) => {
-        expectTypeOf(request.searchParams).toEqualTypeOf<HttpSearchParams<{}>>();
+        expectTypeOf(request.searchParams).toEqualTypeOf<HttpSearchParams<never>>();
 
         return {
           status: 200,
@@ -118,7 +118,7 @@ export function declareTypeHttpInterceptorTests(options: RuntimeSharedHttpInterc
 
       const _listRequests = await listHandler.requests();
       type RequestSearchParams = (typeof _listRequests)[number]['searchParams'];
-      expectTypeOf<RequestSearchParams>().toEqualTypeOf<HttpSearchParams<{}>>();
+      expectTypeOf<RequestSearchParams>().toEqualTypeOf<HttpSearchParams<never>>();
     });
   });
 
@@ -176,7 +176,7 @@ export function declareTypeHttpInterceptorTests(options: RuntimeSharedHttpInterc
       };
     }>({ type, baseURL }, async (interceptor) => {
       const listHandler = await interceptor.get('/users').respond((request) => {
-        expectTypeOf(request.headers).toEqualTypeOf<HttpHeaders<{}>>();
+        expectTypeOf(request.headers).toEqualTypeOf<HttpHeaders<never>>();
 
         return {
           status: 200,
@@ -186,7 +186,7 @@ export function declareTypeHttpInterceptorTests(options: RuntimeSharedHttpInterc
 
       const _listRequests = await listHandler.requests();
       type RequestHeaders = (typeof _listRequests)[number]['headers'];
-      expectTypeOf<RequestHeaders>().toEqualTypeOf<HttpHeaders<{}>>();
+      expectTypeOf<RequestHeaders>().toEqualTypeOf<HttpHeaders<never>>();
     });
   });
 

--- a/packages/zimic/src/interceptor/http/requestHandler/types/public.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/types/public.ts
@@ -10,7 +10,7 @@ import {
   HttpServiceSchemaMethod,
   HttpServiceSchemaPath,
 } from '@/http/types/schema';
-import { DeepPartial, Default, IfAny, PossiblePromise } from '@/types/utils';
+import { DeepPartial, Default, IfAny, IfNever, PossiblePromise } from '@/types/utils';
 
 import {
   HttpInterceptorRequest,
@@ -38,10 +38,11 @@ export type HttpRequestHandlerHeadersStaticRestriction<
   Method extends HttpServiceSchemaMethod<Schema>,
 > = PartialHttpHeadersOrSchema<HttpRequestHeadersSchema<Default<Schema[Path][Method]>>>;
 
-type PartialHttpSearchParamsOrSchema<Schema extends HttpSearchParamsSchema> =
-  | Partial<Schema>
-  | HttpSearchParams<Partial<Schema>>
-  | HttpSearchParams<Schema>;
+type PartialHttpSearchParamsOrSchema<Schema extends HttpSearchParamsSchema> = IfNever<
+  Schema,
+  never,
+  Partial<Schema> | HttpSearchParams<Partial<Schema>> | HttpSearchParams<Schema>
+>;
 
 /**
  * A static search params restriction to match intercepted requests.

--- a/packages/zimic/src/interceptor/http/requestHandler/types/requests.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/types/requests.ts
@@ -43,14 +43,12 @@ export type HttpRequestHandlerResponseDeclarationFactory<
   request: Omit<HttpInterceptorRequest<Path, MethodSchema>, 'response'>,
 ) => PossiblePromise<HttpRequestHandlerResponseDeclaration<MethodSchema, StatusCode>>;
 
-export type HttpRequestHeadersSchema<MethodSchema extends HttpServiceMethodSchema> = IfNever<
-  Default<DefaultNoExclude<Default<MethodSchema['request']>['headers']>>,
-  {}
+export type HttpRequestHeadersSchema<MethodSchema extends HttpServiceMethodSchema> = Default<
+  DefaultNoExclude<Default<MethodSchema['request']>['headers']>
 >;
 
-export type HttpRequestSearchParamsSchema<MethodSchema extends HttpServiceMethodSchema> = IfNever<
-  Default<DefaultNoExclude<Default<MethodSchema['request']>['searchParams']>>,
-  {}
+export type HttpRequestSearchParamsSchema<MethodSchema extends HttpServiceMethodSchema> = Default<
+  DefaultNoExclude<Default<MethodSchema['request']>['searchParams']>
 >;
 
 export type HttpRequestBodySchema<MethodSchema extends HttpServiceMethodSchema> = ReplaceBy<

--- a/packages/zimic/tsconfig.json
+++ b/packages/zimic/tsconfig.json
@@ -10,9 +10,9 @@
       "@/*": ["./src/*"],
       "@tests/*": ["./tests/*"],
       "@scripts/*": ["./scripts/*"],
-      "@@/*": ["./*"]
+      "@@/package.json": ["./package.json"]
     }
   },
   "include": ["**/*.ts", "**/*.mts"],
-  "exclude": ["node_modules", "dist", "**/fixtures/**/generated"]
+  "exclude": ["node_modules", "dist", "*.d.ts", "**/fixtures/**/generated"]
 }


### PR DESCRIPTION
Closes #311.
