### PR TITLE
fix(ci): ensure release tests use the correct version

### DIFF
--- a/.github/workflows/cache.yaml
+++ b/.github/workflows/cache.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Zimic
+      - name: Set up zimic
         uses: ./.github/actions/zimic-setup
         with:
           node-version: ${{ env.NODE_VERSION }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Set up Zimic
+      - name: Set up zimic
         id: zimic-setup
         uses: ./.github/actions/zimic-setup
         with:
@@ -104,7 +104,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Set up Zimic
+      - name: Set up zimic
         id: zimic-setup
         uses: ./.github/actions/zimic-setup
         with:
@@ -165,7 +165,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Set up Zimic
+      - name: Set up zimic
         id: zimic-setup
         uses: ./.github/actions/zimic-setup
         with:

--- a/.github/workflows/release-github.yaml
+++ b/.github/workflows/release-github.yaml
@@ -18,29 +18,9 @@ env:
   TURBO_LOG_ORDER: stream
 
 jobs:
-  prepare-github-release:
-    name: Prepare GitHub release
-    runs-on: ubuntu-latest
-    timeout-minutes: 2
-
-    outputs:
-      version: ${{ steps.get-version.outputs.version }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Get monorepo release version
-        id: get-version
-        run: |
-          version=v$(jq -r '.version' package.json)
-          echo "version=$version" >> $GITHUB_OUTPUT
-
   release-to-github:
     name: Release to GitHub
     runs-on: ubuntu-latest
-    needs:
-      - prepare-github-release
     timeout-minutes: 3
 
     environment: GitHub
@@ -49,11 +29,20 @@ jobs:
       contents: write
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Get zimic release version
+        id: zimic-version
+        run: |
+          version=$(jq -r '.version' ./packages/zimic/package.json)
+          echo "value=$version" >> $GITHUB_OUTPUT
+
       - name: Create GitHub release
         uses: ncipollo/release-action@v1
         with:
-          name: ${{ needs.prepare-github-release.outputs.version }}
-          tag: ${{ needs.prepare-github-release.outputs.version }}
+          name: v${{ steps.zimic-version.outputs.value }}
+          tag: v${{ steps.zimic-version.outputs.value }}
           commit: ${{ github.sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
           makeLatest: ${{ startsWith(github.ref, 'refs/heads/') && github.ref_name == 'main' }}

--- a/.github/workflows/release-npm.yaml
+++ b/.github/workflows/release-npm.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Zimic
+      - name: Set up zimic
         uses: ./.github/actions/zimic-setup
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -38,23 +38,34 @@ jobs:
           build: zimic^...
           install-playwright-browsers: true
 
+      - name: Get zimic release version
+        id: zimic-version
+        run: |
+          version=$(jq -r '.version' ./packages/zimic/package.json)
+          echo "value=$version" >> $GITHUB_OUTPUT
+
       - name: Build zimic
         run: pnpm turbo build --filter zimic
 
       - name: Prepare NPM tag
         id: npm-tag
         run: |
+          if [[ '${{ github.ref_name }}' != 'v${{ steps.zimic-version.outputs.value }}' ]]; then
+            echo 'The release tag does not match the package version.' >&2
+            exit 1
+          fi
+
           if [[ '${{ github.ref_name }}' == v*.*.*-canary.* ]]; then
-            echo "tag=canary" >> $GITHUB_OUTPUT
+            echo "value=canary" >> $GITHUB_OUTPUT
           elif [[ '${{ github.ref_name }}' == v*.*.* ]]; then
-            echo "tag=latest" >> $GITHUB_OUTPUT
+            echo "value=latest" >> $GITHUB_OUTPUT
           else
-            echo "tag=next" >> $GITHUB_OUTPUT
+            echo "value=next" >> $GITHUB_OUTPUT
           fi
 
       - name: Release to NPM
         working-directory: packages/zimic
-        run: pnpm publish --no-git-checks --tag ${{ steps.npm-tag.outputs.tag }}
+        run: pnpm publish --no-git-checks --tag ${{ steps.npm-tag.outputs.value }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.ZIMIC_NPM_RELEASE_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
@@ -65,12 +76,13 @@ jobs:
             's/link-workspace-packages = true/link-workspace-packages = false/' \
             .npmrc
 
-          for packageJSON in apps/zimic-test-client/package.json examples/package.json examples/*/package.json; do
-            sed -E -i \
-              's/"zimic([0-9]?)": ".*"/"zimic\1": "npm:zimic@${{ steps.npm-tag.outputs.tag }}"/' \
-              $packageJSON
-          done
+          echo "Using zimic@${{ steps.zimic-version.outputs.value }} for testing..."
 
+          for file in apps/zimic-test-client/package.json examples/package.json examples/*/package.json; do
+            sed -E -i \
+              's/"zimic([0-9]?)": ".*"/"zimic\1": "npm:zimic@${{ steps.zimic-version.outputs.value }}"/' \
+              $file
+          done
 
           pnpm install --no-frozen-lockfile
 


### PR DESCRIPTION
### Fixes
- [ci] Refactored the post-release Zimic tests to explicitly use the released version. Previously, the script used the tag (`latest` or `canary`)  and NPM's cache was sometimes not invalidated quickly enough, resulting in the action downloading the **previous** version matching the tag.

### Refactoring
- [ci] Changed the GitHub release workflow to use one job instead of two. Two are not necessary.