### PR TITLE
docs(wiki): add missing `async` to code snippet (#407)

### DIFF
--- a/docs/wiki/api‐zimic‐interceptor‐http.md
+++ b/docs/wiki/api‐zimic‐interceptor‐http.md
@@ -195,7 +195,7 @@ import { httpInterceptor } from 'zimic/interceptor/http';
 httpInterceptor.default.onUnhandledRequest({ log: false });
 
 // Example 2: Ignore only unhandled requests to /assets
-httpInterceptor.default.onUnhandledRequest((request, context) => {
+httpInterceptor.default.onUnhandledRequest(async (request, context) => {
   const url = new URL(request.url);
 
   if (!url.pathname.startsWith('/assets')) {


### PR DESCRIPTION
Closes #407.