### PR TITLE
chore(#zimic): disable msw updates in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,11 @@ updates:
       - dependency-name: eslint
         update-types:
           - version-update:semver-major
+      - dependency-name: msw
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor
+          - version-update:semver-patch
 
   - package-ecosystem: github-actions
     directories:


### PR DESCRIPTION
Considering that msw@2.4.4 and above is currently breaking our tests, we're going to fix msw@2.4.3 until https://github.com/mswjs/msw/issues/2297 is resolved.