### PR TITLE
fix(#zimic): use specific `bufferutil` version

### DIFF
--- a/packages/zimic/package.json
+++ b/packages/zimic/package.json
@@ -129,7 +129,7 @@
     "vitest": "2.1.2"
   },
   "optionalDependencies": {
-    "bufferutil": "^4.0.8"
+    "bufferutil": "4.0.8"
   },
   "peerDependencies": {
     "typescript": ">=4.8.0"

--- a/packages/zimic/package.json
+++ b/packages/zimic/package.json
@@ -108,14 +108,17 @@
     "ws": "8.18.0",
     "yargs": "17.7.2"
   },
+  "optionalDependencies": {
+    "bufferutil": "4.0.8"
+  },
   "devDependencies": {
     "@types/cross-spawn": "^6.0.6",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^22.7.5",
     "@types/ws": "^8.5.12",
     "@types/yargs": "^17.0.33",
-    "@vitest/browser": "2.1.2",
-    "@vitest/coverage-istanbul": "2.1.2",
+    "@vitest/browser": "^2.1.2",
+    "@vitest/coverage-istanbul": "^2.1.2",
     "@zimic/eslint-config-node": "workspace:*",
     "@zimic/lint-staged-config": "workspace:*",
     "@zimic/tsconfig": "workspace:*",
@@ -126,10 +129,7 @@
     "tsup": "^8.3.0",
     "tsx": "^4.19.1",
     "typescript": "^5.6.3",
-    "vitest": "2.1.2"
-  },
-  "optionalDependencies": {
-    "bufferutil": "4.0.8"
+    "vitest": "^2.1.2"
   },
   "peerDependencies": {
     "typescript": ">=4.8.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -570,7 +570,7 @@ importers:
         version: 17.7.2
     optionalDependencies:
       bufferutil:
-        specifier: ^4.0.8
+        specifier: 4.0.8
         version: 4.0.8
     devDependencies:
       '@types/cross-spawn':
@@ -589,10 +589,10 @@ importers:
         specifier: ^17.0.33
         version: 17.0.33
       '@vitest/browser':
-        specifier: 2.1.2
+        specifier: ^2.1.2
         version: 2.1.2(@vitest/spy@2.1.2)(bufferutil@4.0.8)(playwright@1.48.0)(typescript@5.6.3)(vite@5.3.4(@types/node@22.7.5))(vitest@2.1.2)
       '@vitest/coverage-istanbul':
-        specifier: 2.1.2
+        specifier: ^2.1.2
         version: 2.1.2(vitest@2.1.2(@types/node@22.7.5)(@vitest/browser@2.1.2)(jsdom@20.0.3(bufferutil@4.0.8))(msw@2.4.3(typescript@5.6.3)))
       '@zimic/eslint-config-node':
         specifier: workspace:*
@@ -625,7 +625,7 @@ importers:
         specifier: ^5.6.3
         version: 5.6.3
       vitest:
-        specifier: 2.1.2
+        specifier: ^2.1.2
         version: 2.1.2(@types/node@22.7.5)(@vitest/browser@2.1.2)(jsdom@20.0.3(bufferutil@4.0.8))(msw@2.4.3(typescript@5.6.3))
 
 packages:


### PR DESCRIPTION
It's important to use specific versions (without the prefix `^`) in production dependencies so that users install the versions we use when testing.