### PR TITLE
feat(#zimic): improve path params and schema types (#320)

### DIFF
--- a/apps/zimic-test-client/tests/v0/exports/exports.test.ts
+++ b/apps/zimic-test-client/tests/v0/exports/exports.test.ts
@@ -122,6 +122,7 @@ describe('Exports', () => {
     expectTypeOf<HttpSchema.Headers<never>>().not.toBeAny();
     expectTypeOf<HttpSchema.Body<never>>().not.toBeAny();
     expectTypeOf<HttpSchema.SearchParams<never>>().not.toBeAny();
+    expectTypeOf<HttpSchema.PathParams<never>>().not.toBeAny();
     expectTypeOf<HttpSchema.FormData<never>>().not.toBeAny();
 
     expectTypeOf<HttpMethod>().not.toBeAny();

--- a/apps/zimic-test-client/tests/v0/exports/exports.test.ts
+++ b/apps/zimic-test-client/tests/v0/exports/exports.test.ts
@@ -36,6 +36,7 @@ import {
   type LiteralHttpServiceSchemaPath,
   type NonLiteralHttpServiceSchemaPath,
   type PathParamsSchemaFromPath,
+  type InferPathParams,
   type MergeHttpResponsesByStatusCode,
   InvalidFormDataError,
 } from 'zimic0/http';
@@ -53,6 +54,7 @@ import {
   type RemoteHttpInterceptorOptions,
   type UnhandledRequestStrategy,
   type ExtractHttpInterceptorSchema,
+  type InferHttpInterceptorSchema,
   type HttpInterceptorRequest,
   type HttpInterceptorResponse,
   type TrackedHttpInterceptorRequest,
@@ -137,6 +139,7 @@ describe('Exports', () => {
     expectTypeOf<LiteralHttpServiceSchemaPath<never, never>>().not.toBeAny();
     expectTypeOf<NonLiteralHttpServiceSchemaPath<never, never>>().not.toBeAny();
     expectTypeOf<PathParamsSchemaFromPath<never>>().not.toBeAny();
+    expectTypeOf<InferPathParams<never>>().not.toBeAny();
     expectTypeOf<MergeHttpResponsesByStatusCode<never>>().not.toBeAny();
 
     expectTypeOf<InvalidJSONError>().not.toBeAny();
@@ -168,6 +171,7 @@ describe('Exports', () => {
     expectTypeOf<LocalHttpInterceptorOptions>().not.toBeAny();
     expectTypeOf<RemoteHttpInterceptorOptions>().not.toBeAny();
     expectTypeOf<ExtractHttpInterceptorSchema<never>>().not.toBeAny();
+    expectTypeOf<InferHttpInterceptorSchema<never>>().not.toBeAny();
     expectTypeOf<HttpInterceptorRequest<never, never>>().not.toBeAny();
     expectTypeOf<HttpInterceptorResponse<never, never>>().not.toBeAny();
     expectTypeOf<TrackedHttpInterceptorRequest<never, {}>>().not.toBeAny();

--- a/docs/wiki/api‐zimic‐http.md
+++ b/docs/wiki/api‐zimic‐http.md
@@ -391,10 +391,10 @@ type Schema = HttpSchema.Paths<{
   };
 }>;
 
-type Path = NonLiteralHttpServiceSchemaPath<Schema>;
+type Path = HttpServiceSchemaPath<Schema>;
 // "/users" | "/users/:userId" | "/users/${string}"
 
-type GetPath = NonLiteralHttpServiceSchemaPath<Schema, 'GET'>;
+type GetPath = HttpServiceSchemaPath<Schema, 'GET'>;
 // "/users"
 ```
 
@@ -456,7 +456,7 @@ import { type HttpSchema, type HttpStatusCode, type MergeHttpResponsesByStatusCo
 
 // Overriding the 400 status code with a more specific schema
 // and using a generic schema for all other client errors.
-type MergedResponses = MergeHttpResponsesByStatusCode<
+type MergedResponseByStatusCode = MergeHttpResponsesByStatusCode<
   [
     {
       400: { body: { message: string; issues: string[] } };
@@ -476,7 +476,7 @@ type MergedResponses = MergeHttpResponsesByStatusCode<
 
 type Schema = HttpSchema.Paths<{
   '/users': {
-    GET: { response: MergedResponses };
+    GET: { response: MergedResponseByStatusCode };
   };
 }>;
 ```

--- a/docs/wiki/api‐zimic‐http.md
+++ b/docs/wiki/api‐zimic‐http.md
@@ -19,6 +19,7 @@
   - [`NonLiteralHttpServiceSchemaPath`](#nonliteralhttpserviceschemapath)
   - [`HttpServiceSchemaPath`](#httpserviceschemapath)
   - [`PathParamsSchemaFromPath`](#pathparamsschemafrompath)
+  - [`InferPathParams`](#inferpathparams)
   - [`MergeHttpResponsesByStatusCode`](#mergehttpresponsesbystatuscode)
 
 ---
@@ -397,9 +398,46 @@ type GetPath = NonLiteralHttpServiceSchemaPath<Schema, 'GET'>;
 // "/users"
 ```
 
+### `InferPathParams`
+
+Infers the path parameters schema from a path string, optionally validating it against an
+[HttpServiceSchema](api‐zimic‐interceptor‐http‐schemas).
+
+If the first argument is a [HttpServiceSchema](api‐zimic‐interceptor‐http‐schemas) (recommended), the second argument is
+checked to be a valid path in that schema.
+
+```ts
+import { HttpSchema, InferPathParams } from 'zimic/http';
+
+type MySchema = HttpSchema.Paths<{
+  '/users/:userId': {
+    GET: {
+      response: { 200: { body: User } };
+    };
+  };
+}>;
+
+// Using a schema to validate the path (recommended):
+type PathParams = InferPathParams<MySchema, '/users/:userId'>;
+// { userId: string }
+```
+
+```ts
+import { InferPathParams } from 'zimic/http';
+
+// Without using a schema to validate the path (works as `PathParamsSchemaFromPath`):
+type PathParams = InferPathParams<'/users/:userId'>;
+// { userId: string }
+```
+
 ### `PathParamsSchemaFromPath`
 
 Infers the path parameters schema from a path string.
+
+> [!WARNING]
+>
+> This type is **deprecated** and will be removed in a future release. Please use [`InferPathParams`](#inferpathparams)
+> instead.
 
 ```ts
 import { type PathParamsSchemaFromPath } from 'zimic/http';

--- a/docs/wiki/api‐zimic‐interceptor‐http.md
+++ b/docs/wiki/api‐zimic‐interceptor‐http.md
@@ -19,6 +19,7 @@
   - [HTTP `interceptor.clear()`](#http-interceptorclear)
   - [`HttpInterceptor` utility types](#httpinterceptor-utility-types)
     - [`ExtractHttpInterceptorSchema`](#extracthttpinterceptorschema)
+    - [`InferHttpInterceptorSchema`](#inferhttpinterceptorschema)
 - [`HttpRequestHandler`](#httprequesthandler)
   - [HTTP `handler.method()`](#http-handlermethod)
   - [HTTP `handler.path()`](#http-handlerpath)
@@ -437,12 +438,12 @@ await interceptor.clear();
 
 ### `HttpInterceptor` utility types
 
-#### `ExtractHttpInterceptorSchema`
+#### `InferHttpInterceptorSchema`
 
-Extracts the schema of an [HTTP interceptor](#httpinterceptor).
+Infers the schema of an [HTTP interceptor](#httpinterceptor).
 
 ```ts
-import { httpInterceptor, type ExtractHttpInterceptorSchema } from 'zimic/interceptor/http';
+import { httpInterceptor, type InferHttpInterceptorSchema } from 'zimic/interceptor/http';
 
 const interceptor = httpInterceptor.create<{
   '/users': {
@@ -455,7 +456,7 @@ const interceptor = httpInterceptor.create<{
   baseURL: 'http://localhost:3000',
 });
 
-type Schema = ExtractHttpInterceptorSchema<typeof interceptor>;
+type Schema = InferHttpInterceptorSchema<typeof interceptor>;
 // {
 //   '/users': {
 //     GET: {
@@ -464,6 +465,15 @@ type Schema = ExtractHttpInterceptorSchema<typeof interceptor>;
 //   };
 // }
 ```
+
+#### `ExtractHttpInterceptorSchema`
+
+Infers the schema of an [HTTP interceptor](#httpinterceptor).
+
+> [!WARNING]
+>
+> This type is **deprecated** and was renamed to [`InferHttpInterceptorSchema`](#inferhttpinterceptorschema) with no
+> behavior change. Please use [`InferHttpInterceptorSchema`](#inferhttpinterceptorschema) instead.
 
 ## `HttpRequestHandler`
 

--- a/packages/zimic/src/http/index.ts
+++ b/packages/zimic/src/http/index.ts
@@ -35,6 +35,7 @@ export type {
   HttpSchema,
   HttpMethod,
   HttpStatusCode,
+  HttpPathParamsSchema,
   HttpServiceRequestSchema,
   HttpServiceResponseSchema,
   HttpServiceResponseSchemaByStatusCode,

--- a/packages/zimic/src/http/index.ts
+++ b/packages/zimic/src/http/index.ts
@@ -47,5 +47,6 @@ export type {
   NonLiteralHttpServiceSchemaPath,
   HttpServiceSchemaPath,
   PathParamsSchemaFromPath,
+  InferPathParams,
   MergeHttpResponsesByStatusCode,
 } from './types/schema';

--- a/packages/zimic/src/http/types/__tests__/schema.test.ts
+++ b/packages/zimic/src/http/types/__tests__/schema.test.ts
@@ -2,9 +2,112 @@ import { describe, expectTypeOf, it } from 'vitest';
 
 import { JSONValue } from '@/types/json';
 
-import { HttpSchema, InferPathParams } from '../schema';
+import {
+  HttpSchema,
+  HttpServiceSchemaPath,
+  HttpStatusCode,
+  InferPathParams,
+  LiteralHttpServiceSchemaPath,
+  MergeHttpResponsesByStatusCode,
+  NonLiteralHttpServiceSchemaPath,
+  PathParamsSchemaFromPath,
+} from '../schema';
 
 describe('Schema types', () => {
+  type User = JSONValue<{
+    name: string;
+  }>;
+
+  type Schema = HttpSchema.Paths<{
+    '/users': {
+      POST: {
+        request: { body: User };
+        response: { 201: { body: User } };
+      };
+    };
+
+    '/users/:userId': {
+      GET: {
+        response: { 200: { body: User } };
+      };
+    };
+
+    '/users/:userId/notifications/:notificationId': {
+      PATCH: {
+        request: { body: { read: boolean } };
+        response: { 204: {} };
+      };
+    };
+  }>;
+
+  describe('LiteralHttpServiceSchemaPath', () => {
+    it('should extract the literal paths from a service schema', () => {
+      expectTypeOf<LiteralHttpServiceSchemaPath<Schema>>().toEqualTypeOf<
+        '/users' | '/users/:userId' | '/users/:userId/notifications/:notificationId'
+      >();
+
+      expectTypeOf<LiteralHttpServiceSchemaPath<Schema, 'GET'>>().toEqualTypeOf<'/users/:userId'>();
+    });
+  });
+
+  describe('NonLiteralHttpServiceSchemaPath', () => {
+    it('should extract the nonLiteral paths from a service schema', () => {
+      expectTypeOf<NonLiteralHttpServiceSchemaPath<Schema>>().toEqualTypeOf<
+        '/users' | `/users/${string}` | `/users/${string}/notifications/${string}`
+      >();
+
+      expectTypeOf<NonLiteralHttpServiceSchemaPath<Schema, 'GET'>>().toEqualTypeOf<`/users/${string}`>();
+    });
+  });
+
+  describe('HttpServiceSchemaPath', () => {
+    it('should extract the nonLiteral paths from a service schema', () => {
+      expectTypeOf<HttpServiceSchemaPath<Schema>>().toEqualTypeOf<
+        | '/users'
+        | '/users/:userId'
+        | `/users/${string}`
+        | '/users/:userId/notifications/:notificationId'
+        | `/users/${string}/notifications/${string}`
+      >();
+
+      expectTypeOf<HttpServiceSchemaPath<Schema, 'GET'>>().toEqualTypeOf<'/users/:userId' | `/users/${string}`>();
+    });
+  });
+
+  describe('PathParamsSchemaFromPath', () => {
+    it('should infer path param schemas from path strings', () => {
+      expectTypeOf<PathParamsSchemaFromPath<'/users'>>().toEqualTypeOf<HttpSchema.PathParams<{}>>();
+
+      expectTypeOf<PathParamsSchemaFromPath<'/users/:userId'>>().toEqualTypeOf<
+        HttpSchema.PathParams<{
+          userId: string;
+        }>
+      >();
+
+      expectTypeOf<PathParamsSchemaFromPath<'/users/:userId/:otherId'>>().toEqualTypeOf<
+        HttpSchema.PathParams<{
+          userId: string;
+          otherId: string;
+        }>
+      >();
+
+      expectTypeOf<PathParamsSchemaFromPath<'/users/:userId/:otherId/:anotherId'>>().toEqualTypeOf<
+        HttpSchema.PathParams<{
+          userId: string;
+          otherId: string;
+          anotherId: string;
+        }>
+      >();
+
+      expectTypeOf<PathParamsSchemaFromPath<'/users/:userId/notifications/:notificationId'>>().toEqualTypeOf<
+        HttpSchema.PathParams<{
+          userId: string;
+          notificationId: string;
+        }>
+      >();
+    });
+  });
+
   describe('InferPathParams', () => {
     it('should infer path param schemas from path strings', () => {
       expectTypeOf<InferPathParams<'/users'>>().toEqualTypeOf<HttpSchema.PathParams<{}>>();
@@ -39,32 +142,6 @@ describe('Schema types', () => {
     });
 
     it('should infer path param schemas from path strings validated by a service schema', () => {
-      type User = JSONValue<{
-        name: string;
-      }>;
-
-      type Schema = HttpSchema.Paths<{
-        '/users': {
-          POST: {
-            request: { body: User };
-            response: { 201: { body: User } };
-          };
-        };
-
-        '/users/:userId': {
-          GET: {
-            response: { 200: { body: User } };
-          };
-        };
-
-        '/users/:userId/notifications/:notificationId': {
-          PATCH: {
-            request: { body: { read: boolean } };
-            response: { 204: {} };
-          };
-        };
-      }>;
-
       expectTypeOf<InferPathParams<Schema, '/users'>>().toEqualTypeOf<HttpSchema.PathParams<{}>>();
 
       expectTypeOf<InferPathParams<Schema, '/users/:userId'>>().toEqualTypeOf<
@@ -81,6 +158,33 @@ describe('Schema types', () => {
       expectTypeOf<InferPathParams<Schema, '/users/1'>>();
       // @ts-expect-error
       expectTypeOf<InferPathParams<Schema, '/users/1/notifications/2'>>();
+    });
+  });
+
+  describe('MergeHttpResponsesByStatusCode', () => {
+    it('should merge responses by status code', () => {
+      type MergedResponseByStatusCode = MergeHttpResponsesByStatusCode<
+        [
+          { 100: { body: { message: string; issues: string[] } } },
+          { 101: { body: null } },
+          { 101: { body: string } },
+          { [StatusCode in HttpStatusCode.Information]: { body: { message: string } } },
+          { 102: { body: Blob }; 502: { headers: {} } },
+          { 500: { body: { message?: string } } },
+          { 502: { body: string } },
+        ]
+      >;
+
+      expectTypeOf<MergedResponseByStatusCode>().toEqualTypeOf<
+        HttpSchema.ResponseByStatusCode<{
+          100: { body: { message: string; issues: string[] } };
+          101: { body: null };
+          102: { body: { message: string } };
+          103: { body: { message: string } };
+          500: { body: { message?: string } };
+          502: { headers: {} };
+        }>
+      >();
     });
   });
 });

--- a/packages/zimic/src/http/types/__tests__/schema.test.ts
+++ b/packages/zimic/src/http/types/__tests__/schema.test.ts
@@ -1,0 +1,86 @@
+import { describe, expectTypeOf, it } from 'vitest';
+
+import { JSONValue } from '@/types/json';
+
+import { HttpSchema, InferPathParams } from '../schema';
+
+describe('Schema types', () => {
+  describe('InferPathParams', () => {
+    it('should infer path param schemas from path strings', () => {
+      expectTypeOf<InferPathParams<'/users'>>().toEqualTypeOf<HttpSchema.PathParams<{}>>();
+
+      expectTypeOf<InferPathParams<'/users/:userId'>>().toEqualTypeOf<
+        HttpSchema.PathParams<{
+          userId: string;
+        }>
+      >();
+
+      expectTypeOf<InferPathParams<'/users/:userId/:otherId'>>().toEqualTypeOf<
+        HttpSchema.PathParams<{
+          userId: string;
+          otherId: string;
+        }>
+      >();
+
+      expectTypeOf<InferPathParams<'/users/:userId/:otherId/:anotherId'>>().toEqualTypeOf<
+        HttpSchema.PathParams<{
+          userId: string;
+          otherId: string;
+          anotherId: string;
+        }>
+      >();
+
+      expectTypeOf<InferPathParams<'/users/:userId/notifications/:notificationId'>>().toEqualTypeOf<
+        HttpSchema.PathParams<{
+          userId: string;
+          notificationId: string;
+        }>
+      >();
+    });
+
+    it('should infer path param schemas from path strings validated by a service schema', () => {
+      type User = JSONValue<{
+        name: string;
+      }>;
+
+      type Schema = HttpSchema.Paths<{
+        '/users': {
+          POST: {
+            request: { body: User };
+            response: { 201: { body: User } };
+          };
+        };
+
+        '/users/:userId': {
+          GET: {
+            response: { 200: { body: User } };
+          };
+        };
+
+        '/users/:userId/notifications/:notificationId': {
+          PATCH: {
+            request: { body: { read: boolean } };
+            response: { 204: {} };
+          };
+        };
+      }>;
+
+      expectTypeOf<InferPathParams<Schema, '/users'>>().toEqualTypeOf<HttpSchema.PathParams<{}>>();
+
+      expectTypeOf<InferPathParams<Schema, '/users/:userId'>>().toEqualTypeOf<
+        HttpSchema.PathParams<{ userId: string }>
+      >();
+
+      expectTypeOf<InferPathParams<Schema, '/users/:userId/notifications/:notificationId'>>().toEqualTypeOf<
+        HttpSchema.PathParams<{ userId: string; notificationId: string }>
+      >();
+
+      // @ts-expect-error
+      expectTypeOf<InferPathParams<Schema, '/unknown'>>();
+      // @ts-expect-error
+      expectTypeOf<InferPathParams<Schema, '/users/1'>>();
+      // @ts-expect-error
+      expectTypeOf<InferPathParams<Schema, '/users/1/notifications/2'>>();
+    });
+  });
+});

--- a/packages/zimic/src/http/types/schema.ts
+++ b/packages/zimic/src/http/types/schema.ts
@@ -25,6 +25,10 @@ export const HTTP_METHODS = Object.freeze(['GET', 'POST', 'PUT', 'PATCH', 'DELET
  */
 export type HttpMethod = (typeof HTTP_METHODS)[number];
 
+export interface HttpPathParamsSchema {
+  [paramName: string]: string | undefined;
+}
+
 /**
  * A schema representing the structure of an HTTP request.
  *
@@ -249,6 +253,8 @@ export namespace HttpSchema {
   export type Headers<Schema extends HttpHeadersSchema> = Schema;
   /** Validates that a type is a valid HTTP search params schema. */
   export type SearchParams<Schema extends HttpSearchParamsSchema> = Schema;
+  /** Validates that a type is a valid HTTP path params schema. */
+  export type PathParams<Schema extends HttpPathParamsSchema> = Schema;
   /** Validates that a type is a valid HTTP form data schema. */
   export type FormData<Schema extends HttpFormDataSchema> = Schema;
 }
@@ -409,23 +415,64 @@ export type HttpServiceSchemaPath<
   Method extends HttpServiceSchemaMethod<Schema> = HttpServiceSchemaMethod<Schema>,
 > = LiteralHttpServiceSchemaPath<Schema, Method> | NonLiteralHttpServiceSchemaPath<Schema, Method>;
 
-type RecursivePathParamsSchemaFromPath<Path extends string> =
-  Path extends `${infer _Prefix}:${infer ParamName}/${infer Suffix}`
-    ? { [Name in ParamName]: string } & RecursivePathParamsSchemaFromPath<Suffix>
-    : Path extends `${infer _Prefix}:${infer ParamName}`
-      ? { [Name in ParamName]: string }
-      : {};
+type RecursiveInferPathParams<Path extends string> = Path extends `${infer _Prefix}:${infer ParamName}/${infer Suffix}`
+  ? { [Name in ParamName]: string } & RecursiveInferPathParams<Suffix>
+  : Path extends `${infer _Prefix}:${infer ParamName}`
+    ? { [Name in ParamName]: string }
+    : {};
+
+/**
+ * Infers the path parameters schema from a path string, optionally validating it against an {@link HttpServiceSchema}.
+ *
+ * If the first argument is a {@link HttpServiceSchema} (recommended), the second argument is checked to be a valid path
+ * in that schema.
+ *
+ * @example
+ *   import { HttpSchema, InferPathParams } from 'zimic/http';
+ *
+ *   type MySchema = HttpSchema.Paths<{
+ *     '/users/:userId': {
+ *       GET: {
+ *         response: { 200: { body: User } };
+ *       };
+ *     };
+ *   }>;
+ *
+ *   // Using a schema to validate the path (recommended):
+ *   type PathParams = InferPathParams<MySchema, '/users/:userId'>;
+ *   // { userId: string }
+ *
+ * @example
+ *   import { InferPathParams } from 'zimic/http';
+ *
+ *   // Without using a schema to validate the path:
+ *   type PathParams = InferPathParams<'/users/:userId'>;
+ *   // { userId: string }
+ */
+export type InferPathParams<
+  PathOrSchema extends string | HttpServiceSchema,
+  OptionalPath extends PathOrSchema extends HttpServiceSchema
+    ? LiteralHttpServiceSchemaPath<PathOrSchema>
+    : never = never,
+> = Prettify<
+  RecursiveInferPathParams<
+    PathOrSchema extends HttpServiceSchema ? OptionalPath : PathOrSchema extends string ? PathOrSchema : never
+  >
+>;
 
 /**
  * Infers the path parameters schema from a path string.
  *
+ * @deprecated Use {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐http#inferpathparams InferPathParams} instead,
+ *   which works as a drop-in replacement with additional validation.
  * @example
  *   import { PathParamsSchemaFromPath } from 'zimic/http';
  *
- *   type PathParams = PathParamsSchemaFromPath<'/users/:userId/notifications'>;
+ *   // Without using a schema to validate the path:
+ *   type PathParams = PathParamsSchemaFromPath<'/users/:userId'>;
  *   // { userId: string }
  */
-export type PathParamsSchemaFromPath<Path extends string> = Prettify<RecursivePathParamsSchemaFromPath<Path>>;
+export type PathParamsSchemaFromPath<Path extends string> = InferPathParams<Path>;
 
 type OmitPastHttpStatusCodes<
   Schema extends HttpServiceResponseSchemaByStatusCode.Loose,

--- a/packages/zimic/src/http/types/schema.ts
+++ b/packages/zimic/src/http/types/schema.ts
@@ -445,7 +445,7 @@ type RecursiveInferPathParams<Path extends string> = Path extends `${infer _Pref
  * @example
  *   import { InferPathParams } from 'zimic/http';
  *
- *   // Without using a schema to validate the path:
+ *   // Without using a schema to validate the path (works as `PathParamsSchemaFromPath`):
  *   type PathParams = InferPathParams<'/users/:userId'>;
  *   // { userId: string }
  */

--- a/packages/zimic/src/http/types/schema.ts
+++ b/packages/zimic/src/http/types/schema.ts
@@ -402,10 +402,10 @@ export type LiteralHttpServiceSchemaPathFromNonLiteral<
  *     };
  *   }>;
  *
- *   type Path = NonLiteralHttpServiceSchemaPath<Schema>;
+ *   type Path = HttpServiceSchemaPath<Schema>;
  *   // "/users" | "/users/:userId" | "/users/${string}"
  *
- *   type GetPath = NonLiteralHttpServiceSchemaPath<Schema, 'GET'>;
+ *   type GetPath = HttpServiceSchemaPath<Schema, 'GET'>;
  *   // "/users"
  *
  * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http‐schemas Declaring HTTP Service Schemas}
@@ -504,7 +504,7 @@ type RecursiveMergeHttpResponsesByStatusCode<
  *
  *   // Overriding the 400 status code with a more specific schema
  *   // and using a generic schema for all other client errors.
- *   type MergedResponses = MergeHttpResponsesByStatusCode<
+ *   type MergedResponseByStatusCode = MergeHttpResponsesByStatusCode<
  *     [
  *       {
  *         400: { body: { message: string; issues: string[] } };
@@ -524,7 +524,7 @@ type RecursiveMergeHttpResponsesByStatusCode<
  *
  *   type Schema = HttpSchema.Paths<{
  *     '/users': {
- *       GET: { response: MergedResponses };
+ *       GET: { response: MergedResponseByStatusCode };
  *     };
  *   }>;
  */

--- a/packages/zimic/src/interceptor/http/index.ts
+++ b/packages/zimic/src/interceptor/http/index.ts
@@ -36,7 +36,7 @@ export type {
   HttpInterceptorOptions,
   UnhandledRequestStrategy,
 } from './interceptor/types/options';
-export type { ExtractHttpInterceptorSchema } from './interceptor/types/schema';
+export type { ExtractHttpInterceptorSchema, InferHttpInterceptorSchema } from './interceptor/types/schema';
 
 export type { LocalHttpInterceptor, RemoteHttpInterceptor, HttpInterceptor } from './interceptor/types/public';
 

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/index.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/index.ts
@@ -10,9 +10,9 @@ import { declareBodyHttpInterceptorTests } from './bodies';
 import { declareBypassHttpInterceptorTests } from './bypass';
 import { declareClearHttpInterceptorTests } from './clear';
 import { declareDeclareHttpInterceptorTests } from './default';
-import { declareDynamicPathsHttpInterceptorTests } from './dynamicPaths';
 import { declareHandlerHttpInterceptorTests } from './handlers';
 import { declareLifeCycleHttpInterceptorTests } from './lifeCycle';
+import { declarePathParamsHttpInterceptorTests } from './pathParams';
 import { declareRestrictionsHttpInterceptorTests } from './restrictions';
 import { SharedHttpInterceptorTestsOptions, RuntimeSharedHttpInterceptorTestsOptions } from './types';
 import { declareTypeHttpInterceptorTests } from './typescript';
@@ -77,8 +77,8 @@ export function declareSharedHttpInterceptorTests(options: SharedHttpInterceptor
       declareHandlerHttpInterceptorTests(runtimeOptions);
     });
 
-    describe('Dynamic paths', async () => {
-      await declareDynamicPathsHttpInterceptorTests(runtimeOptions);
+    describe('Paths params', async () => {
+      await declarePathParamsHttpInterceptorTests(runtimeOptions);
     });
 
     describe('Bodies', async () => {

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/pathParams.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/pathParams.ts
@@ -14,7 +14,7 @@ import { assessPreflightInterference, usingHttpInterceptor } from '@tests/utils/
 import { HttpInterceptorOptions } from '../../types/options';
 import { RuntimeSharedHttpInterceptorTestsOptions } from './types';
 
-export async function declareDynamicPathsHttpInterceptorTests(options: RuntimeSharedHttpInterceptorTestsOptions) {
+export async function declarePathParamsHttpInterceptorTests(options: RuntimeSharedHttpInterceptorTestsOptions) {
   const { platform, type, getBaseURL, getInterceptorOptions } = options;
 
   const crypto = await importCrypto();
@@ -54,7 +54,7 @@ export async function declareDynamicPathsHttpInterceptorTests(options: RuntimeSh
       response: { 200: { headers: AccessControlHeaders } };
     }>;
 
-    it(`should support intercepting ${method} requests with a dynamic path`, async () => {
+    it(`should support intercepting ${method} requests with a path parameter`, async () => {
       await usingHttpInterceptor<{
         '/users/:id': {
           GET: MethodSchema;

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/typescript.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/typescript.ts
@@ -9,7 +9,7 @@ import { Prettify } from '@/types/utils';
 import { usingHttpInterceptor } from '@tests/utils/interceptors';
 
 import { createHttpInterceptor } from '../../factory';
-import { ExtractHttpInterceptorSchema } from '../../types/schema';
+import { InferHttpInterceptorSchema } from '../../types/schema';
 import { RuntimeSharedHttpInterceptorTestsOptions } from './types';
 
 export function declareTypeHttpInterceptorTests(options: RuntimeSharedHttpInterceptorTestsOptions) {
@@ -913,8 +913,8 @@ export function declareTypeHttpInterceptorTests(options: RuntimeSharedHttpInterc
 
     const _compositeInterceptor = createHttpInterceptor<InterceptorSchema>({ type, baseURL });
 
-    type CompositeInterceptorSchema = ExtractHttpInterceptorSchema<typeof _compositeInterceptor>;
-    type InlineInterceptorSchema = ExtractHttpInterceptorSchema<typeof _inlineInterceptor>;
+    type CompositeInterceptorSchema = InferHttpInterceptorSchema<typeof _compositeInterceptor>;
+    type InlineInterceptorSchema = InferHttpInterceptorSchema<typeof _inlineInterceptor>;
     expectTypeOf<Prettify<CompositeInterceptorSchema>>().toEqualTypeOf<Prettify<InlineInterceptorSchema>>();
   });
 

--- a/packages/zimic/src/interceptor/http/interceptor/types/schema.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/types/schema.ts
@@ -1,10 +1,51 @@
 import { LocalHttpInterceptor, RemoteHttpInterceptor } from './public';
 
 /**
- * Extracts the schema of an
+ * Infers the schema of an
  * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#httpinterceptor `HttpInterceptor`}.
  *
  * @example
+ *   import { httpInterceptor, type InferHttpInterceptorSchema } from 'zimic';
+ *
+ *   const interceptor = httpInterceptor.create<{
+ *     '/users': {
+ *       GET: {
+ *         response: { 200: { body: User[] } };
+ *       };
+ *     };
+ *   }>({
+ *     type: 'local',
+ *     baseURL: 'http://localhost:3000',
+ *   });
+ *
+ *   type Schema = InferHttpInterceptorSchema<typeof interceptor>;
+ *   // {
+ *   //   '/users': {
+ *   //     GET: {
+ *   //       response: { 200: { body: User[] } };
+ *   //     };
+ *   //   };
+ *   // }
+ *
+ * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http‐schemas Declaring service schemas}
+ */
+export type InferHttpInterceptorSchema<Interceptor> =
+  Interceptor extends LocalHttpInterceptor<infer Schema>
+    ? Schema
+    : Interceptor extends RemoteHttpInterceptor<infer Schema>
+      ? Schema
+      : never;
+
+/**
+ * Infers the schema of an
+ * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#httpinterceptor `HttpInterceptor`}.
+ *
+ * @deprecated Use
+ *   {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#inferpathparams InferHttpInterceptorSchema}
+ *   instead, which is a drop-in replacement.
+ * @example
+ *   import { httpInterceptor, type ExtractHttpInterceptorSchema } from 'zimic';
+ *
  *   const interceptor = httpInterceptor.create<{
  *     '/users': {
  *       GET: {
@@ -27,9 +68,4 @@ import { LocalHttpInterceptor, RemoteHttpInterceptor } from './public';
  *
  * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http‐schemas Declaring service schemas}
  */
-export type ExtractHttpInterceptorSchema<Interceptor> =
-  Interceptor extends LocalHttpInterceptor<infer Schema>
-    ? Schema
-    : Interceptor extends RemoteHttpInterceptor<infer Schema>
-      ? Schema
-      : never;
+export type ExtractHttpInterceptorSchema<Interceptor> = InferHttpInterceptorSchema<Interceptor>;

--- a/packages/zimic/src/interceptor/http/interceptorWorker/HttpInterceptorWorker.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/HttpInterceptorWorker.ts
@@ -11,7 +11,7 @@ import {
   HttpServiceMethodSchema,
   HttpServiceResponseSchemaStatusCode,
   HttpServiceSchema,
-  PathParamsSchemaFromPath,
+  InferPathParams,
 } from '@/http/types/schema';
 import { Default, PossiblePromise } from '@/types/utils';
 import { formatObjectToLog, logWithPrefix } from '@/utils/console';
@@ -322,13 +322,10 @@ abstract class HttpInterceptorWorker {
     return HTTP_INTERCEPTOR_RESPONSE_HIDDEN_BODY_PROPERTIES.has(property);
   }
 
-  static parseRawPathParams<Path extends string>(
-    matchedURLRegex: RegExp,
-    request: HttpRequest,
-  ): PathParamsSchemaFromPath<Path> {
+  static parseRawPathParams<Path extends string>(matchedURLRegex: RegExp, request: HttpRequest): InferPathParams<Path> {
     const match = request.url.match(matchedURLRegex);
     const pathParams = { ...match?.groups };
-    return pathParams as PathParamsSchemaFromPath<Path>;
+    return pathParams as InferPathParams<Path>;
   }
 
   static async parseRawBody<Body extends HttpBody>(resource: HttpRequest | HttpResponse) {

--- a/packages/zimic/src/interceptor/http/requestHandler/types/requests.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/types/requests.ts
@@ -6,7 +6,7 @@ import {
   HttpServiceMethodSchema,
   HttpServiceResponseSchema,
   HttpServiceResponseSchemaStatusCode,
-  PathParamsSchemaFromPath,
+  InferPathParams,
 } from '@/http/types/schema';
 import { Default, DefaultNoExclude, IfNever, PossiblePromise, ReplaceBy } from '@/types/utils';
 
@@ -66,7 +66,7 @@ export interface HttpInterceptorRequest<Path extends string, MethodSchema extend
   /** The headers of the request. */
   headers: HttpHeaders<HttpRequestHeadersSchema<MethodSchema>>;
   /** The path parameters of the request. They are parsed from the path string when using dynamic paths. */
-  pathParams: PathParamsSchemaFromPath<Path>;
+  pathParams: InferPathParams<Path>;
   /** The search parameters of the request. */
   searchParams: HttpSearchParams<HttpRequestSearchParamsSchema<MethodSchema>>;
   /** The body of the request. It is already parsed by default. */

--- a/packages/zimic/src/interceptor/http/requestHandler/types/requests.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/types/requests.ts
@@ -123,8 +123,8 @@ export const HTTP_INTERCEPTOR_RESPONSE_HIDDEN_BODY_PROPERTIES = Object.freeze(
 );
 
 /**
- * A strict representation of a tracked, intercepted HTTP request, along with its response. The body, search params and
- * path params are already parsed by default.
+ * A strict representation of an intercepted HTTP request, along with its response. The body, search params and path
+ * params are already parsed by default.
  */
 export interface TrackedHttpInterceptorRequest<
   Path extends string,


### PR DESCRIPTION
### Refactoring
- [#zimic] Improved the file name of the test file checking path params. 

### Features
- [#zimic] Created the utility type `InferPathParams` and deprecated [`PathParamsSchemaFromPath`](https://github.com/zimicjs/zimic/wiki/api%E2%80%90zimic%E2%80%90http#pathparamsschemafrompath).
- [#zimic] Renamed the utility type [`ExtractHttpInterceptorSchema`](https://github.com/zimicjs/zimic/wiki/api%E2%80%90zimic%E2%80%90interceptor%E2%80%90http#extracthttpinterceptorschema) to `InferHttpInterceptorSchema`

### Documentation
- Fixed a wrong type used in a code snippet.

### Tests
- [#zimic] Added tests to check utility HTTP types.

Closes #320.