### PR TITLE
docs(#zimic): add examples to http resource jsdoc (#356)

### DIFF
--- a/docs/wiki/api‐zimic‐http.md
+++ b/docs/wiki/api‐zimic‐http.md
@@ -15,11 +15,14 @@
 - [`HttpFormData`](#httpformdata)
   - [Comparing `HttpFormData`](#comparing-httpformdata)
 - [Utility types](#utility-types)
+  - [`HttpSchemaPath`](#httpschemapath)
+    - [`HttpSchemaPath.Literal`](#httpschemapathliteral)
+    - [`HttpSchemaPath.NonLiteral`](#httpschemapathnonliteral)
+  - [`HttpServiceSchemaPath`](#httpserviceschemapath)
   - [`LiteralHttpServiceSchemaPath`](#literalhttpserviceschemapath)
   - [`NonLiteralHttpServiceSchemaPath`](#nonliteralhttpserviceschemapath)
-  - [`HttpServiceSchemaPath`](#httpserviceschemapath)
-  - [`PathParamsSchemaFromPath`](#pathparamsschemafrompath)
   - [`InferPathParams`](#inferpathparams)
+  - [`PathParamsSchemaFromPath`](#pathparamsschemafrompath)
   - [`MergeHttpResponsesByStatusCode`](#mergehttpresponsesbystatuscode)
 
 ---

--- a/packages/zimic/src/http/formData/HttpFormData.ts
+++ b/packages/zimic/src/http/formData/HttpFormData.ts
@@ -7,6 +7,23 @@ import { HttpFormDataSchema } from './types';
  * An extended HTTP form data object with a strictly-typed schema. Fully compatible with the built-in
  * {@link https://developer.mozilla.org/docs/Web/API/FormData `FormData`} class.
  *
+ * @example
+ *   import { HttpFormData } from 'zimic/http';
+ *
+ *   const formData = new HttpFormData<{
+ *     files: File[];
+ *     description?: string;
+ *   }>();
+ *
+ *   formData.append('file', new File(['content'], 'file.txt', { type: 'text/plain' }));
+ *   formData.append('description', 'My file');
+ *
+ *   const files = formData.getAll('file');
+ *   console.log(files); // [File { name: 'file.txt', type: 'text/plain' }]
+ *
+ *   const description = formData.get('description');
+ *   console.log(description); // 'My file'
+ *
  * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐http#httpformdata `HttpFormData` API reference}
  */
 class HttpFormData<Schema extends HttpFormDataSchema = HttpFormDataSchema> extends FormData {
@@ -57,7 +74,7 @@ class HttpFormData<Schema extends HttpFormDataSchema = HttpFormDataSchema> exten
   /**
    * Get the value of the entry associated to a key name.
    *
-   * If the key might have multiple values, use {@link HttpFormData.getAll} instead.
+   * If the key might have multiple values, use {@link HttpFormData#getAll} instead.
    *
    * @param name The name of the key to get the value of.
    * @returns The value associated with the key name, or `null` if the key does not exist.
@@ -72,7 +89,7 @@ class HttpFormData<Schema extends HttpFormDataSchema = HttpFormDataSchema> exten
   /**
    * Get all the values of the entry associated with a key name.
    *
-   * If the key has at most a single value, use {@link HttpFormData.get} instead.
+   * If the key has at most a single value, use {@link HttpFormData#get} instead.
    *
    * @param name The name of the key to get the values of.
    * @returns An array of values associated with the key name, or an empty array if the key does not exist.
@@ -179,7 +196,7 @@ class HttpFormData<Schema extends HttpFormDataSchema = HttpFormDataSchema> exten
   }
 
   /**
-   * Checks if the data contains the other data. This method is less strict than {@link HttpFormData.equals} and only
+   * Checks if the data contains the other data. This method is less strict than {@link HttpFormData#equals} and only
    * requires that all keys and values in the other data are present in this data.
    *
    * @param otherData The other data to compare.

--- a/packages/zimic/src/http/headers/HttpHeaders.ts
+++ b/packages/zimic/src/http/headers/HttpHeaders.ts
@@ -15,6 +15,20 @@ function pickPrimitiveProperties<Schema extends HttpHeadersSchema>(schema: Schem
  * An extended HTTP headers object with a strictly-typed schema. Fully compatible with the built-in
  * {@link https://developer.mozilla.org/docs/Web/API/Headers `Headers`} class.
  *
+ * @example
+ *   import { HttpHeaders } from 'zimic/http';
+ *
+ *   const headers = new HttpHeaders<{
+ *     accept?: string;
+ *     'content-type'?: string;
+ *   }>({
+ *     accept: '*',
+ *     'content-type': 'application/json',
+ *   });
+ *
+ *   const contentType = headers.get('content-type');
+ *   console.log(contentType); // 'application/json'
+ *
  * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐http#httpheaders `HttpHeaders` API reference}
  */
 class HttpHeaders<Schema extends HttpHeadersSchema = HttpHeadersSchema> extends Headers {
@@ -134,7 +148,7 @@ class HttpHeaders<Schema extends HttpHeadersSchema = HttpHeadersSchema> extends 
 
   /**
    * Checks if this headers object contains another set of headers. This method is less strict than
-   * {@link HttpHeaders.equals} and only requires that all keys and values in the other headers are present in these
+   * {@link HttpHeaders#equals} and only requires that all keys and values in the other headers are present in these
    * headers.
    *
    * @param otherHeaders The other headers object to compare against.

--- a/packages/zimic/src/http/headers/types.ts
+++ b/packages/zimic/src/http/headers/types.ts
@@ -46,7 +46,7 @@ export type HttpHeadersSchemaName<Schema extends HttpHeadersSchema> = IfNever<Sc
  *     'content-type': string;
  *     'x-remaining-tries': number;
  *     'x-full'?: boolean;
- *     'x-date'?: Date;
+ *     'x-date': Date;
  *     method(): void;
  *   }>;
  *   // {

--- a/packages/zimic/src/http/searchParams/HttpSearchParams.ts
+++ b/packages/zimic/src/http/searchParams/HttpSearchParams.ts
@@ -19,6 +19,23 @@ function pickPrimitiveProperties<Schema extends HttpSearchParamsSchema>(schema: 
  * An extended HTTP search params object with a strictly-typed schema. Fully compatible with the built-in
  * {@link https://developer.mozilla.org/docs/Web/API/URLSearchParams `URLSearchParams`} class.
  *
+ * @example
+ *   import { HttpSearchParams } from 'zimic/http';
+ *
+ *   const searchParams = new HttpSearchParams<{
+ *     names?: string[];
+ *     page?: `${number}`;
+ *   }>({
+ *     names: ['user 1', 'user 2'],
+ *     page: '1',
+ *   });
+ *
+ *   const names = searchParams.getAll('names');
+ *   console.log(names); // ['user 1', 'user 2']
+ *
+ *   const page = searchParams.get('page');
+ *   console.log(page); // '1'
+ *
  * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐http#httpsearchparams `HttpSearchParams` API reference}
  */
 class HttpSearchParams<Schema extends HttpSearchParamsSchema = HttpSearchParamsSchema> extends URLSearchParams {
@@ -60,7 +77,7 @@ class HttpSearchParams<Schema extends HttpSearchParamsSchema = HttpSearchParamsS
   /**
    * Get the value of the entry associated to a key name.
    *
-   * If the key might have multiple values, use {@link HttpSearchParams.getAll} instead.
+   * If the key might have multiple values, use {@link HttpSearchParams#getAll} instead.
    *
    * @param name The name of the key to get the value of.
    * @returns The value associated with the key name, or `null` if the key does not exist.
@@ -75,7 +92,7 @@ class HttpSearchParams<Schema extends HttpSearchParamsSchema = HttpSearchParamsS
   /**
    * Get all the values of the entry associated with a key name.
    *
-   * If the key has at most one value, use {@link HttpSearchParams.get} instead.
+   * If the key has at most one value, use {@link HttpSearchParams#get} instead.
    *
    * @param name The name of the key to get the values of.
    * @returns An array of values associated with the key name, or an empty array if the key does not exist.
@@ -166,7 +183,7 @@ class HttpSearchParams<Schema extends HttpSearchParamsSchema = HttpSearchParamsS
 
   /**
    * Checks if the current search parameters contain another set of search parameters. This method is less strict than
-   * {@link HttpSearchParams.equals} and only requires that all keys and values in the other search parameters are
+   * {@link HttpSearchParams#equals} and only requires that all keys and values in the other search parameters are
    * present in these search parameters.
    *
    * @param otherParams The other search parameters to check for containment.

--- a/packages/zimic/src/http/searchParams/types.ts
+++ b/packages/zimic/src/http/searchParams/types.ts
@@ -93,7 +93,7 @@ type PrimitiveHttpSearchParamsSerialized<Type> = Type extends HttpSearchParamsSc
  *     query: string | null;
  *     page?: number;
  *     full?: boolean;
- *     date?: Date;
+ *     date: Date;
  *     method(): void;
  *   }>;
  *   // {


### PR DESCRIPTION
Closes #356.