### PR TITLE
style(#eslint, #zimic): prefer single quotes

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -34,6 +34,7 @@ module.exports = {
     'no-array-constructor': 'off',
     'array-callback-return': 'warn',
     eqeqeq: 'warn',
+    quotes: ['warn', 'single', { avoidEscape: true, allowTemplateLiterals: false }],
     'no-constructor-return': 'error',
     'no-catch-shadow': 'error',
     'no-cond-assign': 'warn',

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/restrictions.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/restrictions.ts
@@ -163,7 +163,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
         headers.set('accept', 'application/json');
         headers.set('content-language', 'pt');
 
-        promise = fetch(joinURL(baseURL, `/users`), { method, headers });
+        promise = fetch(joinURL(baseURL, '/users'), { method, headers });
         await expectFetchErrorOrPreflightResponse(promise, {
           shouldBePreflight: overridesPreflightResponse,
         });
@@ -600,7 +600,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
           new HttpSearchParams<SearchParamsSchema>(),
           undefined,
         ]) {
-          const promise = fetch(joinURL(baseURL, `/users?tag=admin`), {
+          const promise = fetch(joinURL(baseURL, '/users?tag=admin'), {
             method,
             body,
           });
@@ -679,7 +679,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
           new HttpSearchParams<SearchParamsSchema>(),
           undefined,
         ]) {
-          const promise = fetch(joinURL(baseURL, `/users?tag=admin`), {
+          const promise = fetch(joinURL(baseURL, '/users?tag=admin'), {
             method,
             body,
           });

--- a/packages/zimic/src/interceptor/http/interceptorWorker/errors/UnregisteredBrowserServiceWorkerError.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/errors/UnregisteredBrowserServiceWorkerError.ts
@@ -8,7 +8,7 @@ import { SERVICE_WORKER_FILE_NAME } from '@/cli/browser/shared/constants';
 class UnregisteredBrowserServiceWorkerError extends Error {
   constructor() {
     super(
-      `Failed to register the browser service worker: ` +
+      'Failed to register the browser service worker: ' +
         `script '${window.location.origin}/${SERVICE_WORKER_FILE_NAME}' not found.\n\n` +
         'Did you forget to run `zimic browser init <publicDirectory>`?\n\n' +
         'Learn more: https://github.com/zimicjs/zimic/wiki/getting‐started#client-side-post-install',

--- a/packages/zimic/src/interceptor/http/requestHandler/__tests__/shared/restrictions.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/__tests__/shared/restrictions.ts
@@ -435,7 +435,7 @@ export function declareRestrictionHttpRequestHandlerTests(
       new HttpSearchParams<SearchParamsSchema>({ name }),
       new HttpSearchParams<SearchParamsSchema>({ name: `Other ${name}` }),
       new HttpSearchParams<SearchParamsSchema>({ other: 'param' }),
-      new HttpSearchParams<SearchParamsSchema>({ other: `Other param` }),
+      new HttpSearchParams<SearchParamsSchema>({ other: 'Other param' }),
       new HttpSearchParams<SearchParamsSchema>({}),
     ];
 


### PR DESCRIPTION
Added the ESLint rule `quotes: ['warn', 'single', { avoidEscape: true, allowTemplateLiterals: false }],` to enforce single quotes when possible.