### PR TITLE
chore(root): improve dependabot config

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -22,15 +22,15 @@
         "#lint-staged",
         "#tsconfig",
         "examples",
-        "examples-vitest-node",
-        "examples-vitest-browser",
-        "examples-vitest-jsdom",
-        "examples-jest-node",
-        "examples-jest-jsdom",
-        "examples-playwright",
-        "examples-next-js-app",
-        "examples-next-js-pages",
-        "examples-openapi-typegen"
+        "example-vitest-node",
+        "example-vitest-browser",
+        "example-vitest-jsdom",
+        "example-jest-node",
+        "example-jest-jsdom",
+        "example-playwright",
+        "example-next-js-app",
+        "example-next-js-pages",
+        "example-openapi-typegen"
       ]
     ],
     "scope-empty": [2, "never"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
       day: sunday
       time: '00:00'
       timezone: America/Sao_Paulo
+    labels:
+      - dependencies
     commit-message:
       prefix: chore
     target-branch: canary
@@ -45,6 +47,8 @@ updates:
       day: sunday
       time: '00:00'
       timezone: America/Sao_Paulo
+    labels:
+      - dependencies
     commit-message:
       prefix: chore
     target-branch: canary

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
     labels:
       - dependencies
     commit-message:
-      prefix: chore
+      prefix: chore(root)
     target-branch: canary
     groups:
       npm:
@@ -48,7 +48,7 @@ updates:
     labels:
       - dependencies
     commit-message:
-      prefix: chore
+      prefix: chore(root)
     target-branch: canary
     groups:
       github-actions:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,8 +13,6 @@ updates:
     commit-message:
       prefix: chore
     target-branch: canary
-    reviewers:
-      - diego-aquino
     groups:
       npm:
         patterns:
@@ -52,8 +50,6 @@ updates:
     commit-message:
       prefix: chore
     target-branch: canary
-    reviewers:
-      - diego-aquino
     groups:
       github-actions:
         patterns:

--- a/examples/with-openapi-typegen/src/types/github/typegen/generated.ts
+++ b/examples/with-openapi-typegen/src/types/github/typegen/generated.ts
@@ -33,6 +33,7 @@ export interface GitHubComponents {
       type: string;
       site_admin: boolean;
       starred_at?: string;
+      user_view_type?: string;
     };
     'basic-error': {
       message?: string;
@@ -62,6 +63,7 @@ export interface GitHubComponents {
       type: string;
       site_admin: boolean;
       starred_at?: string;
+      user_view_type?: string;
     } | null;
     'nullable-license-simple': {
       key: string;


### PR DESCRIPTION
### Chore
- [root] Configured dependabot to use the label `dependencies` in pull requests.
- [root] Removed custom review requests from dependabot. We can automatically request review based on the [CODEOWNERS](https://github.com/zimicjs/zimic/blob/canary/.github/CODEOWNERS) file.
- [root] Configured dependabot to use the prefix `chore(root)` in pull requests.
- [root] Simplified the commit scopes related to examples.