### PR TITLE
fix(ci): wiki release job

### DIFF
--- a/.github/workflows/release-wiki.yaml
+++ b/.github/workflows/release-wiki.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Get zimic release version
         id: zimic-version
-        uses: ./.github/actions/zimic-version
+        uses: ./zimic/.github/actions/zimic-version
         with:
           ref-name: ${{ github.ref_name }}
           working-directory: zimic

--- a/.github/workflows/release-wiki.yaml
+++ b/.github/workflows/release-wiki.yaml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   release-zimic-wiki:
-    name: Release zimic to NPM
+    name: Release zimic to GitHub Wiki
     runs-on: ubuntu-latest
     timeout-minutes: 5
 


### PR DESCRIPTION
### Fixes
- [ci] Changed the name of the release job from `NPM` to `GitHub Wiki`
- [ci] Added the directory `/zimic/` to the path referencing the `zimic-version` action
