### PR TITLE
fix(#zimic): import `openapi-typescript` dynamically (#459)

### DIFF
--- a/apps/zimic-test-client/tests/utils/crypto.ts
+++ b/apps/zimic-test-client/tests/utils/crypto.ts
@@ -1,15 +1,10 @@
+import { createCachedDynamicImport } from './imports';
+
 export type IsomorphicCrypto = Crypto | typeof import('crypto');
 
-let cryptoSingleton: IsomorphicCrypto | undefined;
-
-export async function importCrypto(): Promise<IsomorphicCrypto> {
-  if (cryptoSingleton) {
-    return cryptoSingleton;
-  }
-
+export const importCrypto = createCachedDynamicImport<IsomorphicCrypto>(async () => {
   const globalCrypto = globalThis.crypto as typeof globalThis.crypto | undefined;
   /* istanbul ignore next -- @preserve
    * Ignoring as Node.js >=20 provides a global crypto and the import fallback won't run. */
-  cryptoSingleton = globalCrypto ?? (await import('crypto'));
-  return cryptoSingleton;
-}
+  return globalCrypto ?? (await import('crypto'));
+});

--- a/apps/zimic-test-client/tests/utils/imports.ts
+++ b/apps/zimic-test-client/tests/utils/imports.ts
@@ -1,0 +1,12 @@
+export function createCachedDynamicImport<ImportType>(
+  importModuleDynamically: () => Promise<ImportType>,
+): () => Promise<ImportType> {
+  let cachedImportResult: ImportType | undefined;
+
+  return async function importModuleDynamicallyWithCache() {
+    if (cachedImportResult === undefined) {
+      cachedImportResult = await importModuleDynamically();
+    }
+    return cachedImportResult;
+  };
+}

--- a/packages/zimic/src/typegen/openapi/generate.ts
+++ b/packages/zimic/src/typegen/openapi/generate.ts
@@ -151,7 +151,7 @@ async function generateTypesFromOpenAPI({
   const importDeclarations = createImportDeclarations(context);
   nodes.unshift(...importDeclarations);
 
-  const typeOutput = convertTypesToString(nodes, { includeComments });
+  const typeOutput = await convertTypesToString(nodes, { includeComments });
   const formattedOutput = prepareTypeOutputToSave(typeOutput);
 
   const shouldWriteToStdout = outputFilePath === undefined;

--- a/packages/zimic/src/utils/console.ts
+++ b/packages/zimic/src/utils/console.ts
@@ -1,15 +1,9 @@
 import chalk from 'chalk';
 
 import { isClientSide } from './environment';
+import { createCachedDynamicImport } from './imports';
 
-let utilSingleton: typeof import('util') | undefined;
-
-async function importUtil() {
-  if (!utilSingleton) {
-    utilSingleton = await import('util');
-  }
-  return utilSingleton;
-}
+const importUtil = createCachedDynamicImport(() => import('util'));
 
 export async function formatObjectToLog(value: unknown) {
   if (isClientSide()) {

--- a/packages/zimic/src/utils/crypto.ts
+++ b/packages/zimic/src/utils/crypto.ts
@@ -1,15 +1,10 @@
+import { createCachedDynamicImport } from './imports';
+
 export type IsomorphicCrypto = Crypto | typeof import('crypto');
 
-let cryptoSingleton: IsomorphicCrypto | undefined;
-
-export async function importCrypto(): Promise<IsomorphicCrypto> {
-  if (cryptoSingleton) {
-    return cryptoSingleton;
-  }
-
+export const importCrypto = createCachedDynamicImport<IsomorphicCrypto>(async () => {
   const globalCrypto = globalThis.crypto as typeof globalThis.crypto | undefined;
   /* istanbul ignore next -- @preserve
    * Ignoring as Node.js >=20 provides a global crypto and the import fallback won't run. */
-  cryptoSingleton = globalCrypto ?? (await import('crypto'));
-  return cryptoSingleton;
-}
+  return globalCrypto ?? (await import('crypto'));
+});

--- a/packages/zimic/src/utils/files.ts
+++ b/packages/zimic/src/utils/files.ts
@@ -1,16 +1,11 @@
 import { blobEquals } from './data';
+import { createCachedDynamicImport } from './imports';
 
-let bufferSingleton: typeof import('buffer') | undefined;
-
-/* istanbul ignore next -- @preserve
- * Ignoring as Node.js >=20 provides a global file and the buffer import won't run. */
-export async function importBuffer() {
-  if (bufferSingleton) {
-    return bufferSingleton;
-  }
-  bufferSingleton = await import('buffer');
-  return bufferSingleton;
-}
+export const importBuffer = createCachedDynamicImport(
+  /* istanbul ignore next -- @preserve
+   * Ignoring as Node.js >=20 provides a global file and the buffer import won't run. */
+  () => import('buffer'),
+);
 
 let FileSingleton: typeof File | undefined;
 

--- a/packages/zimic/src/utils/imports.ts
+++ b/packages/zimic/src/utils/imports.ts
@@ -1,0 +1,12 @@
+export function createCachedDynamicImport<ImportType>(
+  importModuleDynamically: () => Promise<ImportType>,
+): () => Promise<ImportType> {
+  let cachedImportResult: ImportType | undefined;
+
+  return async function importModuleDynamicallyWithCache() {
+    if (cachedImportResult === undefined) {
+      cachedImportResult = await importModuleDynamically();
+    }
+    return cachedImportResult;
+  };
+}

--- a/packages/zimic/src/utils/processes.ts
+++ b/packages/zimic/src/utils/processes.ts
@@ -1,3 +1,5 @@
+import { createCachedDynamicImport } from './imports';
+
 export const PROCESS_EXIT_EVENTS = Object.freeze([
   'beforeExit',
   'uncaughtExceptionMonitor',
@@ -19,14 +21,7 @@ export const PROCESS_EXIT_CODE_BY_EXIT_EVENT: Record<string, number | undefined>
   SIGBREAK: 131,
 } satisfies Record<ProcessExitEvent, number | undefined>;
 
-let execaSingleton: typeof import('execa') | undefined;
-
-async function importExeca() {
-  if (!execaSingleton) {
-    execaSingleton = await import('execa');
-  }
-  return execaSingleton;
-}
+export const importExeca = createCachedDynamicImport(() => import('execa'));
 
 interface CommandErrorOptions {
   command?: string[];

--- a/packages/zimic/tests/setup/global/browser.ts
+++ b/packages/zimic/tests/setup/global/browser.ts
@@ -6,7 +6,7 @@ export const GLOBAL_SETUP_SERVER_HOSTNAME = 'localhost';
 export const GLOBAL_SETUP_SERVER_PORT = 3001;
 
 export async function setup() {
-  const Server = (await import('@/interceptor/server/InterceptorServer')).default;
+  const { default: Server } = await import('@/interceptor/server/InterceptorServer');
 
   server = new Server({
     hostname: GLOBAL_SETUP_SERVER_HOSTNAME,


### PR DESCRIPTION
### Fixes
- [#zimic] Changed the `openapi-typescript` import to be dynamic, reducing the [`punycode` deprecated warning](https://github.com/zimicjs/zimic/issues/459) to `zimic typegen openapi` commands.

### Refactoring
- [#zimic, zimic-test-client] Abstracted dynamic import singletons to a utility `createDynamicImportSingleton`.

Part of #459.