### PR TITLE
test(zimic-test-client): add google maps openapi to typegen e2e

### DIFF
--- a/apps/zimic-test-client/tests/v0/typegen/typegen.node.test.ts
+++ b/apps/zimic-test-client/tests/v0/typegen/typegen.node.test.ts
@@ -75,9 +75,15 @@ describe('Typegen', { timeout: 45 * 1000 }, () => {
       },
       {
         input:
+          'https://raw.githubusercontent.com/googlemaps/openapi-specification/main/dist/google-maps-platform-openapi3.json',
+        serviceName: 'GoogleMaps',
+        outputFileName: 'google-maps-3.0.openapi.ts',
+      },
+      {
+        input:
           'https://docs-be.here.com/bundle/geocoding-and-search-api-v7-api-reference/page/open-search-v7-external-spec.json',
-        serviceName: 'Here',
-        outputFileName: 'here-geocoding-search-v7-3.0.openapi.ts',
+        serviceName: 'HereSearch',
+        outputFileName: 'here-geocoding-search-3.0.openapi.ts',
       },
     ])(
       'should correctly generate types from $serviceName OpenAPI schema to $outputFileName',

--- a/apps/zimic-test-client/vitest.config.mts
+++ b/apps/zimic-test-client/vitest.config.mts
@@ -1,15 +1,20 @@
 /// <reference types="vitest" />
 
+import os from 'os';
 import path from 'path';
 import { defineConfig } from 'vitest/config';
+
+const numberOfCPUs = os.cpus().length;
+const maxWorkers = process.env.CI === 'true' ? numberOfCPUs : Math.ceil(numberOfCPUs / 2);
 
 export default defineConfig({
   publicDir: './public',
   test: {
     globals: false,
     testTimeout: 5000,
-    maxWorkers: process.env.CI === 'true' ? '100%' : '50%',
     minWorkers: 1,
+    maxWorkers,
+    maxConcurrency: maxWorkers,
     coverage: {
       provider: 'istanbul',
       reporter: ['text', 'html'],


### PR DESCRIPTION
### Testing
- [zimic-test-client] Added a new typegen end-to-end test case: [Google Maps OpenAPI schema](https://github.com/googlemaps/openapi-specification/tree/main/dist).
- [zimic-test-client] Improved the max concurrency settings in `vitest.config.mts`.
