### PR TITLE
docs(wiki): typegen tips

### DIFF
--- a/docs/wiki/api‐zimic‐interceptor‐http.md
+++ b/docs/wiki/api‐zimic‐interceptor‐http.md
@@ -50,6 +50,11 @@ Each interceptor represents a service and can be used to mock its paths and meth
 Creates an HTTP interceptor, the main interface to intercept HTTP requests and return responses. Learn more about
 [declaring interceptor schemas](api‐zimic‐interceptor‐http‐schemas).
 
+> [!TIP]
+>
+> If you are using TypeScript and have an [OpenAPI 3](https://swagger.io/specification) specification, you can use
+> [`zimic typegen`](cli‐zimic‐typegen) to automatically generate types for your interceptor schema!
+
 #### Creating a local HTTP interceptor
 
 A local interceptor is configured with `type: 'local'`. The `baseURL` represents the URL should be matched by this

--- a/docs/wiki/api‐zimic‐interceptor‐http‐schemas.md
+++ b/docs/wiki/api‐zimic‐interceptor‐http‐schemas.md
@@ -12,6 +12,11 @@
 HTTP interceptor schemas define the structure of the real services being mocked. This includes paths, methods, request
 and response bodies, and status codes. Interceptors use this schema to type your mocks.
 
+> [!TIP]
+>
+> If you are using TypeScript and have an [OpenAPI 3](https://swagger.io/specification) specification, you can use
+> [`zimic typegen`](cli‐zimic‐typegen) to automatically generate types for your interceptor schema!
+
 <details open>
   <summary>An example of a complete HTTP interceptor schema:</summary>
 

--- a/docs/wiki/getting‐started.md
+++ b/docs/wiki/getting‐started.md
@@ -202,8 +202,7 @@ use remote interceptors.
    service supporting `GET` requests to `/users`. A successful response contains an array of `User` objects. Learn more
    about declaring [HTTP service schemas](api‐zimic‐interceptor‐http‐schemas).
 
-   You can also use [`zimic typegen`](cli‐zimic‐typegen) to automatically generate these types from an
-   [OpenAPI 3](https://swagger.io/specification) schema.
+   You can also use [`zimic typegen`](cli‐zimic‐typegen) to automatically generate types for your interceptor schema.
 
 2. Then, start the interceptor:
 


### PR DESCRIPTION
### Documentation
- [wiki] Improved and added more tips about `zimic typegen`.