### PR TITLE
refactor(#zimic): simplify http schema type names

### DIFF
--- a/apps/zimic-test-client/tests/v0/exports/exports.test.ts
+++ b/apps/zimic-test-client/tests/v0/exports/exports.test.ts
@@ -26,15 +26,25 @@ import {
   type HttpStatusCode,
   type HttpServiceSchema,
   type HttpServiceMethodsSchema,
+  type HttpMethodsSchema,
   type HttpServiceMethodSchema,
+  type HttpMethodSchema,
   type HttpServiceRequestSchema,
+  type HttpRequestSchema,
   type HttpServiceResponseSchemaByStatusCode,
+  type HttpResponseSchemaByStatusCode,
   type HttpServiceResponseSchema,
+  type HttpResponseSchema,
   type HttpServiceResponseSchemaStatusCode,
+  type HttpResponseSchemaStatusCode,
   type HttpServiceSchemaMethod,
+  type HttpSchemaMethod,
   type HttpServiceSchemaPath,
+  type HttpSchemaPath,
   type LiteralHttpServiceSchemaPath,
+  type LiteralHttpSchemaPath,
   type NonLiteralHttpServiceSchemaPath,
+  type NonLiteralHttpSchemaPath,
   type PathParamsSchemaFromPath,
   type InferPathParams,
   type MergeHttpResponsesByStatusCode,
@@ -127,18 +137,29 @@ describe('Exports', () => {
 
     expectTypeOf<HttpMethod>().not.toBeAny();
     expectTypeOf<HttpStatusCode>().not.toBeAny();
+    expectTypeOf<HttpSchema>().not.toBeAny();
     expectTypeOf<HttpServiceSchema>().not.toBeAny();
     expectTypeOf<HttpServiceMethodsSchema>().not.toBeAny();
+    expectTypeOf<HttpMethodsSchema>().not.toBeAny();
     expectTypeOf<HttpServiceMethodSchema>().not.toBeAny();
+    expectTypeOf<HttpMethodSchema>().not.toBeAny();
     expectTypeOf<HttpServiceRequestSchema>().not.toBeAny();
+    expectTypeOf<HttpRequestSchema>().not.toBeAny();
     expectTypeOf<HttpServiceResponseSchemaByStatusCode>().not.toBeAny();
+    expectTypeOf<HttpResponseSchemaByStatusCode>().not.toBeAny();
     expectTypeOf<HttpServiceResponseSchema>().not.toBeAny();
+    expectTypeOf<HttpResponseSchema>().not.toBeAny();
     expectTypeOf<HttpServiceResponseSchemaStatusCode<never>>().not.toBeAny();
+    expectTypeOf<HttpResponseSchemaStatusCode<never>>().not.toBeAny();
 
     expectTypeOf<HttpServiceSchemaMethod<never>>().not.toBeAny();
+    expectTypeOf<HttpSchemaMethod<never>>().not.toBeAny();
     expectTypeOf<HttpServiceSchemaPath<never, never>>().not.toBeAny();
+    expectTypeOf<HttpSchemaPath<never, never>>().not.toBeAny();
     expectTypeOf<LiteralHttpServiceSchemaPath<never, never>>().not.toBeAny();
+    expectTypeOf<LiteralHttpSchemaPath<never, never>>().not.toBeAny();
     expectTypeOf<NonLiteralHttpServiceSchemaPath<never, never>>().not.toBeAny();
+    expectTypeOf<NonLiteralHttpSchemaPath<never, never>>().not.toBeAny();
     expectTypeOf<PathParamsSchemaFromPath<never>>().not.toBeAny();
     expectTypeOf<InferPathParams<never>>().not.toBeAny();
     expectTypeOf<MergeHttpResponsesByStatusCode<never>>().not.toBeAny();

--- a/apps/zimic-test-client/tests/v0/exports/exports.test.ts
+++ b/apps/zimic-test-client/tests/v0/exports/exports.test.ts
@@ -42,9 +42,7 @@ import {
   type HttpServiceSchemaPath,
   type HttpSchemaPath,
   type LiteralHttpServiceSchemaPath,
-  type LiteralHttpSchemaPath,
   type NonLiteralHttpServiceSchemaPath,
-  type NonLiteralHttpSchemaPath,
   type PathParamsSchemaFromPath,
   type InferPathParams,
   type MergeHttpResponsesByStatusCode,
@@ -157,9 +155,9 @@ describe('Exports', () => {
     expectTypeOf<HttpServiceSchemaPath<never, never>>().not.toBeAny();
     expectTypeOf<HttpSchemaPath<never, never>>().not.toBeAny();
     expectTypeOf<LiteralHttpServiceSchemaPath<never, never>>().not.toBeAny();
-    expectTypeOf<LiteralHttpSchemaPath<never, never>>().not.toBeAny();
+    expectTypeOf<HttpSchemaPath.Literal<never, never>>().not.toBeAny();
     expectTypeOf<NonLiteralHttpServiceSchemaPath<never, never>>().not.toBeAny();
-    expectTypeOf<NonLiteralHttpSchemaPath<never, never>>().not.toBeAny();
+    expectTypeOf<HttpSchemaPath.NonLiteral<never, never>>().not.toBeAny();
     expectTypeOf<PathParamsSchemaFromPath<never>>().not.toBeAny();
     expectTypeOf<InferPathParams<never>>().not.toBeAny();
     expectTypeOf<MergeHttpResponsesByStatusCode<never>>().not.toBeAny();

--- a/apps/zimic-test-client/tests/v0/exports/exports.test.ts
+++ b/apps/zimic-test-client/tests/v0/exports/exports.test.ts
@@ -137,8 +137,8 @@ describe('Exports', () => {
 
     expectTypeOf<HttpMethod>().not.toBeAny();
     expectTypeOf<HttpStatusCode>().not.toBeAny();
-    expectTypeOf<HttpSchema>().not.toBeAny();
     expectTypeOf<HttpServiceSchema>().not.toBeAny();
+    expectTypeOf<HttpSchema>().not.toBeAny();
     expectTypeOf<HttpServiceMethodsSchema>().not.toBeAny();
     expectTypeOf<HttpMethodsSchema>().not.toBeAny();
     expectTypeOf<HttpServiceMethodSchema>().not.toBeAny();

--- a/docs/wiki/api‐zimic‐http.md
+++ b/docs/wiki/api‐zimic‐http.md
@@ -15,9 +15,9 @@
 - [`HttpFormData`](#httpformdata)
   - [Comparing `HttpFormData`](#comparing-httpformdata)
 - [Utility types](#utility-types)
-  - [`LiteralHttpSchemaPath`](#literalhttpserviceschemapath)
-  - [`NonLiteralHttpSchemaPath`](#nonliteralhttpserviceschemapath)
-  - [`HttpSchemaPath`](#httpserviceschemapath)
+  - [`LiteralHttpServiceSchemaPath`](#literalhttpserviceschemapath)
+  - [`NonLiteralHttpServiceSchemaPath`](#nonliteralhttpserviceschemapath)
+  - [`HttpServiceSchemaPath`](#httpserviceschemapath)
   - [`PathParamsSchemaFromPath`](#pathparamsschemafrompath)
   - [`InferPathParams`](#inferpathparams)
   - [`MergeHttpResponsesByStatusCode`](#mergehttpresponsesbystatuscode)
@@ -313,7 +313,36 @@ console.log(formData3.contains(formData1)); // false
 
 ## Utility types
 
-### `LiteralHttpSchemaPath`
+### `HttpSchemaPath`
+
+Extracts the [literal](#httpschemapathliteral) and [non-literal](#httpschemapathnonliteral) paths from an HTTP service
+schema. Optionally receives a second argument with one or more methods to filter the paths with. Only the methods
+defined in the schema are allowed.
+
+```ts
+import { type HttpSchema, type HttpSchemaPath } from 'zimic/http';
+
+type Schema = HttpSchema.Paths<{
+  '/users': {
+    GET: {
+      response: { 200: { body: User[] } };
+    };
+  };
+  '/users/:userId': {
+    DELETE: {
+      response: { 200: { body: User } };
+    };
+  };
+}>;
+
+type Path = HttpSchemaPath<Schema>;
+// "/users" | "/users/:userId" | "/users/${string}"
+
+type GetPath = HttpSchemaPath<Schema, 'GET'>;
+// "/users"
+```
+
+#### `HttpSchemaPath.Literal`
 
 Extracts the literal paths from an HTTP service schema. Optionally receives a second argument with one or more methods
 to filter the paths with. Only the methods defined in the schema are allowed.
@@ -341,13 +370,7 @@ type LiteralGetPath = LiteralHttpSchemaPath<Schema, 'GET'>;
 // "/users"
 ```
 
-### `LiteralHttpServiceSchemaPath`
-
-> [!WARNING]
->
-> This type is **deprecated**. Please use [`LiteralHttpSchemaPath`](#literalhttpschemapath) instead.
-
-### `NonLiteralHttpSchemaPath`
+#### `HttpSchemaPath.NonLiteral`
 
 Extracts the non-literal paths from an HTTP service schema. Optionally receives a second argument with one or more
 methods to filter the paths with. Only the methods defined in the schema are allowed.
@@ -375,46 +398,23 @@ type NonLiteralGetPath = NonLiteralHttpSchemaPath<Schema, 'GET'>;
 // "/users"
 ```
 
-### `NonLiteralHttpServiceSchemaPath`
-
-> [!WARNING]
->
-> This type is **deprecated**. Please use [`NonLiteralHttpSchemaPath`](#nonliteralhttpschemapath) instead.
-
-### `HttpSchemaPath`
-
-Extracts the [literal](#literalhttpserviceschemapath) and [non-literal](#nonliteralhttpserviceschemapath) paths from an
-HTTP service schema. Optionally receives a second argument with one or more methods to filter the paths with. Only the
-methods defined in the schema are allowed.
-
-```ts
-import { type HttpSchema, type HttpSchemaPath } from 'zimic/http';
-
-type Schema = HttpSchema.Paths<{
-  '/users': {
-    GET: {
-      response: { 200: { body: User[] } };
-    };
-  };
-  '/users/:userId': {
-    DELETE: {
-      response: { 200: { body: User } };
-    };
-  };
-}>;
-
-type Path = HttpSchemaPath<Schema>;
-// "/users" | "/users/:userId" | "/users/${string}"
-
-type GetPath = HttpSchemaPath<Schema, 'GET'>;
-// "/users"
-```
-
 ### `HttpServiceSchemaPath`
 
 > [!WARNING]
 >
 > This type is **deprecated**. Please use [`HttpSchemaPath`](#httpschemapath) instead.
+
+### `LiteralHttpServiceSchemaPath`
+
+> [!WARNING]
+>
+> This type is **deprecated**. Please use [`HttpSchemaPath.Literal`](#httpschemapathliteral) instead.
+
+### `NonLiteralHttpServiceSchemaPath`
+
+> [!WARNING]
+>
+> This type is **deprecated**. Please use [`HttpSchemaPath.NonLiteral`](#httpschemapathnonliteral) instead.
 
 ### `InferPathParams`
 

--- a/docs/wiki/api‐zimic‐http.md
+++ b/docs/wiki/api‐zimic‐http.md
@@ -15,9 +15,9 @@
 - [`HttpFormData`](#httpformdata)
   - [Comparing `HttpFormData`](#comparing-httpformdata)
 - [Utility types](#utility-types)
-  - [`LiteralHttpServiceSchemaPath`](#literalhttpserviceschemapath)
-  - [`NonLiteralHttpServiceSchemaPath`](#nonliteralhttpserviceschemapath)
-  - [`HttpServiceSchemaPath`](#httpserviceschemapath)
+  - [`LiteralHttpSchemaPath`](#literalhttpserviceschemapath)
+  - [`NonLiteralHttpSchemaPath`](#nonliteralhttpserviceschemapath)
+  - [`HttpSchemaPath`](#httpserviceschemapath)
   - [`PathParamsSchemaFromPath`](#pathparamsschemafrompath)
   - [`InferPathParams`](#inferpathparams)
   - [`MergeHttpResponsesByStatusCode`](#mergehttpresponsesbystatuscode)
@@ -313,13 +313,13 @@ console.log(formData3.contains(formData1)); // false
 
 ## Utility types
 
-### `LiteralHttpServiceSchemaPath`
+### `LiteralHttpSchemaPath`
 
 Extracts the literal paths from an HTTP service schema. Optionally receives a second argument with one or more methods
 to filter the paths with. Only the methods defined in the schema are allowed.
 
 ```ts
-import { type HttpSchema, type LiteralHttpServiceSchemaPath } from 'zimic/http';
+import { type HttpSchema, type LiteralHttpSchemaPath } from 'zimic/http';
 
 type Schema = HttpSchema.Paths<{
   '/users': {
@@ -334,20 +334,26 @@ type Schema = HttpSchema.Paths<{
   };
 }>;
 
-type LiteralPath = LiteralHttpServiceSchemaPath<Schema>;
+type LiteralPath = LiteralHttpSchemaPath<Schema>;
 // "/users" | "/users/:userId"
 
-type LiteralGetPath = LiteralHttpServiceSchemaPath<Schema, 'GET'>;
+type LiteralGetPath = LiteralHttpSchemaPath<Schema, 'GET'>;
 // "/users"
 ```
 
-### `NonLiteralHttpServiceSchemaPath`
+### `LiteralHttpServiceSchemaPath`
+
+> [!WARNING]
+>
+> This type is **deprecated**. Please use [`LiteralHttpSchemaPath`](#literalhttpschemapath) instead.
+
+### `NonLiteralHttpSchemaPath`
 
 Extracts the non-literal paths from an HTTP service schema. Optionally receives a second argument with one or more
 methods to filter the paths with. Only the methods defined in the schema are allowed.
 
 ```ts
-import { type HttpSchema, type NonLiteralHttpServiceSchemaPath } from 'zimic/http';
+import { type HttpSchema, type NonLiteralHttpSchemaPath } from 'zimic/http';
 
 type Schema = HttpSchema.Paths<{
   '/users': {
@@ -362,21 +368,27 @@ type Schema = HttpSchema.Paths<{
   };
 }>;
 
-type NonLiteralPath = NonLiteralHttpServiceSchemaPath<Schema>;
+type NonLiteralPath = NonLiteralHttpSchemaPath<Schema>;
 // "/users" | "/users/${string}"
 
-type NonLiteralGetPath = NonLiteralHttpServiceSchemaPath<Schema, 'GET'>;
+type NonLiteralGetPath = NonLiteralHttpSchemaPath<Schema, 'GET'>;
 // "/users"
 ```
 
-### `HttpServiceSchemaPath`
+### `NonLiteralHttpServiceSchemaPath`
+
+> [!WARNING]
+>
+> This type is **deprecated**. Please use [`NonLiteralHttpSchemaPath`](#nonliteralhttpschemapath) instead.
+
+### `HttpSchemaPath`
 
 Extracts the [literal](#literalhttpserviceschemapath) and [non-literal](#nonliteralhttpserviceschemapath) paths from an
 HTTP service schema. Optionally receives a second argument with one or more methods to filter the paths with. Only the
 methods defined in the schema are allowed.
 
 ```ts
-import { type HttpSchema, type HttpServiceSchemaPath } from 'zimic/http';
+import { type HttpSchema, type HttpSchemaPath } from 'zimic/http';
 
 type Schema = HttpSchema.Paths<{
   '/users': {
@@ -391,19 +403,25 @@ type Schema = HttpSchema.Paths<{
   };
 }>;
 
-type Path = HttpServiceSchemaPath<Schema>;
+type Path = HttpSchemaPath<Schema>;
 // "/users" | "/users/:userId" | "/users/${string}"
 
-type GetPath = HttpServiceSchemaPath<Schema, 'GET'>;
+type GetPath = HttpSchemaPath<Schema, 'GET'>;
 // "/users"
 ```
+
+### `HttpServiceSchemaPath`
+
+> [!WARNING]
+>
+> This type is **deprecated**. Please use [`HttpSchemaPath`](#httpschemapath) instead.
 
 ### `InferPathParams`
 
 Infers the path parameters schema from a path string, optionally validating it against an
-[HttpServiceSchema](api‐zimic‐interceptor‐http‐schemas).
+[HttpSchema](api‐zimic‐interceptor‐http‐schemas).
 
-If the first argument is a [HttpServiceSchema](api‐zimic‐interceptor‐http‐schemas) (recommended), the second argument is
+If the first argument is a [HttpSchema](api‐zimic‐interceptor‐http‐schemas) (recommended), the second argument is
 checked to be a valid path in that schema.
 
 ```ts
@@ -432,19 +450,9 @@ type PathParams = InferPathParams<'/users/:userId'>;
 
 ### `PathParamsSchemaFromPath`
 
-Infers the path parameters schema from a path string.
-
 > [!WARNING]
 >
-> This type is **deprecated** and will be removed in a future release. Please use [`InferPathParams`](#inferpathparams)
-> instead.
-
-```ts
-import { type PathParamsSchemaFromPath } from 'zimic/http';
-
-type PathParams = PathParamsSchemaFromPath<'/users/:userId/notifications'>;
-// { userId: string }
-```
+> This type is **deprecated**. Please use [`InferPathParams`](#inferpathparams) instead.
 
 ### `MergeHttpResponsesByStatusCode`
 

--- a/docs/wiki/api‐zimic‐interceptor‐http.md
+++ b/docs/wiki/api‐zimic‐interceptor‐http.md
@@ -468,8 +468,6 @@ type Schema = InferHttpInterceptorSchema<typeof interceptor>;
 
 #### `ExtractHttpInterceptorSchema`
 
-Infers the schema of an [HTTP interceptor](#httpinterceptor).
-
 > [!WARNING]
 >
 > This type is **deprecated** and was renamed to [`InferHttpInterceptorSchema`](#inferhttpinterceptorschema) with no

--- a/examples/with-openapi-typegen/src/types/github/types.ts
+++ b/examples/with-openapi-typegen/src/types/github/types.ts
@@ -1,7 +1,7 @@
-import type { HttpServiceSchemaPath } from 'zimic/http';
+import type { HttpSchemaPath } from 'zimic/http';
 
 import { GitHubComponents, GitHubSchema } from './typegen/generated';
 
 export type GitHubRepository = GitHubComponents['schemas']['full-repository'];
 
-export type GitHubPath = HttpServiceSchemaPath<GitHubSchema>;
+export type GitHubPath = HttpSchemaPath<GitHubSchema>;

--- a/packages/zimic/src/http/index.ts
+++ b/packages/zimic/src/http/index.ts
@@ -32,22 +32,58 @@ export type {
 } from './types/requests';
 
 export type {
+  /** @deprecated Use `HttpSchema` instead, which works as a drop-in replacement. */
+  HttpSchema as HttpServiceSchema,
   HttpSchema,
   HttpMethod,
   HttpStatusCode,
   HttpPathParamsSchema,
-  HttpServiceRequestSchema,
-  HttpServiceResponseSchema,
-  HttpServiceResponseSchemaByStatusCode,
-  HttpServiceResponseSchemaStatusCode,
-  HttpServiceMethodSchema,
-  HttpServiceMethodsSchema,
-  HttpServiceSchema,
-  HttpServiceSchemaMethod,
-  LiteralHttpServiceSchemaPath,
-  NonLiteralHttpServiceSchemaPath,
-  HttpServiceSchemaPath,
-  PathParamsSchemaFromPath,
+
+  /** @deprecated Use `HttpRequestSchema` instead, which works as a drop-in replacement. */
+  HttpRequestSchema as HttpServiceRequestSchema,
+  HttpRequestSchema,
+
+  /** @deprecated Use `HttpResponseSchema` instead, which works as a drop-in replacement. */
+  HttpResponseSchema as HttpServiceResponseSchema,
+  HttpResponseSchema,
+
+  /** @deprecated Use `HttpResponseSchemaByStatusCode` instead, which works as a drop-in replacement. */
+  HttpResponseSchemaByStatusCode as HttpServiceResponseSchemaByStatusCode,
+  HttpResponseSchemaByStatusCode,
+
+  /** @deprecated Use `HttpResponseSchemaStatusCode` instead, which works as a drop-in replacement. */
+  HttpResponseSchemaStatusCode as HttpServiceResponseSchemaStatusCode,
+  HttpResponseSchemaStatusCode,
+
+  /** @deprecated Use `HttpMethodSchema` instead, which works as a drop-in replacement. */
+  HttpMethodSchema as HttpServiceMethodSchema,
+  HttpMethodSchema,
+
+  /** @deprecated Use `HttpMethodsSchema` instead, which works as a drop-in replacement. */
+  HttpMethodsSchema as HttpServiceMethodsSchema,
+  HttpMethodsSchema,
+
+  /** @deprecated Use `HttpSchemaMethod` instead, which works as a drop-in replacement. */
+  HttpSchemaMethod as HttpServiceSchemaMethod,
+  HttpSchemaMethod,
+
+  /** @deprecated Use `LiteralHttpSchemaPath` instead, which works as a drop-in replacement. */
+  LiteralHttpSchemaPath as LiteralHttpServiceSchemaPath,
+  LiteralHttpSchemaPath,
+
+  /** @deprecated Use `NonLiteralHttpSchemaPath` instead, which works as a drop-in replacement. */
+  NonLiteralHttpSchemaPath as NonLiteralHttpServiceSchemaPath,
+  NonLiteralHttpSchemaPath,
+
+  /** @deprecated Use `HttpSchemaPath` instead, which works as a drop-in replacement. */
+  HttpSchemaPath as HttpServiceSchemaPath,
+  HttpSchemaPath,
+
+  /**
+   * @deprecated Use {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐http#inferpathparams `InferPathParams` }
+   *   instead, which works as a drop-in replacement with additional validation.
+   */
+  InferPathParams as PathParamsSchemaFromPath,
   InferPathParams,
   MergeHttpResponsesByStatusCode,
 } from './types/schema';

--- a/packages/zimic/src/http/index.ts
+++ b/packages/zimic/src/http/index.ts
@@ -9,8 +9,6 @@ import {
   HttpSchemaMethod,
   HttpSchemaPath,
   InferPathParams,
-  LiteralHttpSchemaPath,
-  NonLiteralHttpSchemaPath,
 } from './types/schema';
 
 export { default as InvalidFormDataError } from './errors/InvalidFormDataError';
@@ -75,13 +73,13 @@ export type HttpServiceSchemaMethod<Schema extends HttpSchema> = HttpSchemaMetho
 export type LiteralHttpServiceSchemaPath<
   Schema extends HttpSchema,
   Method extends HttpSchemaMethod<Schema> = HttpSchemaMethod<Schema>,
-> = LiteralHttpSchemaPath<Schema, Method>;
+> = HttpSchemaPath.Literal<Schema, Method>;
 
 /** @deprecated Use `NonLiteralHttpSchemaPath` instead, which works as a drop-in replacement. */
 export type NonLiteralHttpServiceSchemaPath<
   Schema extends HttpSchema,
   Method extends HttpSchemaMethod<Schema> = HttpSchemaMethod<Schema>,
-> = NonLiteralHttpSchemaPath<Schema, Method>;
+> = HttpSchemaPath.NonLiteral<Schema, Method>;
 
 /** @deprecated Use `HttpSchemaPath` instead, which works as a drop-in replacement. */
 export type HttpServiceSchemaPath<
@@ -107,8 +105,6 @@ export type {
   HttpMethodSchema,
   HttpMethodsSchema,
   HttpSchemaMethod,
-  LiteralHttpSchemaPath,
-  NonLiteralHttpSchemaPath,
   HttpSchemaPath,
   InferPathParams,
   MergeHttpResponsesByStatusCode,

--- a/packages/zimic/src/http/index.ts
+++ b/packages/zimic/src/http/index.ts
@@ -44,44 +44,44 @@ export type {
   StrictFormData,
 } from './types/requests';
 
-/** @deprecated Use `HttpSchema` instead, which works as a drop-in replacement. */
+/** @deprecated Use {@link HttpSchema} instead, which is a drop-in replacement. */
 export type HttpServiceSchema = HttpSchema;
 
-/** @deprecated Use `HttpRequestSchema` instead, which works as a drop-in replacement. */
+/** @deprecated Use {@link HttpRequestSchema} instead, which is a drop-in replacement. */
 export type HttpServiceRequestSchema = HttpRequestSchema;
 
-/** @deprecated Use `HttpResponseSchema` instead, which works as a drop-in replacement. */
+/** @deprecated Use {@link HttpResponseSchema} instead, which is a drop-in replacement. */
 export type HttpServiceResponseSchema = HttpResponseSchema;
 
-/** @deprecated Use `HttpResponseSchemaByStatusCode` instead, which works as a drop-in replacement. */
+/** @deprecated Use {@link HttpResponseSchemaByStatusCode} instead, which is a drop-in replacement. */
 export type HttpServiceResponseSchemaByStatusCode = HttpResponseSchemaByStatusCode;
 
-/** @deprecated Use `HttpResponseSchemaStatusCode` instead, which works as a drop-in replacement. */
+/** @deprecated Use {@link HttpResponseSchemaStatusCode} instead, which is a drop-in replacement. */
 export type HttpServiceResponseSchemaStatusCode<ResponseSchemaByStatusCode extends HttpResponseSchemaByStatusCode> =
   HttpResponseSchemaStatusCode<ResponseSchemaByStatusCode>;
 
-/** @deprecated Use `HttpMethodSchema` instead, which works as a drop-in replacement. */
+/** @deprecated Use {@link HttpMethodSchema} instead, which is a drop-in replacement. */
 export type HttpServiceMethodSchema = HttpMethodSchema;
 
-/** @deprecated Use `HttpMethodsSchema` instead, which works as a drop-in replacement. */
+/** @deprecated Use {@link HttpMethodsSchema} instead, which is a drop-in replacement. */
 export type HttpServiceMethodsSchema = HttpMethodsSchema;
 
-/** @deprecated Use `HttpSchemaMethod` instead, which works as a drop-in replacement. */
+/** @deprecated Use {@link HttpSchemaMethod} instead, which is a drop-in replacement. */
 export type HttpServiceSchemaMethod<Schema extends HttpSchema> = HttpSchemaMethod<Schema>;
 
-/** @deprecated Use `LiteralHttpSchemaPath` instead, which works as a drop-in replacement. */
+/** @deprecated Use {@link HttpSchemaPath.Literal} instead, which is a drop-in replacement. */
 export type LiteralHttpServiceSchemaPath<
   Schema extends HttpSchema,
   Method extends HttpSchemaMethod<Schema> = HttpSchemaMethod<Schema>,
 > = HttpSchemaPath.Literal<Schema, Method>;
 
-/** @deprecated Use `NonLiteralHttpSchemaPath` instead, which works as a drop-in replacement. */
+/** @deprecated Use {@link HttpSchemaPath.NonLiteral} instead, which is a drop-in replacement. */
 export type NonLiteralHttpServiceSchemaPath<
   Schema extends HttpSchema,
   Method extends HttpSchemaMethod<Schema> = HttpSchemaMethod<Schema>,
 > = HttpSchemaPath.NonLiteral<Schema, Method>;
 
-/** @deprecated Use `HttpSchemaPath` instead, which works as a drop-in replacement. */
+/** @deprecated Use {@link HttpSchemaPath} instead, which is a drop-in replacement. */
 export type HttpServiceSchemaPath<
   Schema extends HttpSchema,
   Method extends HttpSchemaMethod<Schema> = HttpSchemaMethod<Schema>,
@@ -89,7 +89,7 @@ export type HttpServiceSchemaPath<
 
 /**
  * @deprecated Use {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐http#inferpathparams `InferPathParams` }
- *   instead, which works as a drop-in replacement with additional validation.
+ *   instead, which is a drop-in replacement with additional validation.
  */
 export type PathParamsSchemaFromPath<Path extends string> = InferPathParams<Path>;
 

--- a/packages/zimic/src/http/index.ts
+++ b/packages/zimic/src/http/index.ts
@@ -1,3 +1,18 @@
+import {
+  HttpMethodSchema,
+  HttpMethodsSchema,
+  HttpRequestSchema,
+  HttpResponseSchema,
+  HttpResponseSchemaByStatusCode,
+  HttpResponseSchemaStatusCode,
+  HttpSchema,
+  HttpSchemaMethod,
+  HttpSchemaPath,
+  InferPathParams,
+  LiteralHttpSchemaPath,
+  NonLiteralHttpSchemaPath,
+} from './types/schema';
+
 export { default as InvalidFormDataError } from './errors/InvalidFormDataError';
 export { default as HttpFormData } from './formData/HttpFormData';
 export { default as HttpHeaders } from './headers/HttpHeaders';
@@ -31,59 +46,70 @@ export type {
   StrictFormData,
 } from './types/requests';
 
+/** @deprecated Use `HttpSchema` instead, which works as a drop-in replacement. */
+export type HttpServiceSchema = HttpSchema;
+
+/** @deprecated Use `HttpRequestSchema` instead, which works as a drop-in replacement. */
+export type HttpServiceRequestSchema = HttpRequestSchema;
+
+/** @deprecated Use `HttpResponseSchema` instead, which works as a drop-in replacement. */
+export type HttpServiceResponseSchema = HttpResponseSchema;
+
+/** @deprecated Use `HttpResponseSchemaByStatusCode` instead, which works as a drop-in replacement. */
+export type HttpServiceResponseSchemaByStatusCode = HttpResponseSchemaByStatusCode;
+
+/** @deprecated Use `HttpResponseSchemaStatusCode` instead, which works as a drop-in replacement. */
+export type HttpServiceResponseSchemaStatusCode<ResponseSchemaByStatusCode extends HttpResponseSchemaByStatusCode> =
+  HttpResponseSchemaStatusCode<ResponseSchemaByStatusCode>;
+
+/** @deprecated Use `HttpMethodSchema` instead, which works as a drop-in replacement. */
+export type HttpServiceMethodSchema = HttpMethodSchema;
+
+/** @deprecated Use `HttpMethodsSchema` instead, which works as a drop-in replacement. */
+export type HttpServiceMethodsSchema = HttpMethodsSchema;
+
+/** @deprecated Use `HttpSchemaMethod` instead, which works as a drop-in replacement. */
+export type HttpServiceSchemaMethod<Schema extends HttpSchema> = HttpSchemaMethod<Schema>;
+
+/** @deprecated Use `LiteralHttpSchemaPath` instead, which works as a drop-in replacement. */
+export type LiteralHttpServiceSchemaPath<
+  Schema extends HttpSchema,
+  Method extends HttpSchemaMethod<Schema> = HttpSchemaMethod<Schema>,
+> = LiteralHttpSchemaPath<Schema, Method>;
+
+/** @deprecated Use `NonLiteralHttpSchemaPath` instead, which works as a drop-in replacement. */
+export type NonLiteralHttpServiceSchemaPath<
+  Schema extends HttpSchema,
+  Method extends HttpSchemaMethod<Schema> = HttpSchemaMethod<Schema>,
+> = NonLiteralHttpSchemaPath<Schema, Method>;
+
+/** @deprecated Use `HttpSchemaPath` instead, which works as a drop-in replacement. */
+export type HttpServiceSchemaPath<
+  Schema extends HttpSchema,
+  Method extends HttpSchemaMethod<Schema> = HttpSchemaMethod<Schema>,
+> = HttpSchemaPath<Schema, Method>;
+
+/**
+ * @deprecated Use {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐http#inferpathparams `InferPathParams` }
+ *   instead, which works as a drop-in replacement with additional validation.
+ */
+export type PathParamsSchemaFromPath<Path extends string> = InferPathParams<Path>;
+
 export type {
-  /** @deprecated Use `HttpSchema` instead, which works as a drop-in replacement. */
-  HttpSchema as HttpServiceSchema,
   HttpSchema,
   HttpMethod,
   HttpStatusCode,
   HttpPathParamsSchema,
-
-  /** @deprecated Use `HttpRequestSchema` instead, which works as a drop-in replacement. */
-  HttpRequestSchema as HttpServiceRequestSchema,
   HttpRequestSchema,
-
-  /** @deprecated Use `HttpResponseSchema` instead, which works as a drop-in replacement. */
-  HttpResponseSchema as HttpServiceResponseSchema,
   HttpResponseSchema,
-
-  /** @deprecated Use `HttpResponseSchemaByStatusCode` instead, which works as a drop-in replacement. */
-  HttpResponseSchemaByStatusCode as HttpServiceResponseSchemaByStatusCode,
   HttpResponseSchemaByStatusCode,
-
-  /** @deprecated Use `HttpResponseSchemaStatusCode` instead, which works as a drop-in replacement. */
-  HttpResponseSchemaStatusCode as HttpServiceResponseSchemaStatusCode,
   HttpResponseSchemaStatusCode,
-
-  /** @deprecated Use `HttpMethodSchema` instead, which works as a drop-in replacement. */
-  HttpMethodSchema as HttpServiceMethodSchema,
   HttpMethodSchema,
-
-  /** @deprecated Use `HttpMethodsSchema` instead, which works as a drop-in replacement. */
-  HttpMethodsSchema as HttpServiceMethodsSchema,
   HttpMethodsSchema,
-
-  /** @deprecated Use `HttpSchemaMethod` instead, which works as a drop-in replacement. */
-  HttpSchemaMethod as HttpServiceSchemaMethod,
   HttpSchemaMethod,
-
-  /** @deprecated Use `LiteralHttpSchemaPath` instead, which works as a drop-in replacement. */
-  LiteralHttpSchemaPath as LiteralHttpServiceSchemaPath,
   LiteralHttpSchemaPath,
-
-  /** @deprecated Use `NonLiteralHttpSchemaPath` instead, which works as a drop-in replacement. */
-  NonLiteralHttpSchemaPath as NonLiteralHttpServiceSchemaPath,
   NonLiteralHttpSchemaPath,
-
-  /** @deprecated Use `HttpSchemaPath` instead, which works as a drop-in replacement. */
-  HttpSchemaPath as HttpServiceSchemaPath,
   HttpSchemaPath,
-
-  /**
-   * @deprecated Use {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐http#inferpathparams `InferPathParams` }
-   *   instead, which works as a drop-in replacement with additional validation.
-   */
-  InferPathParams as PathParamsSchemaFromPath,
   InferPathParams,
   MergeHttpResponsesByStatusCode,
 } from './types/schema';

--- a/packages/zimic/src/http/types/__tests__/schema.test.ts
+++ b/packages/zimic/src/http/types/__tests__/schema.test.ts
@@ -98,11 +98,16 @@ describe('Schema types', () => {
       expectTypeOf<InferPathParams<Schema, '/users'>>().toEqualTypeOf<HttpSchema.PathParams<{}>>();
 
       expectTypeOf<InferPathParams<Schema, '/users/:userId'>>().toEqualTypeOf<
-        HttpSchema.PathParams<{ userId: string }>
+        HttpSchema.PathParams<{
+          userId: string;
+        }>
       >();
 
       expectTypeOf<InferPathParams<Schema, '/users/:userId/notifications/:notificationId'>>().toEqualTypeOf<
-        HttpSchema.PathParams<{ userId: string; notificationId: string }>
+        HttpSchema.PathParams<{
+          userId: string;
+          notificationId: string;
+        }>
       >();
 
       // @ts-expect-error

--- a/packages/zimic/src/http/types/__tests__/schema.test.ts
+++ b/packages/zimic/src/http/types/__tests__/schema.test.ts
@@ -4,13 +4,12 @@ import { JSONValue } from '@/types/json';
 
 import {
   HttpSchema,
-  HttpServiceSchemaPath,
+  HttpSchemaPath,
   HttpStatusCode,
   InferPathParams,
-  LiteralHttpServiceSchemaPath,
+  LiteralHttpSchemaPath,
   MergeHttpResponsesByStatusCode,
-  NonLiteralHttpServiceSchemaPath,
-  PathParamsSchemaFromPath,
+  NonLiteralHttpSchemaPath,
 } from '../schema';
 
 describe('Schema types', () => {
@@ -40,29 +39,29 @@ describe('Schema types', () => {
     };
   }>;
 
-  describe('LiteralHttpServiceSchemaPath', () => {
+  describe('LiteralHttpSchemaPath', () => {
     it('should extract the literal paths from a service schema', () => {
-      expectTypeOf<LiteralHttpServiceSchemaPath<Schema>>().toEqualTypeOf<
+      expectTypeOf<LiteralHttpSchemaPath<Schema>>().toEqualTypeOf<
         '/users' | '/users/:userId' | '/users/:userId/notifications/:notificationId'
       >();
 
-      expectTypeOf<LiteralHttpServiceSchemaPath<Schema, 'GET'>>().toEqualTypeOf<'/users/:userId'>();
+      expectTypeOf<LiteralHttpSchemaPath<Schema, 'GET'>>().toEqualTypeOf<'/users/:userId'>();
     });
   });
 
-  describe('NonLiteralHttpServiceSchemaPath', () => {
+  describe('NonLiteralHttpSchemaPath', () => {
     it('should extract the nonLiteral paths from a service schema', () => {
-      expectTypeOf<NonLiteralHttpServiceSchemaPath<Schema>>().toEqualTypeOf<
+      expectTypeOf<NonLiteralHttpSchemaPath<Schema>>().toEqualTypeOf<
         '/users' | `/users/${string}` | `/users/${string}/notifications/${string}`
       >();
 
-      expectTypeOf<NonLiteralHttpServiceSchemaPath<Schema, 'GET'>>().toEqualTypeOf<`/users/${string}`>();
+      expectTypeOf<NonLiteralHttpSchemaPath<Schema, 'GET'>>().toEqualTypeOf<`/users/${string}`>();
     });
   });
 
-  describe('HttpServiceSchemaPath', () => {
+  describe('HttpSchemaPath', () => {
     it('should extract the nonLiteral paths from a service schema', () => {
-      expectTypeOf<HttpServiceSchemaPath<Schema>>().toEqualTypeOf<
+      expectTypeOf<HttpSchemaPath<Schema>>().toEqualTypeOf<
         | '/users'
         | '/users/:userId'
         | `/users/${string}`
@@ -70,41 +69,7 @@ describe('Schema types', () => {
         | `/users/${string}/notifications/${string}`
       >();
 
-      expectTypeOf<HttpServiceSchemaPath<Schema, 'GET'>>().toEqualTypeOf<'/users/:userId' | `/users/${string}`>();
-    });
-  });
-
-  describe('PathParamsSchemaFromPath', () => {
-    it('should infer path param schemas from path strings', () => {
-      expectTypeOf<PathParamsSchemaFromPath<'/users'>>().toEqualTypeOf<HttpSchema.PathParams<{}>>();
-
-      expectTypeOf<PathParamsSchemaFromPath<'/users/:userId'>>().toEqualTypeOf<
-        HttpSchema.PathParams<{
-          userId: string;
-        }>
-      >();
-
-      expectTypeOf<PathParamsSchemaFromPath<'/users/:userId/:otherId'>>().toEqualTypeOf<
-        HttpSchema.PathParams<{
-          userId: string;
-          otherId: string;
-        }>
-      >();
-
-      expectTypeOf<PathParamsSchemaFromPath<'/users/:userId/:otherId/:anotherId'>>().toEqualTypeOf<
-        HttpSchema.PathParams<{
-          userId: string;
-          otherId: string;
-          anotherId: string;
-        }>
-      >();
-
-      expectTypeOf<PathParamsSchemaFromPath<'/users/:userId/notifications/:notificationId'>>().toEqualTypeOf<
-        HttpSchema.PathParams<{
-          userId: string;
-          notificationId: string;
-        }>
-      >();
+      expectTypeOf<HttpSchemaPath<Schema, 'GET'>>().toEqualTypeOf<'/users/:userId' | `/users/${string}`>();
     });
   });
 

--- a/packages/zimic/src/http/types/__tests__/schema.test.ts
+++ b/packages/zimic/src/http/types/__tests__/schema.test.ts
@@ -2,15 +2,7 @@ import { describe, expectTypeOf, it } from 'vitest';
 
 import { JSONValue } from '@/types/json';
 
-import {
-  HttpSchema,
-  HttpSchemaPath,
-  HttpStatusCode,
-  InferPathParams,
-  LiteralHttpSchemaPath,
-  MergeHttpResponsesByStatusCode,
-  NonLiteralHttpSchemaPath,
-} from '../schema';
+import { HttpSchema, HttpSchemaPath, HttpStatusCode, InferPathParams, MergeHttpResponsesByStatusCode } from '../schema';
 
 describe('Schema types', () => {
   type User = JSONValue<{
@@ -39,28 +31,8 @@ describe('Schema types', () => {
     };
   }>;
 
-  describe('LiteralHttpSchemaPath', () => {
-    it('should extract the literal paths from a service schema', () => {
-      expectTypeOf<LiteralHttpSchemaPath<Schema>>().toEqualTypeOf<
-        '/users' | '/users/:userId' | '/users/:userId/notifications/:notificationId'
-      >();
-
-      expectTypeOf<LiteralHttpSchemaPath<Schema, 'GET'>>().toEqualTypeOf<'/users/:userId'>();
-    });
-  });
-
-  describe('NonLiteralHttpSchemaPath', () => {
-    it('should extract the nonLiteral paths from a service schema', () => {
-      expectTypeOf<NonLiteralHttpSchemaPath<Schema>>().toEqualTypeOf<
-        '/users' | `/users/${string}` | `/users/${string}/notifications/${string}`
-      >();
-
-      expectTypeOf<NonLiteralHttpSchemaPath<Schema, 'GET'>>().toEqualTypeOf<`/users/${string}`>();
-    });
-  });
-
   describe('HttpSchemaPath', () => {
-    it('should extract the nonLiteral paths from a service schema', () => {
+    it('should extract the literal and non-literal paths from a service schema', () => {
       expectTypeOf<HttpSchemaPath<Schema>>().toEqualTypeOf<
         | '/users'
         | '/users/:userId'
@@ -70,6 +42,22 @@ describe('Schema types', () => {
       >();
 
       expectTypeOf<HttpSchemaPath<Schema, 'GET'>>().toEqualTypeOf<'/users/:userId' | `/users/${string}`>();
+    });
+
+    it('should extract the literal paths from a service schema', () => {
+      expectTypeOf<HttpSchemaPath.Literal<Schema>>().toEqualTypeOf<
+        '/users' | '/users/:userId' | '/users/:userId/notifications/:notificationId'
+      >();
+
+      expectTypeOf<HttpSchemaPath.Literal<Schema, 'GET'>>().toEqualTypeOf<'/users/:userId'>();
+    });
+
+    it('should extract the non-literal paths from a service schema', () => {
+      expectTypeOf<HttpSchemaPath.NonLiteral<Schema>>().toEqualTypeOf<
+        '/users' | `/users/${string}` | `/users/${string}/notifications/${string}`
+      >();
+
+      expectTypeOf<HttpSchemaPath.NonLiteral<Schema, 'GET'>>().toEqualTypeOf<`/users/${string}`>();
     });
   });
 

--- a/packages/zimic/src/http/types/schema.ts
+++ b/packages/zimic/src/http/types/schema.ts
@@ -236,27 +236,253 @@ export interface HttpSchema {
  * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http‐schemas Declaring HTTP Service Schemas}
  */
 export namespace HttpSchema {
-  /** Validates that a type is a valid HTTP service schema. */
+  /**
+   * Validates that a type is a valid HTTP service schema
+   *
+   * @example
+   *   import { type HttpSchema } from 'zimic/http';
+   *
+   *   type Schema = HttpSchema.Paths<{
+   *     '/users': {
+   *       GET: {
+   *         response: {
+   *           200: { body: User[] };
+   *         };
+   *       };
+   *     };
+   *   }>;
+   */
   export type Paths<Schema extends HttpSchema> = Schema;
-  /** Validates that a type is a valid HTTP service methods schema. */
+
+  /**
+   * Validates that a type is a valid HTTP service methods schema.
+   *
+   * @example
+   *   import { type HttpSchema } from 'zimic/http';
+   *
+   *   type UserMethods = HttpSchema.Methods<{
+   *     GET: {
+   *       response: {
+   *         200: { body: User[] };
+   *       };
+   *     };
+   *   }>;
+   *
+   *   type Schema = HttpSchema.Paths<{
+   *     '/users': UserMethods;
+   *   }>;
+   */
   export type Methods<Schema extends HttpMethodsSchema> = Schema;
-  /** Validates that a type is a valid HTTP service method schema. */
+
+  /**
+   * Validates that a type is a valid HTTP service method schema.
+   *
+   * @example
+   *   import { type HttpSchema } from 'zimic/http';
+   *
+   *   type UserListMethod = HttpSchema.Method<{
+   *     response: {
+   *       200: { body: User[] };
+   *     };
+   *   }>;
+   *
+   *   type Schema = HttpSchema.Paths<{
+   *     '/users': {
+   *       GET: UserListMethod;
+   *     };
+   *   }>;
+   */
   export type Method<Schema extends HttpMethodSchema> = Schema;
-  /** Validates that a type is a valid HTTP service request schema. */
+
+  /**
+   * Validates that a type is a valid HTTP service request schema.
+   *
+   * @example
+   *   import { type HttpSchema } from 'zimic/http';
+   *
+   *   type UserCreationRequest = HttpSchema.Request<{
+   *     headers: { 'content-type': 'application/json' };
+   *     body: User;
+   *   }>;
+   *
+   *   type Schema = HttpSchema.Paths<{
+   *     '/users': {
+   *       POST: {
+   *         request: UserCreationRequest;
+   *         response: {
+   *           201: { body: User };
+   *         };
+   *       };
+   *     };
+   *   }>;
+   */
   export type Request<Schema extends HttpRequestSchema> = Schema;
-  /** Validates that a type is a valid HTTP service response schema by status code. */
+
+  /**
+   * Validates that a type is a valid HTTP service response schema by status code.
+   *
+   * @example
+   *   import { type HttpSchema } from 'zimic/http';
+   *
+   *   type UserListResponseByStatusCode = HttpSchema.ResponseByStatusCode<{
+   *     200: { body: User[] };
+   *     400: { body: { message: string } };
+   *   }>;
+   *
+   *   type Schema = HttpSchema.Paths<{
+   *     '/users': {
+   *       GET: {
+   *         response: UserListResponseByStatusCode;
+   *       };
+   *     };
+   *   }>;
+   */
   export type ResponseByStatusCode<Schema extends HttpResponseSchemaByStatusCode> = Schema;
-  /** Validates that a type is a valid HTTP service response schema. */
+
+  /**
+   * Validates that a type is a valid HTTP service response schema.
+   *
+   * @example
+   *   import { type HttpSchema } from 'zimic/http';
+   *
+   *   type UserListSuccessResponse = HttpSchema.Response<{
+   *     body: User[];
+   *   }>;
+   *
+   *   type Schema = HttpSchema.Paths<{
+   *     '/users': {
+   *       GET: {
+   *         response: {
+   *           200: UserListSuccessResponse;
+   *         };
+   *       };
+   *     };
+   *   }>;
+   */
   export type Response<Schema extends HttpResponseSchema> = Schema;
-  /** Validates that a type is a valid HTTP body schema. */
+
+  /**
+   * Validates that a type is a valid HTTP body schema.
+   *
+   * @example
+   *   import { type HttpSchema } from 'zimic/http';
+   *
+   *   type UserListSuccessResponseBody = HttpSchema.Body<User[]>;
+   *
+   *   type Schema = HttpSchema.Paths<{
+   *     '/users': {
+   *       GET: {
+   *         response: {
+   *           200: { body: UserListSuccessResponseBody };
+   *         };
+   *       };
+   *     };
+   *   }>;
+   */
   export type Body<Schema extends HttpBody> = Schema;
-  /** Validates that a type is a valid HTTP headers schema. */
+
+  /**
+   * Validates that a type is a valid HTTP headers schema.
+   *
+   * @example
+   *   import { type HttpSchema } from 'zimic/http';
+   *
+   *   type UserListHeaders = HttpSchema.Headers<{
+   *     accept: 'application/json';
+   *   }>;
+   *
+   *   type Schema = HttpSchema.Paths<{
+   *     '/users': {
+   *       GET: {
+   *         request: {
+   *           headers: UserListHeaders;
+   *         };
+   *         response: {
+   *           200: { body: User[] };
+   *         };
+   *       };
+   *     };
+   *   }>;
+   */
   export type Headers<Schema extends HttpHeadersSchema> = Schema;
-  /** Validates that a type is a valid HTTP search params schema. */
+
+  /**
+   * Validates that a type is a valid HTTP search params schema.
+   *
+   * @example
+   *   import { type HttpSchema } from 'zimic/http';
+   *
+   *   type UserListSearchParams = HttpSchema.SearchParams<{
+   *     limit: `${number}`;
+   *     offset: `${number}`;
+   *   }>;
+   *
+   *   type Schema = HttpSchema.Paths<{
+   *     '/users': {
+   *       GET: {
+   *         request: {
+   *           searchParams: UserListSearchParams;
+   *         };
+   *         response: {
+   *           200: { body: User[] };
+   *         };
+   *       };
+   *     };
+   *   }>;
+   */
   export type SearchParams<Schema extends HttpSearchParamsSchema> = Schema;
-  /** Validates that a type is a valid HTTP path params schema. */
+
+  /**
+   * Validates that a type is a valid HTTP path params schema.
+   *
+   * @example
+   *   import { type HttpSchema, InferPathParams } from 'zimic/http';
+   *
+   *   type Schema = HttpSchema.Paths<{
+   *     '/users/:userId': {
+   *       GET: {
+   *         response: {
+   *           200: { body: User };
+   *         };
+   *       };
+   *     };
+   *   }>;
+   *
+   *   type UserByIdPathParams = HttpSchema.PathParams<{
+   *     userId: string;
+   *   }>;
+   *
+   *   // Or infer from the path string
+   *   type UserByIdPathParams = InferPathParams<Schema, '/users/:userId'>;
+   */
   export type PathParams<Schema extends HttpPathParamsSchema> = Schema;
-  /** Validates that a type is a valid HTTP form data schema. */
+
+  /**
+   * Validates that a type is a valid HTTP form data schema.
+   *
+   * @example
+   *   import { HttpFormData, type HttpSchema } from 'zimic/http';
+   *
+   *   type UserCreationFormData = HttpFormData<
+   *     HttpSchema.FormData<{
+   *       name: string;
+   *       email: string;
+   *     }>
+   *   >;
+   *
+   *   type Schema = HttpSchema.Paths<{
+   *     '/users': {
+   *       POST: {
+   *         request: {
+   *           body: UserCreationFormData;
+   *         };
+   *         response: {
+   *           201: { body: User };
+   *         };
+   *       };
+   *     };
+   *   }>;
+   */
   export type FormData<Schema extends HttpFormDataSchema> = Schema;
 }
 
@@ -315,7 +541,7 @@ export namespace HttpSchemaPath {
    * methods to filter the paths with. Only the methods defined in the schema are allowed.
    *
    * @example
-   *   import { type HttpSchema, type LiteralHttpSchemaPath } from 'zimic/http';
+   *   import { type HttpSchema, type HttpSchemaPath } from 'zimic/http';
    *
    *   type Schema = HttpSchema.Paths<{
    *     '/users': {
@@ -330,10 +556,10 @@ export namespace HttpSchemaPath {
    *     };
    *   }>;
    *
-   *   type LiteralPath = LiteralHttpSchemaPath<Schema>;
+   *   type LiteralPath = HttpSchemaPath.Literal<Schema>;
    *   // "/users" | "/users/:userId"
    *
-   *   type LiteralGetPath = LiteralHttpSchemaPath<Schema, 'GET'>;
+   *   type LiteralGetPath = HttpSchemaPath.Literal<Schema, 'GET'>;
    *   // "/users"
    *
    * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http‐schemas Declaring HTTP Service Schemas}
@@ -348,7 +574,7 @@ export namespace HttpSchemaPath {
    * methods to filter the paths with. Only the methods defined in the schema are allowed.
    *
    * @example
-   *   import { type HttpSchema, type NonLiteralHttpSchemaPath } from 'zimic/http';
+   *   import { type HttpSchema, type HttpSchemaPath } from 'zimic/http';
    *
    *   type Schema = HttpSchema.Paths<{
    *     '/users': {
@@ -363,10 +589,10 @@ export namespace HttpSchemaPath {
    *     };
    *   }>;
    *
-   *   type NonLiteralPath = NonLiteralHttpSchemaPath<Schema>;
+   *   type NonLiteralPath = HttpSchemaPath.NonLiteral<Schema>;
    *   // "/users" | "/users/${string}"
    *
-   *   type NonLiteralGetPath = NonLiteralHttpSchemaPath<Schema, 'GET'>;
+   *   type NonLiteralGetPath = HttpSchemaPath.NonLiteral<Schema, 'GET'>;
    *   // "/users"
    *
    * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http‐schemas Declaring HTTP Service Schemas}

--- a/packages/zimic/src/http/types/schema.ts
+++ b/packages/zimic/src/http/types/schema.ts
@@ -34,7 +34,7 @@ export interface HttpPathParamsSchema {
  *
  * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http‐schemas Declaring HTTP service schemas}
  */
-export interface HttpServiceRequestSchema {
+export interface HttpRequestSchema {
   headers?: HttpHeadersSchema;
   searchParams?: HttpSearchParamsSchema;
   body?: HttpBody;
@@ -45,13 +45,13 @@ export interface HttpServiceRequestSchema {
  *
  * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http‐schemas Declaring HTTP Service Schemas}
  */
-export interface HttpServiceResponseSchema {
+export interface HttpResponseSchema {
   headers?: HttpHeadersSchema;
   body?: HttpBody;
 }
 
-export namespace HttpServiceResponseSchema {
-  export interface NoBody extends Omit<HttpServiceResponseSchema, 'body'> {
+export namespace HttpResponseSchema {
+  export interface NoBody extends Omit<HttpResponseSchema, 'body'> {
     body?: null;
   }
 }
@@ -152,19 +152,19 @@ export type HttpStatusCode =
   | HttpStatusCode.ClientError
   | HttpStatusCode.ServerError;
 
-export namespace HttpServiceResponseSchemaByStatusCode {
+export namespace HttpResponseSchemaByStatusCode {
   export type Loose = {
-    [StatusCode in HttpStatusCode]?: HttpServiceResponseSchema;
+    [StatusCode in HttpStatusCode]?: HttpResponseSchema;
   };
 
   export type ConvertToStrict<Schema extends Loose> = {
-    [StatusCode in keyof Schema]: StatusCode extends 204 ? HttpServiceResponseSchema.NoBody : Schema[StatusCode];
+    [StatusCode in keyof Schema]: StatusCode extends 204 ? HttpResponseSchema.NoBody : Schema[StatusCode];
   };
 
   export type Strict = ConvertToStrict<Loose>;
 
   export type NoBody = {
-    [StatusCode in HttpStatusCode]?: HttpServiceResponseSchema.NoBody;
+    [StatusCode in HttpStatusCode]?: HttpResponseSchema.NoBody;
   };
 }
 
@@ -174,34 +174,35 @@ export namespace HttpServiceResponseSchemaByStatusCode {
  * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http‐schemas Declaring HTTP Service Schemas}
  */
 // eslint-disable-next-line @typescript-eslint/no-redeclare
-export type HttpServiceResponseSchemaByStatusCode = HttpServiceResponseSchemaByStatusCode.Strict;
+export type HttpResponseSchemaByStatusCode = HttpResponseSchemaByStatusCode.Strict;
 
 /**
  * Extracts the status codes used in a response schema by status code.
  *
  * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http‐schemas Declaring HTTP Service Schemas}
  */
-export type HttpServiceResponseSchemaStatusCode<
-  ResponseSchemaByStatusCode extends HttpServiceResponseSchemaByStatusCode,
-> = Extract<keyof ResponseSchemaByStatusCode, HttpStatusCode>;
+export type HttpResponseSchemaStatusCode<ResponseSchemaByStatusCode extends HttpResponseSchemaByStatusCode> = Extract<
+  keyof ResponseSchemaByStatusCode,
+  HttpStatusCode
+>;
 
 /**
  * A schema representing the structure of an HTTP request and response for a given method.
  *
  * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http‐schemas Declaring HTTP Service Schemas}
  */
-export interface HttpServiceMethodSchema {
-  request?: HttpServiceRequestSchema;
-  response?: HttpServiceResponseSchemaByStatusCode;
+export interface HttpMethodSchema {
+  request?: HttpRequestSchema;
+  response?: HttpResponseSchemaByStatusCode;
 }
 
-export namespace HttpServiceMethodSchema {
-  export interface NoRequestBody extends Omit<HttpServiceMethodSchema, 'request'> {
-    request?: Omit<HttpServiceRequestSchema, 'body'> & { body?: null };
+export namespace HttpMethodSchema {
+  export interface NoRequestBody extends Omit<HttpMethodSchema, 'request'> {
+    request?: Omit<HttpRequestSchema, 'body'> & { body?: null };
   }
 
   export interface NoBody extends Omit<NoRequestBody, 'response'> {
-    response?: HttpServiceResponseSchemaByStatusCode.NoBody;
+    response?: HttpResponseSchemaByStatusCode.NoBody;
   }
 }
 
@@ -210,14 +211,14 @@ export namespace HttpServiceMethodSchema {
  *
  * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http‐schemas Declaring HTTP Service Schemas}
  */
-export interface HttpServiceMethodsSchema {
-  GET?: HttpServiceMethodSchema.NoRequestBody;
-  POST?: HttpServiceMethodSchema;
-  PUT?: HttpServiceMethodSchema;
-  PATCH?: HttpServiceMethodSchema;
-  DELETE?: HttpServiceMethodSchema;
-  HEAD?: HttpServiceMethodSchema.NoBody;
-  OPTIONS?: HttpServiceMethodSchema.NoRequestBody;
+export interface HttpMethodsSchema {
+  GET?: HttpMethodSchema.NoRequestBody;
+  POST?: HttpMethodSchema;
+  PUT?: HttpMethodSchema;
+  PATCH?: HttpMethodSchema;
+  DELETE?: HttpMethodSchema;
+  HEAD?: HttpMethodSchema.NoBody;
+  OPTIONS?: HttpMethodSchema.NoRequestBody;
 }
 
 /**
@@ -225,8 +226,8 @@ export interface HttpServiceMethodsSchema {
  *
  * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http‐schemas Declaring HTTP Service Schemas}
  */
-export interface HttpServiceSchema {
-  [path: string]: HttpServiceMethodsSchema;
+export interface HttpSchema {
+  [path: string]: HttpMethodsSchema;
 }
 
 /**
@@ -236,17 +237,17 @@ export interface HttpServiceSchema {
  */
 export namespace HttpSchema {
   /** Validates that a type is a valid HTTP service schema. */
-  export type Paths<Schema extends HttpServiceSchema> = Schema;
+  export type Paths<Schema extends HttpSchema> = Schema;
   /** Validates that a type is a valid HTTP service methods schema. */
-  export type Methods<Schema extends HttpServiceMethodsSchema> = Schema;
+  export type Methods<Schema extends HttpMethodsSchema> = Schema;
   /** Validates that a type is a valid HTTP service method schema. */
-  export type Method<Schema extends HttpServiceMethodSchema> = Schema;
+  export type Method<Schema extends HttpMethodSchema> = Schema;
   /** Validates that a type is a valid HTTP service request schema. */
-  export type Request<Schema extends HttpServiceRequestSchema> = Schema;
+  export type Request<Schema extends HttpRequestSchema> = Schema;
   /** Validates that a type is a valid HTTP service response schema by status code. */
-  export type ResponseByStatusCode<Schema extends HttpServiceResponseSchemaByStatusCode> = Schema;
+  export type ResponseByStatusCode<Schema extends HttpResponseSchemaByStatusCode> = Schema;
   /** Validates that a type is a valid HTTP service response schema. */
-  export type Response<Schema extends HttpServiceResponseSchema> = Schema;
+  export type Response<Schema extends HttpResponseSchema> = Schema;
   /** Validates that a type is a valid HTTP body schema. */
   export type Body<Schema extends HttpBody> = Schema;
   /** Validates that a type is a valid HTTP headers schema. */
@@ -264,7 +265,7 @@ export namespace HttpSchema {
  *
  * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http‐schemas Declaring HTTP Service Schemas}
  */
-export type HttpServiceSchemaMethod<Schema extends HttpServiceSchema> = IfAny<
+export type HttpSchemaMethod<Schema extends HttpSchema> = IfAny<
   Schema,
   any, // eslint-disable-line @typescript-eslint/no-explicit-any
   Extract<keyof UnionToIntersection<Schema[keyof Schema]>, HttpMethod>
@@ -275,7 +276,7 @@ export type HttpServiceSchemaMethod<Schema extends HttpServiceSchema> = IfAny<
  * methods to filter the paths with. Only the methods defined in the schema are allowed.
  *
  * @example
- *   import { type HttpSchema, type LiteralHttpServiceSchemaPath } from 'zimic/http';
+ *   import { type HttpSchema, type LiteralHttpSchemaPath } from 'zimic/http';
  *
  *   type Schema = HttpSchema.Paths<{
  *     '/users': {
@@ -290,23 +291,20 @@ export type HttpServiceSchemaMethod<Schema extends HttpServiceSchema> = IfAny<
  *     };
  *   }>;
  *
- *   type LiteralPath = LiteralHttpServiceSchemaPath<Schema>;
+ *   type LiteralPath = LiteralHttpSchemaPath<Schema>;
  *   // "/users" | "/users/:userId"
  *
- *   type LiteralGetPath = LiteralHttpServiceSchemaPath<Schema, 'GET'>;
+ *   type LiteralGetPath = LiteralHttpSchemaPath<Schema, 'GET'>;
  *   // "/users"
  *
  * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http‐schemas Declaring HTTP Service Schemas}
  */
-export type LiteralHttpServiceSchemaPath<
-  Schema extends HttpServiceSchema,
-  Method extends HttpServiceSchemaMethod<Schema> = HttpServiceSchemaMethod<Schema>,
-> = LooseLiteralHttpServiceSchemaPath<Schema, Method>;
+export type LiteralHttpSchemaPath<
+  Schema extends HttpSchema,
+  Method extends HttpSchemaMethod<Schema> = HttpSchemaMethod<Schema>,
+> = LooseLiteralHttpSchemaPath<Schema, Method>;
 
-export type LooseLiteralHttpServiceSchemaPath<
-  Schema extends HttpServiceSchema,
-  Method extends HttpMethod = HttpMethod,
-> = {
+export type LooseLiteralHttpSchemaPath<Schema extends HttpSchema, Method extends HttpMethod = HttpMethod> = {
   [Path in Extract<keyof Schema, string>]: Method extends keyof Schema[Path] ? Path : never;
 }[Extract<keyof Schema, string>];
 
@@ -321,7 +319,7 @@ type AllowAnyStringInPathParams<Path extends string> = Path extends `${infer Pre
  * methods to filter the paths with. Only the methods defined in the schema are allowed.
  *
  * @example
- *   import { type HttpSchema, type NonLiteralHttpServiceSchemaPath } from 'zimic/http';
+ *   import { type HttpSchema, type NonLiteralHttpSchemaPath } from 'zimic/http';
  *
  *   type Schema = HttpSchema.Paths<{
  *     '/users': {
@@ -336,18 +334,18 @@ type AllowAnyStringInPathParams<Path extends string> = Path extends `${infer Pre
  *     };
  *   }>;
  *
- *   type NonLiteralPath = NonLiteralHttpServiceSchemaPath<Schema>;
+ *   type NonLiteralPath = NonLiteralHttpSchemaPath<Schema>;
  *   // "/users" | "/users/${string}"
  *
- *   type NonLiteralGetPath = NonLiteralHttpServiceSchemaPath<Schema, 'GET'>;
+ *   type NonLiteralGetPath = NonLiteralHttpSchemaPath<Schema, 'GET'>;
  *   // "/users"
  *
  * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http‐schemas Declaring HTTP Service Schemas}
  */
-export type NonLiteralHttpServiceSchemaPath<
-  Schema extends HttpServiceSchema,
-  Method extends HttpServiceSchemaMethod<Schema> = HttpServiceSchemaMethod<Schema>,
-> = AllowAnyStringInPathParams<LiteralHttpServiceSchemaPath<Schema, Method>>;
+export type NonLiteralHttpSchemaPath<
+  Schema extends HttpSchema,
+  Method extends HttpSchemaMethod<Schema> = HttpSchemaMethod<Schema>,
+> = AllowAnyStringInPathParams<LiteralHttpSchemaPath<Schema, Method>>;
 
 type LargestPathPrefix<Path extends string> = Path extends `${infer Prefix}/${infer Suffix}`
   ? `${Prefix}/${Suffix extends `${string}/${string}` ? LargestPathPrefix<Suffix> : ''}`
@@ -359,11 +357,11 @@ type ExcludeNonLiteralPathsSupersededByLiteralPath<Path extends string> =
 export type PreferMostStaticLiteralPath<Path extends string> =
   UnionHasMoreThanOneType<Path> extends true ? ExcludeNonLiteralPathsSupersededByLiteralPath<Path> : Path;
 
-type RecursiveInferHttpServiceSchemaPath<
-  Schema extends HttpServiceSchema,
-  Method extends HttpServiceSchemaMethod<Schema>,
+type RecursiveInferHttpSchemaPath<
+  Schema extends HttpSchema,
+  Method extends HttpSchemaMethod<Schema>,
   NonLiteralPath extends string,
-  LiteralPath extends LiteralHttpServiceSchemaPath<Schema, Method>,
+  LiteralPath extends LiteralHttpSchemaPath<Schema, Method>,
 > =
   NonLiteralPath extends AllowAnyStringInPathParams<LiteralPath>
     ? NonLiteralPath extends `${AllowAnyStringInPathParams<LiteralPath>}/${string}`
@@ -371,15 +369,13 @@ type RecursiveInferHttpServiceSchemaPath<
       : LiteralPath
     : never;
 
-export type LiteralHttpServiceSchemaPathFromNonLiteral<
-  Schema extends HttpServiceSchema,
-  Method extends HttpServiceSchemaMethod<Schema>,
+export type LiteralHttpSchemaPathFromNonLiteral<
+  Schema extends HttpSchema,
+  Method extends HttpSchemaMethod<Schema>,
   NonLiteralPath extends string,
-  LiteralPath extends LiteralHttpServiceSchemaPath<Schema, Method> = LiteralHttpServiceSchemaPath<Schema, Method>,
+  LiteralPath extends LiteralHttpSchemaPath<Schema, Method> = LiteralHttpSchemaPath<Schema, Method>,
 > = PreferMostStaticLiteralPath<
-  LiteralPath extends LiteralPath
-    ? RecursiveInferHttpServiceSchemaPath<Schema, Method, NonLiteralPath, LiteralPath>
-    : never
+  LiteralPath extends LiteralPath ? RecursiveInferHttpSchemaPath<Schema, Method, NonLiteralPath, LiteralPath> : never
 >;
 
 /**
@@ -387,7 +383,7 @@ export type LiteralHttpServiceSchemaPathFromNonLiteral<
  * filter the paths with. Only the methods defined in the schema are allowed.
  *
  * @example
- *   import { type HttpSchema, type HttpServiceSchemaPath } from 'zimic/http';
+ *   import { type HttpSchema, type HttpSchemaPath } from 'zimic/http';
  *
  *   type Schema = HttpSchema.Paths<{
  *     '/users': {
@@ -402,18 +398,18 @@ export type LiteralHttpServiceSchemaPathFromNonLiteral<
  *     };
  *   }>;
  *
- *   type Path = HttpServiceSchemaPath<Schema>;
+ *   type Path = HttpSchemaPath<Schema>;
  *   // "/users" | "/users/:userId" | "/users/${string}"
  *
- *   type GetPath = HttpServiceSchemaPath<Schema, 'GET'>;
+ *   type GetPath = HttpSchemaPath<Schema, 'GET'>;
  *   // "/users"
  *
  * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http‐schemas Declaring HTTP Service Schemas}
  */
-export type HttpServiceSchemaPath<
-  Schema extends HttpServiceSchema,
-  Method extends HttpServiceSchemaMethod<Schema> = HttpServiceSchemaMethod<Schema>,
-> = LiteralHttpServiceSchemaPath<Schema, Method> | NonLiteralHttpServiceSchemaPath<Schema, Method>;
+export type HttpSchemaPath<
+  Schema extends HttpSchema,
+  Method extends HttpSchemaMethod<Schema> = HttpSchemaMethod<Schema>,
+> = LiteralHttpSchemaPath<Schema, Method> | NonLiteralHttpSchemaPath<Schema, Method>;
 
 type RecursiveInferPathParams<Path extends string> = Path extends `${infer _Prefix}:${infer ParamName}/${infer Suffix}`
   ? { [Name in ParamName]: string } & RecursiveInferPathParams<Suffix>
@@ -422,10 +418,10 @@ type RecursiveInferPathParams<Path extends string> = Path extends `${infer _Pref
     : {};
 
 /**
- * Infers the path parameters schema from a path string, optionally validating it against an {@link HttpServiceSchema}.
+ * Infers the path parameters schema from a path string, optionally validating it against an {@link HttpSchema}.
  *
- * If the first argument is a {@link HttpServiceSchema} (recommended), the second argument is checked to be a valid path
- * in that schema.
+ * If the first argument is a {@link HttpSchema} (recommended), the second argument is checked to be a valid path in that
+ * schema.
  *
  * @example
  *   import { HttpSchema, InferPathParams } from 'zimic/http';
@@ -450,46 +446,30 @@ type RecursiveInferPathParams<Path extends string> = Path extends `${infer _Pref
  *   // { userId: string }
  */
 export type InferPathParams<
-  PathOrSchema extends string | HttpServiceSchema,
-  OptionalPath extends PathOrSchema extends HttpServiceSchema
-    ? LiteralHttpServiceSchemaPath<PathOrSchema>
-    : never = never,
+  PathOrSchema extends string | HttpSchema,
+  OptionalPath extends PathOrSchema extends HttpSchema ? LiteralHttpSchemaPath<PathOrSchema> : never = never,
 > = Prettify<
   RecursiveInferPathParams<
-    PathOrSchema extends HttpServiceSchema ? OptionalPath : PathOrSchema extends string ? PathOrSchema : never
+    PathOrSchema extends HttpSchema ? OptionalPath : PathOrSchema extends string ? PathOrSchema : never
   >
 >;
 
-/**
- * Infers the path parameters schema from a path string.
- *
- * @deprecated Use {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐http#inferpathparams InferPathParams} instead,
- *   which works as a drop-in replacement with additional validation.
- * @example
- *   import { PathParamsSchemaFromPath } from 'zimic/http';
- *
- *   // Without using a schema to validate the path:
- *   type PathParams = PathParamsSchemaFromPath<'/users/:userId'>;
- *   // { userId: string }
- */
-export type PathParamsSchemaFromPath<Path extends string> = InferPathParams<Path>;
-
 type OmitPastHttpStatusCodes<
-  Schema extends HttpServiceResponseSchemaByStatusCode.Loose,
-  PastSchemas extends HttpServiceResponseSchemaByStatusCode.Loose[],
+  Schema extends HttpResponseSchemaByStatusCode.Loose,
+  PastSchemas extends HttpResponseSchemaByStatusCode.Loose[],
 > =
-  PastSchemas extends NonEmptyArray<HttpServiceResponseSchemaByStatusCode.Loose>
+  PastSchemas extends NonEmptyArray<HttpResponseSchemaByStatusCode.Loose>
     ? Omit<Schema, keyof UnionToIntersection<PastSchemas[number]>>
     : Schema;
 
 type RecursiveMergeHttpResponsesByStatusCode<
-  Schemas extends HttpServiceResponseSchemaByStatusCode.Loose[],
-  PastSchemas extends HttpServiceResponseSchemaByStatusCode.Loose[] = [],
+  Schemas extends HttpResponseSchemaByStatusCode.Loose[],
+  PastSchemas extends HttpResponseSchemaByStatusCode.Loose[] = [],
 > = Schemas extends [
-  infer FirstSchema extends HttpServiceResponseSchemaByStatusCode.Loose,
-  ...infer RestSchemas extends HttpServiceResponseSchemaByStatusCode.Loose[],
+  infer FirstSchema extends HttpResponseSchemaByStatusCode.Loose,
+  ...infer RestSchemas extends HttpResponseSchemaByStatusCode.Loose[],
 ]
-  ? RestSchemas extends NonEmptyArray<HttpServiceResponseSchemaByStatusCode.Loose>
+  ? RestSchemas extends NonEmptyArray<HttpResponseSchemaByStatusCode.Loose>
     ? OmitPastHttpStatusCodes<FirstSchema, PastSchemas> &
         RecursiveMergeHttpResponsesByStatusCode<RestSchemas, [...PastSchemas, FirstSchema]>
     : OmitPastHttpStatusCodes<FirstSchema, PastSchemas>
@@ -529,8 +509,6 @@ type RecursiveMergeHttpResponsesByStatusCode<
  *   }>;
  */
 export type MergeHttpResponsesByStatusCode<
-  Schemas extends HttpServiceResponseSchemaByStatusCode.Loose[],
-  PastSchemas extends HttpServiceResponseSchemaByStatusCode.Loose[] = [],
-> = HttpServiceResponseSchemaByStatusCode.ConvertToStrict<
-  RecursiveMergeHttpResponsesByStatusCode<Schemas, PastSchemas>
->;
+  Schemas extends HttpResponseSchemaByStatusCode.Loose[],
+  PastSchemas extends HttpResponseSchemaByStatusCode.Loose[] = [],
+> = HttpResponseSchemaByStatusCode.ConvertToStrict<RecursiveMergeHttpResponsesByStatusCode<Schemas, PastSchemas>>;

--- a/packages/zimic/src/interceptor/http/index.ts
+++ b/packages/zimic/src/interceptor/http/index.ts
@@ -36,7 +36,15 @@ export type {
   HttpInterceptorOptions,
   UnhandledRequestStrategy,
 } from './interceptor/types/options';
-export type { ExtractHttpInterceptorSchema, InferHttpInterceptorSchema } from './interceptor/types/schema';
+export type {
+  /**
+   * @deprecated Use
+   *   {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#inferpathparams `InferHttpInterceptorSchema` }
+   *   instead, which is a drop-in replacement.
+   */
+  InferHttpInterceptorSchema as ExtractHttpInterceptorSchema,
+  InferHttpInterceptorSchema,
+} from './interceptor/types/schema';
 
 export type { LocalHttpInterceptor, RemoteHttpInterceptor, HttpInterceptor } from './interceptor/types/public';
 

--- a/packages/zimic/src/interceptor/http/index.ts
+++ b/packages/zimic/src/interceptor/http/index.ts
@@ -1,3 +1,4 @@
+import { InferHttpInterceptorSchema } from './interceptor/types/schema';
 import HttpInterceptorNamespace from './namespace/HttpInterceptorNamespace';
 
 export { default as NotStartedHttpInterceptorError } from './interceptor/errors/NotStartedHttpInterceptorError';
@@ -36,15 +37,14 @@ export type {
   HttpInterceptorOptions,
   UnhandledRequestStrategy,
 } from './interceptor/types/options';
-export type {
-  /**
-   * @deprecated Use
-   *   {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#inferpathparams `InferHttpInterceptorSchema` }
-   *   instead, which is a drop-in replacement.
-   */
-  InferHttpInterceptorSchema as ExtractHttpInterceptorSchema,
-  InferHttpInterceptorSchema,
-} from './interceptor/types/schema';
+
+/**
+ * @deprecated Use
+ *   {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#inferpathparams `InferHttpInterceptorSchema` }
+ *   instead, which is a drop-in replacement.
+ */
+export type ExtractHttpInterceptorSchema<Interceptor> = InferHttpInterceptorSchema<Interceptor>;
+export type { InferHttpInterceptorSchema } from './interceptor/types/schema';
 
 export type { LocalHttpInterceptor, RemoteHttpInterceptor, HttpInterceptor } from './interceptor/types/public';
 

--- a/packages/zimic/src/interceptor/http/interceptor/HttpInterceptorClient.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/HttpInterceptorClient.ts
@@ -1,10 +1,10 @@
 import {
   HTTP_METHODS,
   HttpMethod,
-  HttpServiceResponseSchemaStatusCode,
-  HttpServiceSchema,
-  HttpServiceSchemaMethod,
-  HttpServiceSchemaPath,
+  HttpResponseSchemaStatusCode,
+  HttpSchema,
+  HttpSchemaMethod,
+  HttpSchemaPath,
 } from '@/http/types/schema';
 import { Default, PossiblePromise } from '@/types/utils';
 import { joinURL, ExtendedURL, createRegexFromURL } from '@/utils/urls';
@@ -25,7 +25,7 @@ import { HttpInterceptorRequestContext } from './types/requests';
 export const SUPPORTED_BASE_URL_PROTOCOLS = Object.freeze(['http', 'https']);
 
 class HttpInterceptorClient<
-  Schema extends HttpServiceSchema,
+  Schema extends HttpSchema,
   HandlerConstructor extends HttpRequestHandlerConstructor = HttpRequestHandlerConstructor,
 > {
   private worker: HttpInterceptorWorker;
@@ -117,37 +117,37 @@ class HttpInterceptorClient<
     }
   }
 
-  get(path: HttpServiceSchemaPath<Schema, HttpServiceSchemaMethod<Schema>>) {
-    return this.createHttpRequestHandler('GET' as HttpServiceSchemaMethod<Schema>, path);
+  get(path: HttpSchemaPath<Schema, HttpSchemaMethod<Schema>>) {
+    return this.createHttpRequestHandler('GET' as HttpSchemaMethod<Schema>, path);
   }
 
-  post(path: HttpServiceSchemaPath<Schema, HttpServiceSchemaMethod<Schema>>) {
-    return this.createHttpRequestHandler('POST' as HttpServiceSchemaMethod<Schema>, path);
+  post(path: HttpSchemaPath<Schema, HttpSchemaMethod<Schema>>) {
+    return this.createHttpRequestHandler('POST' as HttpSchemaMethod<Schema>, path);
   }
 
-  patch(path: HttpServiceSchemaPath<Schema, HttpServiceSchemaMethod<Schema>>) {
-    return this.createHttpRequestHandler('PATCH' as HttpServiceSchemaMethod<Schema>, path);
+  patch(path: HttpSchemaPath<Schema, HttpSchemaMethod<Schema>>) {
+    return this.createHttpRequestHandler('PATCH' as HttpSchemaMethod<Schema>, path);
   }
 
-  put(path: HttpServiceSchemaPath<Schema, HttpServiceSchemaMethod<Schema>>) {
-    return this.createHttpRequestHandler('PUT' as HttpServiceSchemaMethod<Schema>, path);
+  put(path: HttpSchemaPath<Schema, HttpSchemaMethod<Schema>>) {
+    return this.createHttpRequestHandler('PUT' as HttpSchemaMethod<Schema>, path);
   }
 
-  delete(path: HttpServiceSchemaPath<Schema, HttpServiceSchemaMethod<Schema>>) {
-    return this.createHttpRequestHandler('DELETE' as HttpServiceSchemaMethod<Schema>, path);
+  delete(path: HttpSchemaPath<Schema, HttpSchemaMethod<Schema>>) {
+    return this.createHttpRequestHandler('DELETE' as HttpSchemaMethod<Schema>, path);
   }
 
-  head(path: HttpServiceSchemaPath<Schema, HttpServiceSchemaMethod<Schema>>) {
-    return this.createHttpRequestHandler('HEAD' as HttpServiceSchemaMethod<Schema>, path);
+  head(path: HttpSchemaPath<Schema, HttpSchemaMethod<Schema>>) {
+    return this.createHttpRequestHandler('HEAD' as HttpSchemaMethod<Schema>, path);
   }
 
-  options(path: HttpServiceSchemaPath<Schema, HttpServiceSchemaMethod<Schema>>) {
-    return this.createHttpRequestHandler('OPTIONS' as HttpServiceSchemaMethod<Schema>, path);
+  options(path: HttpSchemaPath<Schema, HttpSchemaMethod<Schema>>) {
+    return this.createHttpRequestHandler('OPTIONS' as HttpSchemaMethod<Schema>, path);
   }
 
   private createHttpRequestHandler<
-    Method extends HttpServiceSchemaMethod<Schema>,
-    Path extends HttpServiceSchemaPath<Schema, Method>,
+    Method extends HttpSchemaMethod<Schema>,
+    Path extends HttpSchemaPath<Schema, Method>,
   >(method: Method, path: Path): HttpRequestHandler<Schema, Method, Path> {
     if (!this.isRunning()) {
       throw new NotStartedHttpInterceptorError();
@@ -158,9 +158,9 @@ class HttpInterceptorClient<
   }
 
   registerRequestHandler<
-    Method extends HttpServiceSchemaMethod<Schema>,
-    Path extends HttpServiceSchemaPath<Schema, Method>,
-    StatusCode extends HttpServiceResponseSchemaStatusCode<Default<Default<Schema[Path][Method]>['response']>> = never,
+    Method extends HttpSchemaMethod<Schema>,
+    Path extends HttpSchemaPath<Schema, Method>,
+    StatusCode extends HttpResponseSchemaStatusCode<Default<Default<Schema[Path][Method]>['response']>> = never,
   >(
     handler:
       | LocalHttpRequestHandler<Schema, Method, Path, StatusCode>
@@ -197,8 +197,8 @@ class HttpInterceptorClient<
   }
 
   private async handleInterceptedRequest<
-    Method extends HttpServiceSchemaMethod<Schema>,
-    Path extends HttpServiceSchemaPath<Schema, Method>,
+    Method extends HttpSchemaMethod<Schema>,
+    Path extends HttpSchemaPath<Schema, Method>,
     Context extends HttpInterceptorRequestContext<Schema, Method, Path>,
   >(matchedURLRegex: RegExp, method: Method, path: Path, { request }: Context): Promise<HttpResponseFactoryResult> {
     const parsedRequest = await HttpInterceptorWorker.parseRawRequest<Path, Default<Schema[Path][Method]>>(request, {
@@ -229,8 +229,8 @@ class HttpInterceptorClient<
   }
 
   private async findMatchedHandler<
-    Method extends HttpServiceSchemaMethod<Schema>,
-    Path extends HttpServiceSchemaPath<Schema, Method>,
+    Method extends HttpSchemaMethod<Schema>,
+    Path extends HttpSchemaPath<Schema, Method>,
   >(
     method: Method,
     path: Path,
@@ -289,7 +289,7 @@ export type AnyHttpInterceptorClient = HttpInterceptorClient<any>;
 
 export type HttpRequestHandlerConstructor = typeof LocalHttpRequestHandler | typeof RemoteHttpRequestHandler;
 
-export type SharedHttpInterceptorClient<Schema extends HttpServiceSchema> = HttpInterceptorClient<
+export type SharedHttpInterceptorClient<Schema extends HttpSchema> = HttpInterceptorClient<
   Schema,
   typeof LocalHttpRequestHandler
 > &

--- a/packages/zimic/src/interceptor/http/interceptor/LocalHttpInterceptor.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/LocalHttpInterceptor.ts
@@ -1,4 +1,4 @@
-import { HttpServiceSchema, HttpServiceSchemaMethod, HttpServiceSchemaPath } from '@/http/types/schema';
+import { HttpSchema, HttpSchemaMethod, HttpSchemaPath } from '@/http/types/schema';
 import { createURL, excludeNonPathParams } from '@/utils/urls';
 
 import LocalHttpRequestHandler from '../requestHandler/LocalHttpRequestHandler';
@@ -8,7 +8,7 @@ import { SyncHttpInterceptorMethodHandler } from './types/handlers';
 import { LocalHttpInterceptorOptions } from './types/options';
 import { LocalHttpInterceptor as PublicLocalHttpInterceptor } from './types/public';
 
-class LocalHttpInterceptor<Schema extends HttpServiceSchema> implements PublicLocalHttpInterceptor<Schema> {
+class LocalHttpInterceptor<Schema extends HttpSchema> implements PublicLocalHttpInterceptor<Schema> {
   readonly type: 'local';
 
   private store = new HttpInterceptorStore();
@@ -67,31 +67,31 @@ class LocalHttpInterceptor<Schema extends HttpServiceSchema> implements PublicLo
     await this._client.stop();
   }
 
-  get = ((path: HttpServiceSchemaPath<Schema, HttpServiceSchemaMethod<Schema>>) => {
+  get = ((path: HttpSchemaPath<Schema, HttpSchemaMethod<Schema>>) => {
     return this._client.get(path);
   }) as unknown as SyncHttpInterceptorMethodHandler<Schema, 'GET'>;
 
-  post = ((path: HttpServiceSchemaPath<Schema, HttpServiceSchemaMethod<Schema>>) => {
+  post = ((path: HttpSchemaPath<Schema, HttpSchemaMethod<Schema>>) => {
     return this._client.post(path);
   }) as unknown as SyncHttpInterceptorMethodHandler<Schema, 'POST'>;
 
-  patch = ((path: HttpServiceSchemaPath<Schema, HttpServiceSchemaMethod<Schema>>) => {
+  patch = ((path: HttpSchemaPath<Schema, HttpSchemaMethod<Schema>>) => {
     return this._client.patch(path);
   }) as unknown as SyncHttpInterceptorMethodHandler<Schema, 'PATCH'>;
 
-  put = ((path: HttpServiceSchemaPath<Schema, HttpServiceSchemaMethod<Schema>>) => {
+  put = ((path: HttpSchemaPath<Schema, HttpSchemaMethod<Schema>>) => {
     return this._client.put(path);
   }) as unknown as SyncHttpInterceptorMethodHandler<Schema, 'PUT'>;
 
-  delete = ((path: HttpServiceSchemaPath<Schema, HttpServiceSchemaMethod<Schema>>) => {
+  delete = ((path: HttpSchemaPath<Schema, HttpSchemaMethod<Schema>>) => {
     return this._client.delete(path);
   }) as unknown as SyncHttpInterceptorMethodHandler<Schema, 'DELETE'>;
 
-  head = ((path: HttpServiceSchemaPath<Schema, HttpServiceSchemaMethod<Schema>>) => {
+  head = ((path: HttpSchemaPath<Schema, HttpSchemaMethod<Schema>>) => {
     return this._client.head(path);
   }) as unknown as SyncHttpInterceptorMethodHandler<Schema, 'HEAD'>;
 
-  options = ((path: HttpServiceSchemaPath<Schema, HttpServiceSchemaMethod<Schema>>) => {
+  options = ((path: HttpSchemaPath<Schema, HttpSchemaMethod<Schema>>) => {
     return this._client.options(path);
   }) as unknown as SyncHttpInterceptorMethodHandler<Schema, 'OPTIONS'>;
 

--- a/packages/zimic/src/interceptor/http/interceptor/RemoteHttpInterceptor.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/RemoteHttpInterceptor.ts
@@ -1,4 +1,4 @@
-import { HttpServiceSchema, HttpServiceSchemaMethod, HttpServiceSchemaPath } from '@/http/types/schema';
+import { HttpSchema, HttpSchemaMethod, HttpSchemaPath } from '@/http/types/schema';
 import { createURL, excludeNonPathParams } from '@/utils/urls';
 
 import RemoteHttpRequestHandler from '../requestHandler/RemoteHttpRequestHandler';
@@ -8,7 +8,7 @@ import { AsyncHttpInterceptorMethodHandler } from './types/handlers';
 import { RemoteHttpInterceptorOptions } from './types/options';
 import { RemoteHttpInterceptor as PublicRemoteHttpInterceptor } from './types/public';
 
-class RemoteHttpInterceptor<Schema extends HttpServiceSchema> implements PublicRemoteHttpInterceptor<Schema> {
+class RemoteHttpInterceptor<Schema extends HttpSchema> implements PublicRemoteHttpInterceptor<Schema> {
   readonly type: 'remote';
 
   private store = new HttpInterceptorStore();
@@ -72,31 +72,31 @@ class RemoteHttpInterceptor<Schema extends HttpServiceSchema> implements PublicR
     await this._client.stop();
   }
 
-  get = ((path: HttpServiceSchemaPath<Schema, HttpServiceSchemaMethod<Schema>>) => {
+  get = ((path: HttpSchemaPath<Schema, HttpSchemaMethod<Schema>>) => {
     return this._client.get(path);
   }) as unknown as AsyncHttpInterceptorMethodHandler<Schema, 'GET'>;
 
-  post = ((path: HttpServiceSchemaPath<Schema, HttpServiceSchemaMethod<Schema>>) => {
+  post = ((path: HttpSchemaPath<Schema, HttpSchemaMethod<Schema>>) => {
     return this._client.post(path);
   }) as unknown as AsyncHttpInterceptorMethodHandler<Schema, 'POST'>;
 
-  patch = ((path: HttpServiceSchemaPath<Schema, HttpServiceSchemaMethod<Schema>>) => {
+  patch = ((path: HttpSchemaPath<Schema, HttpSchemaMethod<Schema>>) => {
     return this._client.patch(path);
   }) as unknown as AsyncHttpInterceptorMethodHandler<Schema, 'PATCH'>;
 
-  put = ((path: HttpServiceSchemaPath<Schema, HttpServiceSchemaMethod<Schema>>) => {
+  put = ((path: HttpSchemaPath<Schema, HttpSchemaMethod<Schema>>) => {
     return this._client.put(path);
   }) as unknown as AsyncHttpInterceptorMethodHandler<Schema, 'PUT'>;
 
-  delete = ((path: HttpServiceSchemaPath<Schema, HttpServiceSchemaMethod<Schema>>) => {
+  delete = ((path: HttpSchemaPath<Schema, HttpSchemaMethod<Schema>>) => {
     return this._client.delete(path);
   }) as unknown as AsyncHttpInterceptorMethodHandler<Schema, 'DELETE'>;
 
-  head = ((path: HttpServiceSchemaPath<Schema, HttpServiceSchemaMethod<Schema>>) => {
+  head = ((path: HttpSchemaPath<Schema, HttpSchemaMethod<Schema>>) => {
     return this._client.head(path);
   }) as unknown as AsyncHttpInterceptorMethodHandler<Schema, 'HEAD'>;
 
-  options = ((path: HttpServiceSchemaPath<Schema, HttpServiceSchemaMethod<Schema>>) => {
+  options = ((path: HttpSchemaPath<Schema, HttpSchemaMethod<Schema>>) => {
     return this._client.options(path);
   }) as unknown as AsyncHttpInterceptorMethodHandler<Schema, 'OPTIONS'>;
 

--- a/packages/zimic/src/interceptor/http/interceptor/factory.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/factory.ts
@@ -1,4 +1,4 @@
-import { HttpServiceSchema } from '@/http/types/schema';
+import { HttpSchema } from '@/http/types/schema';
 
 import UnknownHttpInterceptorTypeError from './errors/UnknownHttpInterceptorTypeError';
 import LocalHttpInterceptor from './LocalHttpInterceptor';
@@ -26,16 +26,16 @@ function isRemoteHttpInterceptorOptions(options: HttpInterceptorOptions) {
  * @throws {UnsupportedURLProtocolError} If the base URL protocol is not either `http` or `https`.
  * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#httpinterceptorcreateoptions `httpInterceptor.create(options)` API reference}
  */
-export function createHttpInterceptor<Schema extends HttpServiceSchema>(
+export function createHttpInterceptor<Schema extends HttpSchema>(
   options: LocalHttpInterceptorOptions,
 ): PublicLocalHttpInterceptor<Schema>;
-export function createHttpInterceptor<Schema extends HttpServiceSchema>(
+export function createHttpInterceptor<Schema extends HttpSchema>(
   options: RemoteHttpInterceptorOptions,
 ): PublicRemoteHttpInterceptor<Schema>;
-export function createHttpInterceptor<Schema extends HttpServiceSchema>(
+export function createHttpInterceptor<Schema extends HttpSchema>(
   options: HttpInterceptorOptions,
 ): PublicLocalHttpInterceptor<Schema> | PublicRemoteHttpInterceptor<Schema>;
-export function createHttpInterceptor<Schema extends HttpServiceSchema>(
+export function createHttpInterceptor<Schema extends HttpSchema>(
   options: HttpInterceptorOptions,
 ): PublicLocalHttpInterceptor<Schema> | PublicRemoteHttpInterceptor<Schema> {
   const type = options.type;

--- a/packages/zimic/src/interceptor/http/interceptor/types/handlers.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/types/handlers.ts
@@ -2,7 +2,7 @@ import {
   HttpMethod,
   HttpSchema,
   HttpSchemaMethod,
-  NonLiteralHttpSchemaPath,
+  HttpSchemaPath,
   LiteralHttpSchemaPathFromNonLiteral,
 } from '@/http/types/schema';
 
@@ -10,7 +10,7 @@ import { LocalHttpRequestHandler, RemoteHttpRequestHandler } from '../../request
 
 export type SyncHttpInterceptorMethodHandler<Schema extends HttpSchema, Method extends HttpMethod> =
   Method extends HttpSchemaMethod<Schema>
-    ? <Path extends NonLiteralHttpSchemaPath<Schema, Method>>(
+    ? <Path extends HttpSchemaPath.NonLiteral<Schema, Method>>(
         path: Path,
       ) => LocalHttpRequestHandler<Schema, Method, LiteralHttpSchemaPathFromNonLiteral<Schema, Method, Path>>
     : // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -18,7 +18,7 @@ export type SyncHttpInterceptorMethodHandler<Schema extends HttpSchema, Method e
 
 export type AsyncHttpInterceptorMethodHandler<Schema extends HttpSchema, Method extends HttpMethod> =
   Method extends HttpSchemaMethod<Schema>
-    ? <Path extends NonLiteralHttpSchemaPath<Schema, Method>>(
+    ? <Path extends HttpSchemaPath.NonLiteral<Schema, Method>>(
         path: Path,
       ) => RemoteHttpRequestHandler<Schema, Method, LiteralHttpSchemaPathFromNonLiteral<Schema, Method, Path>>
     : // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/zimic/src/interceptor/http/interceptor/types/handlers.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/types/handlers.ts
@@ -1,29 +1,29 @@
 import {
   HttpMethod,
-  HttpServiceSchema,
-  HttpServiceSchemaMethod,
-  NonLiteralHttpServiceSchemaPath,
-  LiteralHttpServiceSchemaPathFromNonLiteral,
+  HttpSchema,
+  HttpSchemaMethod,
+  NonLiteralHttpSchemaPath,
+  LiteralHttpSchemaPathFromNonLiteral,
 } from '@/http/types/schema';
 
 import { LocalHttpRequestHandler, RemoteHttpRequestHandler } from '../../requestHandler/types/public';
 
-export type SyncHttpInterceptorMethodHandler<Schema extends HttpServiceSchema, Method extends HttpMethod> =
-  Method extends HttpServiceSchemaMethod<Schema>
-    ? <Path extends NonLiteralHttpServiceSchemaPath<Schema, Method>>(
+export type SyncHttpInterceptorMethodHandler<Schema extends HttpSchema, Method extends HttpMethod> =
+  Method extends HttpSchemaMethod<Schema>
+    ? <Path extends NonLiteralHttpSchemaPath<Schema, Method>>(
         path: Path,
-      ) => LocalHttpRequestHandler<Schema, Method, LiteralHttpServiceSchemaPathFromNonLiteral<Schema, Method, Path>>
+      ) => LocalHttpRequestHandler<Schema, Method, LiteralHttpSchemaPathFromNonLiteral<Schema, Method, Path>>
     : // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (path: never) => LocalHttpRequestHandler<any, any, never>;
 
-export type AsyncHttpInterceptorMethodHandler<Schema extends HttpServiceSchema, Method extends HttpMethod> =
-  Method extends HttpServiceSchemaMethod<Schema>
-    ? <Path extends NonLiteralHttpServiceSchemaPath<Schema, Method>>(
+export type AsyncHttpInterceptorMethodHandler<Schema extends HttpSchema, Method extends HttpMethod> =
+  Method extends HttpSchemaMethod<Schema>
+    ? <Path extends NonLiteralHttpSchemaPath<Schema, Method>>(
         path: Path,
-      ) => RemoteHttpRequestHandler<Schema, Method, LiteralHttpServiceSchemaPathFromNonLiteral<Schema, Method, Path>>
+      ) => RemoteHttpRequestHandler<Schema, Method, LiteralHttpSchemaPathFromNonLiteral<Schema, Method, Path>>
     : // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (path: never) => RemoteHttpRequestHandler<any, any, never>;
 
-export type HttpInterceptorMethodHandler<Schema extends HttpServiceSchema, Method extends HttpMethod> =
+export type HttpInterceptorMethodHandler<Schema extends HttpSchema, Method extends HttpMethod> =
   | SyncHttpInterceptorMethodHandler<Schema, Method>
   | AsyncHttpInterceptorMethodHandler<Schema, Method>;

--- a/packages/zimic/src/interceptor/http/interceptor/types/public.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/types/public.ts
@@ -1,4 +1,4 @@
-import { HttpServiceSchema } from '@/http/types/schema';
+import { HttpSchema } from '@/http/types/schema';
 
 import {
   HttpInterceptorMethodHandler,
@@ -13,7 +13,7 @@ import { HttpInterceptorPlatform } from './options';
  *
  * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#httpinterceptor `HttpInterceptor` API reference}
  */
-export interface HttpInterceptor<Schema extends HttpServiceSchema> {
+export interface HttpInterceptor<Schema extends HttpSchema> {
   /**
    * @returns The base URL used by the interceptor.
    * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-interceptorbaseurl `interceptor.baseURL()` API reference}
@@ -151,7 +151,7 @@ export interface HttpInterceptor<Schema extends HttpServiceSchema> {
  *
  * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#httpinterceptor `HttpInterceptor` API reference}
  */
-export interface LocalHttpInterceptor<Schema extends HttpServiceSchema> extends HttpInterceptor<Schema> {
+export interface LocalHttpInterceptor<Schema extends HttpSchema> extends HttpInterceptor<Schema> {
   readonly type: 'local';
 
   get: SyncHttpInterceptorMethodHandler<Schema, 'GET'>;
@@ -176,7 +176,7 @@ export interface LocalHttpInterceptor<Schema extends HttpServiceSchema> extends 
  *
  * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#httpinterceptor `HttpInterceptor` API reference}
  */
-export interface RemoteHttpInterceptor<Schema extends HttpServiceSchema> extends HttpInterceptor<Schema> {
+export interface RemoteHttpInterceptor<Schema extends HttpSchema> extends HttpInterceptor<Schema> {
   readonly type: 'remote';
 
   get: AsyncHttpInterceptorMethodHandler<Schema, 'GET'>;

--- a/packages/zimic/src/interceptor/http/interceptor/types/requests.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/types/requests.ts
@@ -1,10 +1,10 @@
-import { HttpServiceSchema, HttpServiceSchemaMethod, HttpServiceSchemaPath } from '@/http/types/schema';
+import { HttpSchema, HttpSchemaMethod, HttpSchemaPath } from '@/http/types/schema';
 import { Default } from '@/types/utils';
 
 import { HttpResponseFactoryContext } from '../../interceptorWorker/types/requests';
 
 export type HttpInterceptorRequestContext<
-  Schema extends HttpServiceSchema,
-  Method extends HttpServiceSchemaMethod<Schema>,
-  Path extends HttpServiceSchemaPath<Schema, Method>,
+  Schema extends HttpSchema,
+  Method extends HttpSchemaMethod<Schema>,
+  Path extends HttpSchemaPath<Schema, Method>,
 > = HttpResponseFactoryContext<Default<Default<Schema[Path][Method]>['request']>['body']>;

--- a/packages/zimic/src/interceptor/http/interceptor/types/schema.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/types/schema.ts
@@ -35,37 +35,3 @@ export type InferHttpInterceptorSchema<Interceptor> =
     : Interceptor extends RemoteHttpInterceptor<infer Schema>
       ? Schema
       : never;
-
-/**
- * Infers the schema of an
- * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#httpinterceptor `HttpInterceptor`}.
- *
- * @deprecated Use
- *   {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#inferpathparams InferHttpInterceptorSchema}
- *   instead, which is a drop-in replacement.
- * @example
- *   import { httpInterceptor, type ExtractHttpInterceptorSchema } from 'zimic';
- *
- *   const interceptor = httpInterceptor.create<{
- *     '/users': {
- *       GET: {
- *         response: { 200: { body: User[] } };
- *       };
- *     };
- *   }>({
- *     type: 'local',
- *     baseURL: 'http://localhost:3000',
- *   });
- *
- *   type Schema = ExtractHttpInterceptorSchema<typeof interceptor>;
- *   // {
- *   //   '/users': {
- *   //     GET: {
- *   //       response: { 200: { body: User[] } };
- *   //     };
- *   //   };
- *   // }
- *
- * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http‐schemas Declaring service schemas}
- */
-export type ExtractHttpInterceptorSchema<Interceptor> = InferHttpInterceptorSchema<Interceptor>;

--- a/packages/zimic/src/interceptor/http/interceptorWorker/HttpInterceptorWorker.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/HttpInterceptorWorker.ts
@@ -8,9 +8,9 @@ import { HttpHeadersInit, HttpHeadersSchema } from '@/http/headers/types';
 import { HttpBody, HttpRequest, HttpResponse } from '@/http/types/requests';
 import {
   HttpMethod,
-  HttpServiceMethodSchema,
-  HttpServiceResponseSchemaStatusCode,
-  HttpServiceSchema,
+  HttpMethodSchema,
+  HttpResponseSchemaStatusCode,
+  HttpSchema,
   InferPathParams,
 } from '@/http/types/schema';
 import { Default, PossiblePromise } from '@/types/utils';
@@ -107,7 +107,7 @@ abstract class HttpInterceptorWorker {
     this.stoppingPromise = undefined;
   }
 
-  abstract use<Schema extends HttpServiceSchema>(
+  abstract use<Schema extends HttpSchema>(
     interceptor: HttpInterceptorClient<Schema>,
     method: HttpMethod,
     url: string,
@@ -183,7 +183,7 @@ abstract class HttpInterceptorWorker {
 
   abstract clearHandlers(): PossiblePromise<void>;
 
-  abstract clearInterceptorHandlers<Schema extends HttpServiceSchema>(
+  abstract clearInterceptorHandlers<Schema extends HttpSchema>(
     interceptor: HttpInterceptorClient<Schema>,
   ): PossiblePromise<void>;
 
@@ -220,7 +220,7 @@ abstract class HttpInterceptorWorker {
     return Response.json(declaration.body, { headers, status });
   }
 
-  static async parseRawRequest<Path extends string, MethodSchema extends HttpServiceMethodSchema>(
+  static async parseRawRequest<Path extends string, MethodSchema extends HttpMethodSchema>(
     originalRawRequest: HttpRequest,
     options: { urlRegex?: RegExp } = {},
   ): Promise<HttpInterceptorRequest<Path, MethodSchema>> {
@@ -278,8 +278,8 @@ abstract class HttpInterceptorWorker {
   }
 
   static async parseRawResponse<
-    MethodSchema extends HttpServiceMethodSchema,
-    StatusCode extends HttpServiceResponseSchemaStatusCode<Default<MethodSchema['response']>>,
+    MethodSchema extends HttpMethodSchema,
+    StatusCode extends HttpResponseSchemaStatusCode<Default<MethodSchema['response']>>,
   >(originalRawResponse: HttpResponse): Promise<HttpInterceptorResponse<MethodSchema, StatusCode>> {
     const rawResponse = originalRawResponse.clone();
     const rawResponseClone = rawResponse.clone();

--- a/packages/zimic/src/interceptor/http/interceptorWorker/LocalHttpInterceptorWorker.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/LocalHttpInterceptorWorker.ts
@@ -1,7 +1,7 @@
 import { HttpHandler as MSWHttpHandler, SharedOptions as MSWWorkerSharedOptions, http, passthrough } from 'msw';
 
 import { HttpRequest } from '@/http/types/requests';
-import { HttpMethod, HttpServiceSchema } from '@/http/types/schema';
+import { HttpMethod, HttpSchema } from '@/http/types/schema';
 import { importMSWBrowser, importMSWNode } from '@/utils/msw';
 import { createURL, ensureUniquePathParams, excludeNonPathParams } from '@/utils/urls';
 
@@ -136,7 +136,7 @@ class LocalHttpInterceptorWorker extends HttpInterceptorWorker {
     return !this.hasInternalBrowserWorker();
   }
 
-  use<Schema extends HttpServiceSchema>(
+  use<Schema extends HttpSchema>(
     interceptor: HttpInterceptorClient<Schema>,
     method: HttpMethod,
     rawURL: string | URL,
@@ -180,7 +180,7 @@ class LocalHttpInterceptorWorker extends HttpInterceptorWorker {
     this.httpHandlerGroups = [];
   }
 
-  clearInterceptorHandlers<Schema extends HttpServiceSchema>(interceptor: HttpInterceptorClient<Schema>) {
+  clearInterceptorHandlers<Schema extends HttpSchema>(interceptor: HttpInterceptorClient<Schema>) {
     const internalWorker = this.internalWorkerOrThrow();
 
     const httpHandlerGroupsToKeep = this.httpHandlerGroups.filter((group) => group.interceptor !== interceptor);

--- a/packages/zimic/src/interceptor/http/interceptorWorker/RemoteHttpInterceptorWorker.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/RemoteHttpInterceptorWorker.ts
@@ -1,5 +1,5 @@
 import { HttpResponse } from '@/http/types/requests';
-import { HttpMethod, HttpServiceSchema } from '@/http/types/schema';
+import { HttpMethod, HttpSchema } from '@/http/types/schema';
 import { HttpHandlerCommit, InterceptorServerWebSocketSchema } from '@/interceptor/server/types/schema';
 import { importCrypto } from '@/utils/crypto';
 import { deserializeRequest, serializeResponse } from '@/utils/fetch';
@@ -113,7 +113,7 @@ class RemoteHttpInterceptorWorker extends HttpInterceptorWorker {
     });
   }
 
-  async use<Schema extends HttpServiceSchema>(
+  async use<Schema extends HttpSchema>(
     interceptor: HttpInterceptorClient<Schema>,
     method: HttpMethod,
     rawURL: string | URL,
@@ -159,7 +159,7 @@ class RemoteHttpInterceptorWorker extends HttpInterceptorWorker {
     }
   }
 
-  async clearInterceptorHandlers<Schema extends HttpServiceSchema>(interceptor: HttpInterceptorClient<Schema>) {
+  async clearInterceptorHandlers<Schema extends HttpSchema>(interceptor: HttpInterceptorClient<Schema>) {
     if (!super.isRunning()) {
       throw new NotStartedHttpInterceptorError();
     }

--- a/packages/zimic/src/interceptor/http/requestHandler/HttpRequestHandlerClient.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/HttpRequestHandlerClient.ts
@@ -1,12 +1,7 @@
 import HttpFormData from '@/http/formData/HttpFormData';
 import HttpHeaders from '@/http/headers/HttpHeaders';
 import HttpSearchParams from '@/http/searchParams/HttpSearchParams';
-import {
-  HttpServiceResponseSchemaStatusCode,
-  HttpServiceSchema,
-  HttpServiceSchemaMethod,
-  HttpServiceSchemaPath,
-} from '@/http/types/schema';
+import { HttpResponseSchemaStatusCode, HttpSchema, HttpSchemaMethod, HttpSchemaPath } from '@/http/types/schema';
 import { Default, IfAny } from '@/types/utils';
 import { blobContains, blobEquals } from '@/utils/data';
 import { jsonContains, jsonEquals } from '@/utils/json';
@@ -28,13 +23,13 @@ import {
 } from './types/requests';
 
 class HttpRequestHandlerClient<
-  Schema extends HttpServiceSchema,
-  Method extends HttpServiceSchemaMethod<Schema>,
-  Path extends HttpServiceSchemaPath<Schema, Method>,
+  Schema extends HttpSchema,
+  Method extends HttpSchemaMethod<Schema>,
+  Path extends HttpSchemaPath<Schema, Method>,
   StatusCode extends IfAny<
     Schema,
     any, // eslint-disable-line @typescript-eslint/no-explicit-any
-    HttpServiceResponseSchemaStatusCode<Default<Default<Schema[Path][Method]>['response']>>
+    HttpResponseSchemaStatusCode<Default<Default<Schema[Path][Method]>['response']>>
   > = never,
 > {
   private restrictions: HttpRequestHandlerRestriction<Schema, Method, Path>[] = [];
@@ -70,9 +65,7 @@ class HttpRequestHandlerClient<
     return this;
   }
 
-  respond<
-    NewStatusCode extends HttpServiceResponseSchemaStatusCode<Default<Default<Schema[Path][Method]>['response']>>,
-  >(
+  respond<NewStatusCode extends HttpResponseSchemaStatusCode<Default<Default<Schema[Path][Method]>['response']>>>(
     declaration:
       | HttpRequestHandlerResponseDeclaration<Default<Schema[Path][Method]>, NewStatusCode>
       | HttpRequestHandlerResponseDeclarationFactory<Path, Default<Schema[Path][Method]>, NewStatusCode>,
@@ -90,7 +83,7 @@ class HttpRequestHandlerClient<
   }
 
   private isResponseDeclarationFactory<
-    StatusCode extends HttpServiceResponseSchemaStatusCode<Default<Default<Schema[Path][Method]>['response']>>,
+    StatusCode extends HttpResponseSchemaStatusCode<Default<Default<Schema[Path][Method]>['response']>>,
   >(
     declaration:
       | HttpRequestHandlerResponseDeclaration<Default<Schema[Path][Method]>, StatusCode>

--- a/packages/zimic/src/interceptor/http/requestHandler/LocalHttpRequestHandler.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/LocalHttpRequestHandler.ts
@@ -1,9 +1,4 @@
-import {
-  HttpServiceResponseSchemaStatusCode,
-  HttpServiceSchema,
-  HttpServiceSchemaMethod,
-  HttpServiceSchemaPath,
-} from '@/http/types/schema';
+import { HttpResponseSchemaStatusCode, HttpSchema, HttpSchemaMethod, HttpSchemaPath } from '@/http/types/schema';
 import { Default } from '@/types/utils';
 
 import HttpInterceptorClient from '../interceptor/HttpInterceptorClient';
@@ -21,10 +16,10 @@ import {
 } from './types/requests';
 
 class LocalHttpRequestHandler<
-  Schema extends HttpServiceSchema,
-  Method extends HttpServiceSchemaMethod<Schema>,
-  Path extends HttpServiceSchemaPath<Schema, Method>,
-  StatusCode extends HttpServiceResponseSchemaStatusCode<Default<Default<Schema[Path][Method]>['response']>> = never,
+  Schema extends HttpSchema,
+  Method extends HttpSchemaMethod<Schema>,
+  Path extends HttpSchemaPath<Schema, Method>,
+  StatusCode extends HttpResponseSchemaStatusCode<Default<Default<Schema[Path][Method]>['response']>> = never,
 > implements PublicLocalHttpRequestHandler<Schema, Method, Path, StatusCode>
 {
   readonly type = 'local';
@@ -54,9 +49,7 @@ class LocalHttpRequestHandler<
     return this;
   }
 
-  respond<
-    NewStatusCode extends HttpServiceResponseSchemaStatusCode<Default<Default<Schema[Path][Method]>['response']>>,
-  >(
+  respond<NewStatusCode extends HttpResponseSchemaStatusCode<Default<Default<Schema[Path][Method]>['response']>>>(
     declaration:
       | HttpRequestHandlerResponseDeclaration<Default<Schema[Path][Method]>, NewStatusCode>
       | HttpRequestHandlerResponseDeclarationFactory<Path, Default<Schema[Path][Method]>, NewStatusCode>,

--- a/packages/zimic/src/interceptor/http/requestHandler/RemoteHttpRequestHandler.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/RemoteHttpRequestHandler.ts
@@ -1,9 +1,4 @@
-import {
-  HttpServiceResponseSchemaStatusCode,
-  HttpServiceSchema,
-  HttpServiceSchemaMethod,
-  HttpServiceSchemaPath,
-} from '@/http/types/schema';
+import { HttpResponseSchemaStatusCode, HttpSchema, HttpSchemaMethod, HttpSchemaPath } from '@/http/types/schema';
 import { Default, PossiblePromise } from '@/types/utils';
 
 import HttpInterceptorClient from '../interceptor/HttpInterceptorClient';
@@ -24,10 +19,10 @@ import {
 const PENDING_PROPERTIES = new Set<string | symbol>(['then'] satisfies (keyof Promise<unknown>)[]);
 
 class RemoteHttpRequestHandler<
-  Schema extends HttpServiceSchema,
-  Method extends HttpServiceSchemaMethod<Schema>,
-  Path extends HttpServiceSchemaPath<Schema, Method>,
-  StatusCode extends HttpServiceResponseSchemaStatusCode<Default<Default<Schema[Path][Method]>['response']>> = never,
+  Schema extends HttpSchema,
+  Method extends HttpSchemaMethod<Schema>,
+  Path extends HttpSchemaPath<Schema, Method>,
+  StatusCode extends HttpResponseSchemaStatusCode<Default<Default<Schema[Path][Method]>['response']>> = never,
 > implements PublicRemoteHttpRequestHandler<Schema, Method, Path, StatusCode>
 {
   readonly type = 'remote';
@@ -86,9 +81,7 @@ class RemoteHttpRequestHandler<
     return this.unsynced;
   }
 
-  respond<
-    NewStatusCode extends HttpServiceResponseSchemaStatusCode<Default<Default<Schema[Path][Method]>['response']>>,
-  >(
+  respond<NewStatusCode extends HttpResponseSchemaStatusCode<Default<Default<Schema[Path][Method]>['response']>>>(
     declaration:
       | HttpRequestHandlerResponseDeclaration<Default<Schema[Path][Method]>, NewStatusCode>
       | HttpRequestHandlerResponseDeclarationFactory<Path, Default<Schema[Path][Method]>, NewStatusCode>,

--- a/packages/zimic/src/interceptor/http/requestHandler/types/public.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/types/public.ts
@@ -4,12 +4,7 @@ import { HttpHeadersSchema } from '@/http/headers/types';
 import HttpSearchParams from '@/http/searchParams/HttpSearchParams';
 import { HttpSearchParamsSchema } from '@/http/searchParams/types';
 import { HttpBody } from '@/http/types/requests';
-import {
-  HttpServiceResponseSchemaStatusCode,
-  HttpServiceSchema,
-  HttpServiceSchemaMethod,
-  HttpServiceSchemaPath,
-} from '@/http/types/schema';
+import { HttpResponseSchemaStatusCode, HttpSchema, HttpSchemaMethod, HttpSchemaPath } from '@/http/types/schema';
 import { DeepPartial, Default, IfAny, IfNever, PossiblePromise } from '@/types/utils';
 
 import {
@@ -33,9 +28,9 @@ type PartialHttpHeadersOrSchema<Schema extends HttpHeadersSchema> =
  * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlerwithrestriction `handler.with()` API reference}
  */
 export type HttpRequestHandlerHeadersStaticRestriction<
-  Schema extends HttpServiceSchema,
-  Path extends HttpServiceSchemaPath<Schema, Method>,
-  Method extends HttpServiceSchemaMethod<Schema>,
+  Schema extends HttpSchema,
+  Path extends HttpSchemaPath<Schema, Method>,
+  Method extends HttpSchemaMethod<Schema>,
 > = PartialHttpHeadersOrSchema<HttpRequestHeadersSchema<Default<Schema[Path][Method]>>>;
 
 type PartialHttpSearchParamsOrSchema<Schema extends HttpSearchParamsSchema> = IfNever<
@@ -50,9 +45,9 @@ type PartialHttpSearchParamsOrSchema<Schema extends HttpSearchParamsSchema> = If
  * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlerwithrestriction `handler.with()` API reference}
  */
 export type HttpRequestHandlerSearchParamsStaticRestriction<
-  Schema extends HttpServiceSchema,
-  Path extends HttpServiceSchemaPath<Schema, Method>,
-  Method extends HttpServiceSchemaMethod<Schema>,
+  Schema extends HttpSchema,
+  Path extends HttpSchemaPath<Schema, Method>,
+  Method extends HttpSchemaMethod<Schema>,
 > = PartialHttpSearchParamsOrSchema<HttpRequestSearchParamsSchema<Default<Schema[Path][Method]>>>;
 
 type PartialBodyOrSchema<Body extends HttpBody> =
@@ -70,9 +65,9 @@ type PartialBodyOrSchema<Body extends HttpBody> =
  * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlerwithrestriction `handler.with()` API reference}
  */
 export type HttpRequestHandlerBodyStaticRestriction<
-  Schema extends HttpServiceSchema,
-  Path extends HttpServiceSchemaPath<Schema, Method>,
-  Method extends HttpServiceSchemaMethod<Schema>,
+  Schema extends HttpSchema,
+  Path extends HttpSchemaPath<Schema, Method>,
+  Method extends HttpSchemaMethod<Schema>,
 > = PartialBodyOrSchema<HttpRequestBodySchema<Default<Schema[Path][Method]>>>;
 
 /**
@@ -81,9 +76,9 @@ export type HttpRequestHandlerBodyStaticRestriction<
  * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlerwithrestriction `handler.with()` API reference}
  */
 export interface HttpRequestHandlerStaticRestriction<
-  Schema extends HttpServiceSchema,
-  Path extends HttpServiceSchemaPath<Schema, Method>,
-  Method extends HttpServiceSchemaMethod<Schema>,
+  Schema extends HttpSchema,
+  Path extends HttpSchemaPath<Schema, Method>,
+  Method extends HttpSchemaMethod<Schema>,
 > {
   /**
    * A set of headers that the intercepted request must contain to match the handler. If exact is `true`, the request
@@ -116,9 +111,9 @@ export interface HttpRequestHandlerStaticRestriction<
  * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlerwithrestriction `handler.with()` API reference}
  */
 export type HttpRequestHandlerComputedRestriction<
-  Schema extends HttpServiceSchema,
-  Method extends HttpServiceSchemaMethod<Schema>,
-  Path extends HttpServiceSchemaPath<Schema, Method>,
+  Schema extends HttpSchema,
+  Method extends HttpSchemaMethod<Schema>,
+  Path extends HttpSchemaPath<Schema, Method>,
 > = (request: HttpInterceptorRequest<Path, Default<Schema[Path][Method]>>) => PossiblePromise<boolean>;
 
 /**
@@ -127,9 +122,9 @@ export type HttpRequestHandlerComputedRestriction<
  * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlerwithrestriction `handler.with()` API reference}
  */
 export type HttpRequestHandlerRestriction<
-  Schema extends HttpServiceSchema,
-  Method extends HttpServiceSchemaMethod<Schema>,
-  Path extends HttpServiceSchemaPath<Schema, Method>,
+  Schema extends HttpSchema,
+  Method extends HttpSchemaMethod<Schema>,
+  Path extends HttpSchemaPath<Schema, Method>,
 > =
   | HttpRequestHandlerStaticRestriction<Schema, Path, Method>
   | HttpRequestHandlerComputedRestriction<Schema, Method, Path>;
@@ -144,10 +139,10 @@ export type HttpRequestHandlerRestriction<
  * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#httprequesthandler `HttpRequestHandler` API reference}
  */
 export interface HttpRequestHandler<
-  Schema extends HttpServiceSchema,
-  Method extends HttpServiceSchemaMethod<Schema>,
-  Path extends HttpServiceSchemaPath<Schema, Method>,
-  StatusCode extends HttpServiceResponseSchemaStatusCode<Default<Default<Schema[Path][Method]>['response']>> = never,
+  Schema extends HttpSchema,
+  Method extends HttpSchemaMethod<Schema>,
+  Path extends HttpSchemaPath<Schema, Method>,
+  StatusCode extends HttpResponseSchemaStatusCode<Default<Default<Schema[Path][Method]>['response']>> = never,
 > {
   /**
    * @returns The method that matches this handler.
@@ -194,7 +189,7 @@ export interface HttpRequestHandler<
    *   status code.
    * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlerrespond `handler.respond()` API reference}
    */
-  respond: <StatusCode extends HttpServiceResponseSchemaStatusCode<Default<Default<Schema[Path][Method]>['response']>>>(
+  respond: <StatusCode extends HttpResponseSchemaStatusCode<Default<Default<Schema[Path][Method]>['response']>>>(
     declaration:
       | HttpRequestHandlerResponseDeclaration<Default<Schema[Path][Method]>, StatusCode>
       | HttpRequestHandlerResponseDeclarationFactory<Path, Default<Schema[Path][Method]>, StatusCode>,
@@ -267,13 +262,13 @@ export interface HttpRequestHandler<
  * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#httprequesthandler `HttpRequestHandler` API reference}
  */
 export interface LocalHttpRequestHandler<
-  Schema extends HttpServiceSchema,
-  Method extends HttpServiceSchemaMethod<Schema>,
-  Path extends HttpServiceSchemaPath<Schema, Method>,
+  Schema extends HttpSchema,
+  Method extends HttpSchemaMethod<Schema>,
+  Path extends HttpSchemaPath<Schema, Method>,
   StatusCode extends IfAny<
     Schema,
     any, // eslint-disable-line @typescript-eslint/no-explicit-any
-    HttpServiceResponseSchemaStatusCode<Default<Default<Schema[Path][Method]>['response']>>
+    HttpResponseSchemaStatusCode<Default<Default<Schema[Path][Method]>['response']>>
   > = never,
 > extends HttpRequestHandler<Schema, Method, Path, StatusCode> {
   readonly type: 'local';
@@ -282,7 +277,7 @@ export interface LocalHttpRequestHandler<
     restriction: HttpRequestHandlerRestriction<Schema, Method, Path>,
   ) => LocalHttpRequestHandler<Schema, Method, Path, StatusCode>;
 
-  respond: <StatusCode extends HttpServiceResponseSchemaStatusCode<Default<Default<Schema[Path][Method]>['response']>>>(
+  respond: <StatusCode extends HttpResponseSchemaStatusCode<Default<Default<Schema[Path][Method]>['response']>>>(
     declaration:
       | HttpRequestHandlerResponseDeclaration<Default<Schema[Path][Method]>, StatusCode>
       | HttpRequestHandlerResponseDeclarationFactory<Path, Default<Schema[Path][Method]>, StatusCode>,
@@ -303,16 +298,16 @@ export interface LocalHttpRequestHandler<
  * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#httprequesthandler `HttpRequestHandler` API reference}
  */
 export interface SyncedRemoteHttpRequestHandler<
-  Schema extends HttpServiceSchema,
-  Method extends HttpServiceSchemaMethod<Schema>,
-  Path extends HttpServiceSchemaPath<Schema, Method>,
-  StatusCode extends HttpServiceResponseSchemaStatusCode<Default<Default<Schema[Path][Method]>['response']>> = never,
+  Schema extends HttpSchema,
+  Method extends HttpSchemaMethod<Schema>,
+  Path extends HttpSchemaPath<Schema, Method>,
+  StatusCode extends HttpResponseSchemaStatusCode<Default<Default<Schema[Path][Method]>['response']>> = never,
 > extends HttpRequestHandler<Schema, Method, Path, StatusCode> {
   with: (
     restriction: HttpRequestHandlerRestriction<Schema, Method, Path>,
   ) => PendingRemoteHttpRequestHandler<Schema, Method, Path, StatusCode>;
 
-  respond: <StatusCode extends HttpServiceResponseSchemaStatusCode<Default<Default<Schema[Path][Method]>['response']>>>(
+  respond: <StatusCode extends HttpResponseSchemaStatusCode<Default<Default<Schema[Path][Method]>['response']>>>(
     declaration:
       | HttpRequestHandlerResponseDeclaration<Default<Schema[Path][Method]>, StatusCode>
       | HttpRequestHandlerResponseDeclarationFactory<Path, Default<Schema[Path][Method]>, StatusCode>,
@@ -336,10 +331,10 @@ export interface SyncedRemoteHttpRequestHandler<
  * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#httprequesthandler `HttpRequestHandler` API reference}
  */
 export interface PendingRemoteHttpRequestHandler<
-  Schema extends HttpServiceSchema,
-  Method extends HttpServiceSchemaMethod<Schema>,
-  Path extends HttpServiceSchemaPath<Schema, Method>,
-  StatusCode extends HttpServiceResponseSchemaStatusCode<Default<Default<Schema[Path][Method]>['response']>> = never,
+  Schema extends HttpSchema,
+  Method extends HttpSchemaMethod<Schema>,
+  Path extends HttpSchemaPath<Schema, Method>,
+  StatusCode extends HttpResponseSchemaStatusCode<Default<Default<Schema[Path][Method]>['response']>> = never,
 > extends SyncedRemoteHttpRequestHandler<Schema, Method, Path, StatusCode> {
   /**
    * Waits for the remote handler to be synced with the connected
@@ -383,13 +378,13 @@ export interface PendingRemoteHttpRequestHandler<
  * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#httprequesthandler `HttpRequestHandler` API reference}
  */
 export interface RemoteHttpRequestHandler<
-  Schema extends HttpServiceSchema,
-  Method extends HttpServiceSchemaMethod<Schema>,
-  Path extends HttpServiceSchemaPath<Schema, Method>,
+  Schema extends HttpSchema,
+  Method extends HttpSchemaMethod<Schema>,
+  Path extends HttpSchemaPath<Schema, Method>,
   StatusCode extends IfAny<
     Schema,
     any, // eslint-disable-line @typescript-eslint/no-explicit-any
-    HttpServiceResponseSchemaStatusCode<Default<Default<Schema[Path][Method]>['response']>>
+    HttpResponseSchemaStatusCode<Default<Default<Schema[Path][Method]>['response']>>
   > = never,
 > extends PendingRemoteHttpRequestHandler<Schema, Method, Path, StatusCode> {
   readonly type: 'remote';

--- a/packages/zimic/src/interceptor/http/requestHandler/types/requests.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/types/requests.ts
@@ -3,25 +3,25 @@ import { HttpHeadersInit } from '@/http/headers/types';
 import HttpSearchParams from '@/http/searchParams/HttpSearchParams';
 import { HttpRequest, HttpResponse } from '@/http/types/requests';
 import {
-  HttpServiceMethodSchema,
-  HttpServiceResponseSchema,
-  HttpServiceResponseSchemaStatusCode,
+  HttpMethodSchema,
+  HttpResponseSchema,
+  HttpResponseSchemaStatusCode,
   InferPathParams,
 } from '@/http/types/schema';
 import { Default, DefaultNoExclude, IfNever, PossiblePromise, ReplaceBy } from '@/types/utils';
 
-export type HttpRequestHandlerResponseBodyAttribute<ResponseSchema extends HttpServiceResponseSchema> =
+export type HttpRequestHandlerResponseBodyAttribute<ResponseSchema extends HttpResponseSchema> =
   undefined extends ResponseSchema['body'] ? { body?: null } : { body: ResponseSchema['body'] };
 
-export type HttpRequestHandlerResponseHeadersAttribute<ResponseSchema extends HttpServiceResponseSchema> =
+export type HttpRequestHandlerResponseHeadersAttribute<ResponseSchema extends HttpResponseSchema> =
   undefined extends ResponseSchema['headers']
     ? { headers?: undefined }
     : { headers: HttpHeadersInit<Default<ResponseSchema['headers']>> };
 
 /** A declaration of an HTTP response for an intercepted request. */
 export type HttpRequestHandlerResponseDeclaration<
-  MethodSchema extends HttpServiceMethodSchema,
-  StatusCode extends HttpServiceResponseSchemaStatusCode<Default<MethodSchema['response']>>,
+  MethodSchema extends HttpMethodSchema,
+  StatusCode extends HttpResponseSchemaStatusCode<Default<MethodSchema['response']>>,
 > = StatusCode extends StatusCode
   ? {
       status: StatusCode;
@@ -37,21 +37,21 @@ export type HttpRequestHandlerResponseDeclaration<
  */
 export type HttpRequestHandlerResponseDeclarationFactory<
   Path extends string,
-  MethodSchema extends HttpServiceMethodSchema,
-  StatusCode extends HttpServiceResponseSchemaStatusCode<Default<MethodSchema['response']>>,
+  MethodSchema extends HttpMethodSchema,
+  StatusCode extends HttpResponseSchemaStatusCode<Default<MethodSchema['response']>>,
 > = (
   request: Omit<HttpInterceptorRequest<Path, MethodSchema>, 'response'>,
 ) => PossiblePromise<HttpRequestHandlerResponseDeclaration<MethodSchema, StatusCode>>;
 
-export type HttpRequestHeadersSchema<MethodSchema extends HttpServiceMethodSchema> = Default<
+export type HttpRequestHeadersSchema<MethodSchema extends HttpMethodSchema> = Default<
   DefaultNoExclude<Default<MethodSchema['request']>['headers']>
 >;
 
-export type HttpRequestSearchParamsSchema<MethodSchema extends HttpServiceMethodSchema> = Default<
+export type HttpRequestSearchParamsSchema<MethodSchema extends HttpMethodSchema> = Default<
   DefaultNoExclude<Default<MethodSchema['request']>['searchParams']>
 >;
 
-export type HttpRequestBodySchema<MethodSchema extends HttpServiceMethodSchema> = ReplaceBy<
+export type HttpRequestBodySchema<MethodSchema extends HttpMethodSchema> = ReplaceBy<
   ReplaceBy<IfNever<DefaultNoExclude<Default<MethodSchema['request']>['body']>, null>, undefined, null>,
   ArrayBuffer,
   Blob
@@ -61,7 +61,7 @@ export type HttpRequestBodySchema<MethodSchema extends HttpServiceMethodSchema> 
  * A strict representation of an intercepted HTTP request. The body, search params and path params are already parsed by
  * default.
  */
-export interface HttpInterceptorRequest<Path extends string, MethodSchema extends HttpServiceMethodSchema>
+export interface HttpInterceptorRequest<Path extends string, MethodSchema extends HttpMethodSchema>
   extends Omit<HttpRequest, keyof Body | 'headers'> {
   /** The headers of the request. */
   headers: HttpHeaders<HttpRequestHeadersSchema<MethodSchema>>;
@@ -76,13 +76,13 @@ export interface HttpInterceptorRequest<Path extends string, MethodSchema extend
 }
 
 export type HttpResponseHeadersSchema<
-  MethodSchema extends HttpServiceMethodSchema,
-  StatusCode extends HttpServiceResponseSchemaStatusCode<Default<MethodSchema['response']>>,
+  MethodSchema extends HttpMethodSchema,
+  StatusCode extends HttpResponseSchemaStatusCode<Default<MethodSchema['response']>>,
 > = IfNever<Default<DefaultNoExclude<Default<Default<MethodSchema['response']>[StatusCode]>['headers']>>, {}>;
 
 export type HttpResponseBodySchema<
-  MethodSchema extends HttpServiceMethodSchema,
-  StatusCode extends HttpServiceResponseSchemaStatusCode<Default<MethodSchema['response']>>,
+  MethodSchema extends HttpMethodSchema,
+  StatusCode extends HttpResponseSchemaStatusCode<Default<MethodSchema['response']>>,
 > = ReplaceBy<
   ReplaceBy<
     IfNever<DefaultNoExclude<Default<Default<MethodSchema['response']>[StatusCode]>['body']>, null>,
@@ -98,8 +98,8 @@ export type HttpResponseBodySchema<
  * by default.
  */
 export interface HttpInterceptorResponse<
-  MethodSchema extends HttpServiceMethodSchema,
-  StatusCode extends HttpServiceResponseSchemaStatusCode<Default<MethodSchema['response']>>,
+  MethodSchema extends HttpMethodSchema,
+  StatusCode extends HttpResponseSchemaStatusCode<Default<MethodSchema['response']>>,
 > extends Omit<HttpResponse, keyof Body | 'headers'> {
   /** The headers of the response. */
   headers: HttpHeaders<HttpResponseHeadersSchema<MethodSchema, StatusCode>>;
@@ -128,8 +128,8 @@ export const HTTP_INTERCEPTOR_RESPONSE_HIDDEN_BODY_PROPERTIES = Object.freeze(
  */
 export interface TrackedHttpInterceptorRequest<
   Path extends string,
-  MethodSchema extends HttpServiceMethodSchema,
-  StatusCode extends HttpServiceResponseSchemaStatusCode<Default<MethodSchema['response']>> = never,
+  MethodSchema extends HttpMethodSchema,
+  StatusCode extends HttpResponseSchemaStatusCode<Default<MethodSchema['response']>> = never,
 > extends HttpInterceptorRequest<Path, MethodSchema> {
   /** The response that was returned for the intercepted request. */
   response: StatusCode extends [never] ? never : HttpInterceptorResponse<MethodSchema, StatusCode>;

--- a/packages/zimic/tests/utils/interceptors.ts
+++ b/packages/zimic/tests/utils/interceptors.ts
@@ -1,6 +1,6 @@
 import { expect } from 'vitest';
 
-import { HttpMethod, HttpServiceSchema } from '@/http/types/schema';
+import { HttpMethod, HttpSchema } from '@/http/types/schema';
 import { httpInterceptor } from '@/interceptor/http';
 import HttpInterceptorStore from '@/interceptor/http/interceptor/HttpInterceptorStore';
 import LocalHttpInterceptor from '@/interceptor/http/interceptor/LocalHttpInterceptor';
@@ -52,23 +52,23 @@ export async function getNodeBaseURL(type: HttpInterceptorType, server: Intercep
   return createURL(baseURL);
 }
 
-export function createInternalHttpInterceptor<Schema extends HttpServiceSchema>(
+export function createInternalHttpInterceptor<Schema extends HttpSchema>(
   options: LocalHttpInterceptorOptions,
 ): LocalHttpInterceptor<Schema>;
-export function createInternalHttpInterceptor<Schema extends HttpServiceSchema>(
+export function createInternalHttpInterceptor<Schema extends HttpSchema>(
   options: RemoteHttpInterceptorOptions,
 ): RemoteHttpInterceptor<Schema>;
-export function createInternalHttpInterceptor<Schema extends HttpServiceSchema>(
+export function createInternalHttpInterceptor<Schema extends HttpSchema>(
   options: HttpInterceptorOptions,
 ): LocalHttpInterceptor<Schema> | RemoteHttpInterceptor<Schema>;
-export function createInternalHttpInterceptor<Schema extends HttpServiceSchema>(options: HttpInterceptorOptions) {
+export function createInternalHttpInterceptor<Schema extends HttpSchema>(options: HttpInterceptorOptions) {
   return httpInterceptor.create<Schema>({
     saveRequests: true,
     ...options,
   }) satisfies HttpInterceptor<Schema> as LocalHttpInterceptor<Schema> | RemoteHttpInterceptor<Schema>;
 }
 
-type UsingInterceptorCallback<Schema extends HttpServiceSchema> = (
+type UsingInterceptorCallback<Schema extends HttpSchema> = (
   interceptor: LocalHttpInterceptor<Schema> | RemoteHttpInterceptor<Schema>,
 ) => PossiblePromise<void>;
 
@@ -76,16 +76,16 @@ interface UsingInterceptorOptions {
   start?: boolean;
 }
 
-export async function usingHttpInterceptor<Schema extends HttpServiceSchema>(
+export async function usingHttpInterceptor<Schema extends HttpSchema>(
   interceptorOptions: HttpInterceptorOptions,
   callback: UsingInterceptorCallback<Schema>,
 ): Promise<void>;
-export async function usingHttpInterceptor<Schema extends HttpServiceSchema>(
+export async function usingHttpInterceptor<Schema extends HttpSchema>(
   interceptorOptions: HttpInterceptorOptions,
   options: UsingInterceptorOptions,
   callback: UsingInterceptorCallback<Schema>,
 ): Promise<void>;
-export async function usingHttpInterceptor<Schema extends HttpServiceSchema>(
+export async function usingHttpInterceptor<Schema extends HttpSchema>(
   interceptorOptions: HttpInterceptorOptions,
   callbackOrOptions: UsingInterceptorCallback<Schema> | UsingInterceptorOptions,
   optionalCallback?: UsingInterceptorCallback<Schema>,


### PR DESCRIPTION
### Refactoring

- [#zimic] Simplified the names of the types related to HTTP schemas. The prefix `HttpService` is redundant and not necessary. The current versions of the changed types are now marked deprecated and will be removed on v0.10.0:

| Current (now deprecated)                    | Renamed to                              |
| --------------------------------------- | -------------------------------- |
| `HttpServiceSchema`                     | `HttpSchema`                     |
| `HttpServiceMethodsSchema`              | `HttpMethodsSchema`              |
| `HttpServiceMethodsSchema`              | `HttpMethodsSchema`              |
| `HttpServiceMethodSchema`               | `HttpMethodSchema`               |
| `HttpServiceRequestSchema`              | `HttpRequestSchema`              |
| `HttpServiceResponseSchemaByStatusCode` | `HttpResponseSchemaByStatusCode` |
| `HttpServiceResponseSchema`             | `HttpResponseSchema`             |
| `HttpServiceResponseSchemaStatusCode`   | `HttpResponseSchemaStatusCode`   |
| `HttpServiceSchemaMethod`               | `HttpSchemaMethod`               |
| `HttpServiceSchemaPath`                 | `HttpSchemaPath`                 |
| `LiteralHttpServiceSchemaPath`          | `HttpSchemaPath.Literal`         |
| `NonLiteralHttpServiceSchemaPath`       | `HttpSchemaPath.NonLiteral`      |