### PR TITLE
feat(#zimic): support rejecing local unhandled requests (#387)

### DIFF
--- a/apps/zimic-test-client/tests/setup/shared.ts
+++ b/apps/zimic-test-client/tests/setup/shared.ts
@@ -1,0 +1,14 @@
+import { beforeEach } from 'vitest';
+import { httpInterceptor } from 'zimic/interceptor/http';
+
+beforeEach(() => {
+  httpInterceptor.default.local.onUnhandledRequest = {
+    action: 'reject',
+    log: true,
+  };
+
+  httpInterceptor.default.remote.onUnhandledRequest = {
+    action: 'reject',
+    log: true,
+  };
+});

--- a/apps/zimic-test-client/tests/typegen/generated/eslint.config.mjs
+++ b/apps/zimic-test-client/tests/typegen/generated/eslint.config.mjs
@@ -6,9 +6,13 @@ import zimicConfigNode from '@zimic/eslint-config-node';
 const fileName = fileURLToPath(import.meta.url);
 const currentDirectory = path.dirname(fileName);
 
+const zimicConfigWithLanguageOptionsIndex = zimicConfigNode.findIndex((config) => config.languageOptions !== undefined);
+
 export default [
-  ...zimicConfigNode,
+  ...zimicConfigNode.slice(0, zimicConfigWithLanguageOptionsIndex),
   {
+    ...zimicConfigNode[zimicConfigWithLanguageOptionsIndex],
+    files: ['*.ts'],
     languageOptions: {
       parserOptions: {
         ecmaFeatures: { ts: true },
@@ -16,6 +20,7 @@ export default [
       },
     },
   },
+  ...zimicConfigNode.slice(zimicConfigWithLanguageOptionsIndex + 1),
   {
     rules: {
       '@typescript-eslint/no-explicit-any': 'off',

--- a/apps/zimic-test-client/tests/typegen/generated/tsconfig.json
+++ b/apps/zimic-test-client/tests/typegen/generated/tsconfig.json
@@ -1,8 +1,8 @@
 {
-  "extends": "../../../tsconfig.json",
+  "extends": "@zimic/tsconfig/tsconfig.node.json",
   "compilerOptions": {
+    "target": "es6",
     "tsBuildInfoFile": "tsconfig.tsbuildinfo"
   },
-  "include": ["**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": ["*.ts"]
 }

--- a/apps/zimic-test-client/tests/typegen/typegen.node.test.ts
+++ b/apps/zimic-test-client/tests/typegen/typegen.node.test.ts
@@ -87,7 +87,7 @@ describe('Typegen', { timeout: 45 * 1000 }, () => {
         await $(
           'pnpm',
           ['zimic', 'typegen', 'openapi', input, '--output', generatedFilePath, '--service-name', serviceName],
-          { stdio: 'inherit' },
+          { stderr: 'inherit' },
         );
 
         if (serviceName === 'Stripe') {

--- a/apps/zimic-test-client/tests/utils/linting.ts
+++ b/apps/zimic-test-client/tests/utils/linting.ts
@@ -1,13 +1,13 @@
 import { execa as $ } from 'execa';
 
 export function checkTypes(tsconfigFilePath: string) {
-  return $('pnpm', ['--silent', 'tsc', '--noEmit', '--project', tsconfigFilePath], { stdio: 'inherit' });
+  return $('pnpm', ['tsc', '--noEmit', '--project', tsconfigFilePath], {
+    stderr: 'inherit',
+  });
 }
 
 export function lint(input: string, eslintConfigFilePath: string) {
-  return $(
-    'pnpm',
-    ['--silent', 'lint', input, '--no-ignore', '--max-warnings', '0', '--config', eslintConfigFilePath],
-    { stdio: 'inherit' },
-  );
+  return $('pnpm', ['lint', input, '--no-ignore', '--max-warnings', '0', '--config', eslintConfigFilePath], {
+    stderr: 'inherit',
+  });
 }

--- a/apps/zimic-test-client/vitest.config.mts
+++ b/apps/zimic-test-client/vitest.config.mts
@@ -15,6 +15,7 @@ export default defineConfig({
     minWorkers: 1,
     maxWorkers,
     maxConcurrency: maxWorkers,
+    setupFiles: ['./tests/setup/shared.ts'],
     coverage: {
       provider: 'istanbul',
       reporter: ['text', 'html'],

--- a/examples/with-jest-node/src/app.ts
+++ b/examples/with-jest-node/src/app.ts
@@ -44,4 +44,9 @@ app.get('/github/repositories/:owner/:name', async (request, reply) => {
   });
 });
 
+app.setErrorHandler(async (error, _request, reply) => {
+  console.error(error);
+  await reply.status(500).send({ message: 'Internal server error' });
+});
+
 export default app;

--- a/examples/with-jest-node/tests/setup.ts
+++ b/examples/with-jest-node/tests/setup.ts
@@ -5,11 +5,15 @@ import githubInterceptor from './interceptors/github';
 
 httpInterceptor.default.local.onUnhandledRequest = (request) => {
   const url = new URL(request.url);
+  const isLocalhost = url.hostname === 'localhost' || url.hostname === '127.0.0.1';
 
-  return {
-    action: 'bypass',
-    logWarning: url.hostname !== '127.0.0.1',
-  };
+  if (isLocalhost) {
+    // Ignore requests to localhost
+    return { action: 'bypass', log: false };
+  }
+
+  // Reject any other requests
+  return { action: 'reject' };
 };
 
 beforeAll(async () => {

--- a/examples/with-jest-node/tests/setup.ts
+++ b/examples/with-jest-node/tests/setup.ts
@@ -8,11 +8,9 @@ httpInterceptor.default.local.onUnhandledRequest = (request) => {
   const isLocalhost = url.hostname === 'localhost' || url.hostname === '127.0.0.1';
 
   if (isLocalhost) {
-    // Ignore requests to localhost
     return { action: 'bypass', log: false };
   }
 
-  // Reject any other requests
   return { action: 'reject' };
 };
 

--- a/examples/with-next-js-app/.env.test
+++ b/examples/with-next-js-app/.env.test
@@ -1,4 +1,4 @@
 NODE_ENV=test
 
-ZIMIC_SERVER_URL=http://localhost:3005
+ZIMIC_SERVER_URL=http://localhost:3007
 GITHUB_API_BASE_URL=$ZIMIC_SERVER_URL/github

--- a/examples/with-next-js-app/README.md
+++ b/examples/with-next-js-app/README.md
@@ -63,7 +63,7 @@ before the application is started in development. It is used by the command `dev
       pnpm run dev:mock
       ```
 
-      After started, the application will be available at [http://localhost:3004](http://localhost:3004).
+      After started, the application will be available at [http://localhost:3006](http://localhost:3006).
 
    2. In another terminal, run the tests:
 

--- a/examples/with-next-js-app/package.json
+++ b/examples/with-next-js-app/package.json
@@ -5,9 +5,9 @@
   "scripts": {
     "dev": "dotenv -c development -- pnpm dev:no-env",
     "dev:mock": "dotenv -c test -- dotenv -c development -- pnpm mock -- pnpm dev:no-env",
-    "dev:no-env": "next dev --turbo --port 3004",
+    "dev:no-env": "next dev --turbo --port 3006",
     "mock": "pnpm mock:start -- pnpm mock:load",
-    "mock:start": "zimic server start --port 3005 --ephemeral",
+    "mock:start": "zimic server start --port 3007 --ephemeral",
     "mock:load": "tsx ./tests/interceptors/scripts/load.ts",
     "test": "dotenv -c test -- dotenv -c development -- playwright test",
     "test:turbo": "dotenv -v CI=true -- pnpm run test",

--- a/examples/with-next-js-app/playwright.config.ts
+++ b/examples/with-next-js-app/playwright.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
   },
 
   use: {
-    baseURL: 'http://localhost:3004',
+    baseURL: 'http://localhost:3006',
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     actionTimeout: 10 * 1000,
@@ -35,7 +35,7 @@ export default defineConfig({
 
   webServer: {
     command: 'pnpm run dev:mock',
-    port: 3004,
+    port: 3006,
     stdout: 'pipe',
     stderr: 'pipe',
     reuseExistingServer: true,

--- a/examples/with-next-js-pages/README.md
+++ b/examples/with-next-js-pages/README.md
@@ -63,7 +63,7 @@ GitHub API and simulate a test case where the repository is found and another wh
       pnpm run dev
       ```
 
-      After started, the application will be available at [http://localhost:3006](http://localhost:3006).
+      After started, the application will be available at [http://localhost:3008](http://localhost:3008).
 
    2. In another terminal, run the tests:
 

--- a/examples/with-next-js-pages/package.json
+++ b/examples/with-next-js-pages/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": false,
   "scripts": {
-    "dev": "dotenv -c development -- next dev --turbo --port 3006",
+    "dev": "dotenv -c development -- next dev --turbo --port 3008",
     "test": "dotenv -c test -- dotenv -c development -- playwright test",
     "test:turbo": "dotenv -v CI=true -- pnpm run test",
     "types:check": "tsc --noEmit",

--- a/examples/with-next-js-pages/playwright.config.ts
+++ b/examples/with-next-js-pages/playwright.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
   },
 
   use: {
-    baseURL: 'http://localhost:3006',
+    baseURL: 'http://localhost:3008',
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     actionTimeout: 10 * 1000,
@@ -35,7 +35,7 @@ export default defineConfig({
 
   webServer: {
     command: 'pnpm run dev',
-    port: 3006,
+    port: 3008,
     stdout: 'pipe',
     stderr: 'pipe',
     reuseExistingServer: true,

--- a/examples/with-next-js-pages/tests/interceptors/utils.ts
+++ b/examples/with-next-js-pages/tests/interceptors/utils.ts
@@ -4,11 +4,15 @@ import githubInterceptor, { githubFixtures } from './github';
 
 httpInterceptor.default.local.onUnhandledRequest = (request) => {
   const url = new URL(request.url);
+  const isSameHost = url.host === window.location.host;
 
-  return {
-    action: 'bypass',
-    logWarning: url.host !== window.location.host,
-  };
+  if (isSameHost) {
+    // Ignore requests to the same host
+    return { action: 'bypass', log: false };
+  }
+
+  // Reject any other requests
+  return { action: 'reject' };
 };
 
 export async function loadInterceptors() {

--- a/examples/with-next-js-pages/tests/interceptors/utils.ts
+++ b/examples/with-next-js-pages/tests/interceptors/utils.ts
@@ -7,11 +7,9 @@ httpInterceptor.default.local.onUnhandledRequest = (request) => {
   const isSameHost = url.host === window.location.host;
 
   if (isSameHost) {
-    // Ignore requests to the same host
     return { action: 'bypass', log: false };
   }
 
-  // Reject any other requests
   return { action: 'reject' };
 };
 

--- a/examples/with-openapi-typegen/tests/setup.ts
+++ b/examples/with-openapi-typegen/tests/setup.ts
@@ -5,11 +5,15 @@ import githubInterceptor from './interceptors/github';
 
 httpInterceptor.default.local.onUnhandledRequest = (request) => {
   const url = new URL(request.url);
+  const isLocalhost = url.hostname === 'localhost' || url.hostname === '127.0.0.1';
 
-  return {
-    action: 'bypass',
-    logWarning: url.hostname !== '127.0.0.1',
-  };
+  if (isLocalhost) {
+    // Ignore requests to localhost
+    return { action: 'bypass', log: false };
+  }
+
+  // Reject any other requests
+  return { action: 'reject' };
 };
 
 beforeAll(async () => {

--- a/examples/with-openapi-typegen/tests/setup.ts
+++ b/examples/with-openapi-typegen/tests/setup.ts
@@ -8,11 +8,9 @@ httpInterceptor.default.local.onUnhandledRequest = (request) => {
   const isLocalhost = url.hostname === 'localhost' || url.hostname === '127.0.0.1';
 
   if (isLocalhost) {
-    // Ignore requests to localhost
     return { action: 'bypass', log: false };
   }
 
-  // Reject any other requests
   return { action: 'reject' };
 };
 

--- a/examples/with-playwright/.env.test
+++ b/examples/with-playwright/.env.test
@@ -1,4 +1,4 @@
 NODE_ENV=test
 
-ZIMIC_SERVER_URL=http://localhost:3003
+ZIMIC_SERVER_URL=http://localhost:3005
 GITHUB_API_BASE_URL=$ZIMIC_SERVER_URL/github

--- a/examples/with-playwright/README.md
+++ b/examples/with-playwright/README.md
@@ -78,7 +78,7 @@ before the application is started in development. It is used by the command `dev
       pnpm run dev:mock
       ```
 
-      After started, it will be available at [http://localhost:3002](http://localhost:3002).
+      After started, it will be available at [http://localhost:3004](http://localhost:3004).
 
    2. In another terminal, run the tests:
 

--- a/examples/with-playwright/package.json
+++ b/examples/with-playwright/package.json
@@ -5,9 +5,9 @@
   "scripts": {
     "dev": "dotenv -c development -- pnpm dev:no-env",
     "dev:mock": "dotenv -c test -- dotenv -c development -- pnpm mock -- pnpm dev:no-env",
-    "dev:no-env": "next dev --turbo --port 3002",
+    "dev:no-env": "next dev --turbo --port 3004",
     "mock": "pnpm mock:start -- pnpm mock:load",
-    "mock:start": "zimic server start --port 3003 --ephemeral",
+    "mock:start": "zimic server start --port 3005 --ephemeral",
     "mock:load": "tsx ./tests/interceptors/scripts/load.ts",
     "test": "dotenv -c test -- dotenv -c development -- playwright test",
     "test:turbo": "dotenv -v CI=true -- pnpm run test",

--- a/examples/with-playwright/playwright.config.ts
+++ b/examples/with-playwright/playwright.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
   },
 
   use: {
-    baseURL: 'http://localhost:3002',
+    baseURL: 'http://localhost:3004',
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     actionTimeout: 10 * 1000,
@@ -35,7 +35,7 @@ export default defineConfig({
 
   webServer: {
     command: 'pnpm run dev:mock',
-    url: 'http://localhost:3002',
+    port: 3004,
     stdout: 'pipe',
     stderr: 'pipe',
     reuseExistingServer: true,

--- a/examples/with-vitest-node/src/app.ts
+++ b/examples/with-vitest-node/src/app.ts
@@ -44,4 +44,9 @@ app.get('/github/repositories/:owner/:name', async (request, reply) => {
   });
 });
 
+app.setErrorHandler(async (error, _request, reply) => {
+  console.error(error);
+  await reply.status(500).send({ message: 'Internal server error' });
+});
+
 export default app;

--- a/examples/with-vitest-node/tests/setup.ts
+++ b/examples/with-vitest-node/tests/setup.ts
@@ -9,11 +9,9 @@ httpInterceptor.default.local.onUnhandledRequest = (request) => {
   const isLocalhost = url.hostname === 'localhost' || url.hostname === '127.0.0.1';
 
   if (isLocalhost) {
-    // Ignore requests to localhost
     return { action: 'bypass', log: false };
   }
 
-  // Reject any other requests
   return { action: 'reject' };
 };
 

--- a/examples/with-vitest-node/tests/setup.ts
+++ b/examples/with-vitest-node/tests/setup.ts
@@ -6,10 +6,15 @@ import githubInterceptor from './interceptors/github';
 httpInterceptor.default.local.onUnhandledRequest = (request) => {
   const url = new URL(request.url);
 
-  return {
-    action: 'bypass',
-    logWarning: url.hostname !== '127.0.0.1',
-  };
+  const isLocalhost = url.hostname === 'localhost' || url.hostname === '127.0.0.1';
+
+  if (isLocalhost) {
+    // Ignore requests to localhost
+    return { action: 'bypass', log: false };
+  }
+
+  // Reject any other requests
+  return { action: 'reject' };
 };
 
 beforeAll(async () => {

--- a/packages/zimic/src/cli/server/__tests__/server.node.test.ts
+++ b/packages/zimic/src/cli/server/__tests__/server.node.test.ts
@@ -708,8 +708,8 @@ describe('CLI (server)', async () => {
           webSocketServerRequestSpy.mockRejectedValueOnce(error);
 
           const request = new Request('http://localhost:5001/users', { method: 'GET' });
-          const fetchPromise = fetch(request);
-          await expectFetchError(fetchPromise);
+          const responsePromise = fetch(request);
+          await expectFetchError(responsePromise);
 
           expect(server!.isRunning()).toBe(true);
 
@@ -776,7 +776,7 @@ describe('CLI (server)', async () => {
           await interceptor.get('/users').respond(responseFactory);
 
           const onFetchError = vi.fn();
-          const fetchPromise = fetch('http://localhost:5001/users', { method: 'GET' }).catch(onFetchError);
+          const responsePromise = fetch('http://localhost:5001/users', { method: 'GET' }).catch(onFetchError);
 
           await waitFor(() => {
             expect(wasResponseFactoryCalled).toBe(true);
@@ -785,7 +785,7 @@ describe('CLI (server)', async () => {
           await interceptor.stop();
           expect(interceptor.isRunning()).toBe(false);
 
-          await fetchPromise;
+          await responsePromise;
 
           await waitFor(() => {
             expect(onFetchError).toHaveBeenCalled();

--- a/packages/zimic/src/interceptor/http/interceptor/HttpInterceptorClient.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/HttpInterceptorClient.ts
@@ -208,7 +208,7 @@ class HttpInterceptorClient<
     const matchedHandler = await this.findMatchedHandler(method, path, parsedRequest);
 
     if (!matchedHandler) {
-      return { bypass: true };
+      return { response: null };
     }
 
     const responseDeclaration = await matchedHandler.applyResponseDeclaration(parsedRequest);

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/bypass.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/bypass.ts
@@ -6,7 +6,7 @@ import LocalHttpRequestHandler from '@/interceptor/http/requestHandler/LocalHttp
 import RemoteHttpRequestHandler from '@/interceptor/http/requestHandler/RemoteHttpRequestHandler';
 import { AccessControlHeaders, DEFAULT_ACCESS_CONTROL_HEADERS } from '@/interceptor/server/constants';
 import { joinURL } from '@/utils/urls';
-import { expectFetchErrorOrPreflightResponse } from '@tests/utils/fetch';
+import { expectBypassedResponse, expectPreflightResponse, expectFetchError } from '@tests/utils/fetch';
 import { assessPreflightInterference, usingHttpInterceptor } from '@tests/utils/interceptors';
 
 import { HttpInterceptorOptions } from '../../types/options';
@@ -70,10 +70,15 @@ export function declareBypassHttpInterceptorTests(options: RuntimeSharedHttpInte
         let initialRequests = await promiseIfRemote(okHandler.requests(), interceptor);
         expect(initialRequests).toHaveLength(0);
 
-        const promise = fetch(joinURL(baseURL, '/users'), { method });
-        await expectFetchErrorOrPreflightResponse(promise, {
-          shouldBePreflight: overridesPreflightResponse,
-        });
+        const responsePromise = fetch(joinURL(baseURL, '/users'), { method });
+
+        if (overridesPreflightResponse) {
+          await expectPreflightResponse(responsePromise);
+        } else if (type === 'local') {
+          await expectBypassedResponse(responsePromise);
+        } else {
+          await expectFetchError(responsePromise);
+        }
 
         const createdHandler = await promiseIfRemote(
           okHandler.respond({

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/handlers.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/handlers.ts
@@ -141,8 +141,8 @@ export function declareHandlerHttpInterceptorTests(options: RuntimeSharedHttpInt
     it(`should log an error if a ${method} request is intercepted with a computed response and the handler throws`, async () => {
       const extendedInterceptorOptions: HttpInterceptorOptions =
         type === 'local'
-          ? { ...interceptorOptions, type, onUnhandledRequest: { action: 'bypass', logWarning: true } }
-          : { ...interceptorOptions, type, onUnhandledRequest: { action: 'reject', logWarning: true } };
+          ? { ...interceptorOptions, type, onUnhandledRequest: { action: 'bypass', log: true } }
+          : { ...interceptorOptions, type, onUnhandledRequest: { action: 'reject', log: true } };
 
       await usingHttpInterceptor<{
         '/users': {

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/handlers.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/handlers.ts
@@ -10,7 +10,7 @@ import RemoteHttpRequestHandler from '@/interceptor/http/requestHandler/RemoteHt
 import { AccessControlHeaders, DEFAULT_ACCESS_CONTROL_HEADERS } from '@/interceptor/server/constants';
 import { joinURL } from '@/utils/urls';
 import { usingIgnoredConsole } from '@tests/utils/console';
-import { expectFetchError, expectFetchErrorOrPreflightResponse } from '@tests/utils/fetch';
+import { expectBypassedResponse, expectPreflightResponse, expectFetchError } from '@tests/utils/fetch';
 import { assessPreflightInterference, usingHttpInterceptor } from '@tests/utils/interceptors';
 
 import { HttpInterceptorOptions } from '../../types/options';
@@ -174,10 +174,15 @@ export function declareHandlerHttpInterceptorTests(options: RuntimeSharedHttpInt
             headers: { 'x-value': '1' },
           });
 
-          const fetchPromise = fetch(request);
-          await expectFetchErrorOrPreflightResponse(fetchPromise, {
-            shouldBePreflight: overridesPreflightResponse,
-          });
+          const responsePromise = fetch(request);
+
+          if (overridesPreflightResponse) {
+            await expectPreflightResponse(responsePromise);
+          } else if (type === 'local') {
+            await expectBypassedResponse(responsePromise);
+          } else {
+            await expectFetchError(responsePromise);
+          }
 
           if (type === 'remote') {
             expect(spies.error).toHaveBeenCalledTimes(method === 'OPTIONS' && platform === 'browser' ? 4 : 2);
@@ -346,10 +351,15 @@ export function declareHandlerHttpInterceptorTests(options: RuntimeSharedHttpInt
           OPTIONS: MethodSchema;
         };
       }>(interceptorOptions, async (interceptor) => {
-        let fetchPromise = fetch(joinURL(baseURL, '/users'), { method });
-        await expectFetchErrorOrPreflightResponse(fetchPromise, {
-          shouldBePreflight: overridesPreflightResponse,
-        });
+        let responsePromise = fetch(joinURL(baseURL, '/users'), { method });
+
+        if (overridesPreflightResponse) {
+          await expectPreflightResponse(responsePromise);
+        } else if (type === 'local') {
+          await expectBypassedResponse(responsePromise);
+        } else {
+          await expectFetchError(responsePromise);
+        }
 
         const handlerWithoutResponse = await promiseIfRemote(interceptor[lowerMethod]('/users'), interceptor);
         expect(handlerWithoutResponse).toBeInstanceOf(Handler);
@@ -361,10 +371,15 @@ export function declareHandlerHttpInterceptorTests(options: RuntimeSharedHttpInt
         expectTypeOf<typeof _requestWithoutResponse.body>().toEqualTypeOf<null>();
         expectTypeOf<typeof _requestWithoutResponse.response>().toEqualTypeOf<never>();
 
-        fetchPromise = fetch(joinURL(baseURL, '/users'), { method });
-        await expectFetchErrorOrPreflightResponse(fetchPromise, {
-          shouldBePreflight: overridesPreflightResponse,
-        });
+        responsePromise = fetch(joinURL(baseURL, '/users'), { method });
+
+        if (overridesPreflightResponse) {
+          await expectPreflightResponse(responsePromise);
+        } else if (type === 'local') {
+          await expectBypassedResponse(responsePromise);
+        } else {
+          await expectFetchError(responsePromise);
+        }
 
         requestsWithoutResponse = await promiseIfRemote(handlerWithoutResponse.requests(), interceptor);
         expect(requestsWithoutResponse).toHaveLength(0);
@@ -505,12 +520,12 @@ export function declareHandlerHttpInterceptorTests(options: RuntimeSharedHttpInt
           const initialRequests = await promiseIfRemote(handler.requests(), interceptor);
           expect(initialRequests).toHaveLength(0);
 
-          const promise = fetch(joinURL(baseURL, '/users'), { method });
+          const responsePromise = fetch(joinURL(baseURL, '/users'), { method });
 
           if (type === 'remote' && platform === 'browser') {
-            await expectFetchError(promise);
+            await expectFetchError(responsePromise);
           } else {
-            const response = await promise;
+            const response = await responsePromise;
             expect(response.status).toBe(200);
           }
         });

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/restrictions.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/restrictions.ts
@@ -12,7 +12,7 @@ import { AccessControlHeaders, DEFAULT_ACCESS_CONTROL_HEADERS } from '@/intercep
 import { importFile } from '@/utils/files';
 import { joinURL } from '@/utils/urls';
 import { usingIgnoredConsole } from '@tests/utils/console';
-import { expectFetchError, expectFetchErrorOrPreflightResponse } from '@tests/utils/fetch';
+import { expectBypassedResponse, expectPreflightResponse, expectFetchError } from '@tests/utils/fetch';
 import { assessPreflightInterference, usingHttpInterceptor } from '@tests/utils/interceptors';
 
 import { HttpInterceptorOptions } from '../../types/options';
@@ -143,30 +143,47 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
 
         headers.delete('accept');
 
-        let promise = fetch(joinURL(baseURL, '/users'), { method, headers });
-        await expectFetchErrorOrPreflightResponse(promise, {
-          shouldBePreflight: overridesPreflightResponse,
-        });
+        let responsePromise = fetch(joinURL(baseURL, '/users'), { method, headers });
+
+        if (overridesPreflightResponse) {
+          await expectPreflightResponse(responsePromise);
+        } else if (type === 'local') {
+          await expectBypassedResponse(responsePromise);
+        } else {
+          await expectFetchError(responsePromise);
+        }
 
         requests = await promiseIfRemote(handler.requests(), interceptor);
         expect(requests).toHaveLength(2);
 
         headers.delete('content-language');
 
-        promise = fetch(joinURL(baseURL, '/users'), { method, headers });
-        await expectFetchErrorOrPreflightResponse(promise, {
-          shouldBePreflight: overridesPreflightResponse,
-        });
+        responsePromise = fetch(joinURL(baseURL, '/users'), { method, headers });
+
+        if (overridesPreflightResponse) {
+          await expectPreflightResponse(responsePromise);
+        } else if (type === 'local') {
+          await expectBypassedResponse(responsePromise);
+        } else {
+          await expectFetchError(responsePromise);
+        }
+
         requests = await promiseIfRemote(handler.requests(), interceptor);
         expect(requests).toHaveLength(2);
 
         headers.set('accept', 'application/json');
         headers.set('content-language', 'pt');
 
-        promise = fetch(joinURL(baseURL, '/users'), { method, headers });
-        await expectFetchErrorOrPreflightResponse(promise, {
-          shouldBePreflight: overridesPreflightResponse,
-        });
+        responsePromise = fetch(joinURL(baseURL, '/users'), { method, headers });
+
+        if (overridesPreflightResponse) {
+          await expectPreflightResponse(responsePromise);
+        } else if (type === 'local') {
+          await expectBypassedResponse(responsePromise);
+        } else {
+          await expectFetchError(responsePromise);
+        }
+
         requests = await promiseIfRemote(handler.requests(), interceptor);
         expect(requests).toHaveLength(2);
       });
@@ -230,12 +247,18 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
 
         searchParams.delete('tag');
 
-        const promise = fetch(joinURL(baseURL, `/users?${searchParams.toString()}`), {
+        const responsePromise = fetch(joinURL(baseURL, `/users?${searchParams.toString()}`), {
           method,
         });
-        await expectFetchErrorOrPreflightResponse(promise, {
-          shouldBePreflight: overridesPreflightResponse,
-        });
+
+        if (overridesPreflightResponse) {
+          await expectPreflightResponse(responsePromise);
+        } else if (type === 'local') {
+          await expectBypassedResponse(responsePromise);
+        } else {
+          await expectFetchError(responsePromise);
+        }
+
         requests = await promiseIfRemote(handler.requests(), interceptor);
         expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
       });
@@ -289,12 +312,17 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
         expect(requests).toHaveLength(1);
 
         for (const body of [JSON.stringify({ message: 'other' }), JSON.stringify({}), undefined]) {
-          const promise = fetch(joinURL(baseURL, '/users'), {
+          const responsePromise = fetch(joinURL(baseURL, '/users'), {
             method,
             headers: body ? { 'content-type': 'application/json' } : undefined,
             body,
           });
-          await expectFetchError(promise);
+
+          if (type === 'local') {
+            await expectBypassedResponse(responsePromise);
+          } else {
+            await expectFetchError(responsePromise);
+          }
 
           requests = await promiseIfRemote(handler.requests(), interceptor);
           expect(requests).toHaveLength(1);
@@ -356,12 +384,17 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
         expect(requests).toHaveLength(2);
 
         for (const body of [JSON.stringify({ message: 'other' }), JSON.stringify({}), undefined]) {
-          const promise = fetch(joinURL(baseURL, '/users'), {
+          const responsePromise = fetch(joinURL(baseURL, '/users'), {
             method,
             headers: body ? { 'content-type': 'application/json' } : undefined,
             body,
           });
-          await expectFetchError(promise);
+
+          if (type === 'local') {
+            await expectBypassedResponse(responsePromise);
+          } else {
+            await expectFetchError(responsePromise);
+          }
 
           requests = await promiseIfRemote(handler.requests(), interceptor);
           expect(requests).toHaveLength(2);
@@ -431,11 +464,16 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
           undefined,
         ]) {
           await usingIgnoredConsole(['error'], async (spies) => {
-            const promise = fetch(joinURL(baseURL, '/users'), {
+            const responsePromise = fetch(joinURL(baseURL, '/users'), {
               method,
               body,
             });
-            await expectFetchError(promise);
+
+            if (type === 'local') {
+              await expectBypassedResponse(responsePromise);
+            } else {
+              await expectFetchError(responsePromise);
+            }
 
             requests = await promiseIfRemote(handler.requests(), interceptor);
             expect(requests).toHaveLength(1);
@@ -525,11 +563,16 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
           undefined,
         ]) {
           await usingIgnoredConsole(['error'], async (spies) => {
-            const promise = fetch(joinURL(baseURL, '/users'), {
+            const responsePromise = fetch(joinURL(baseURL, '/users'), {
               method,
               body,
             });
-            await expectFetchError(promise);
+
+            if (type === 'local') {
+              await expectBypassedResponse(responsePromise);
+            } else {
+              await expectFetchError(responsePromise);
+            }
 
             requests = await promiseIfRemote(handler.requests(), interceptor);
             expect(requests).toHaveLength(2);
@@ -600,11 +643,16 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
           new HttpSearchParams<SearchParamsSchema>(),
           undefined,
         ]) {
-          const promise = fetch(joinURL(baseURL, '/users?tag=admin'), {
+          const responsePromise = fetch(joinURL(baseURL, '/users?tag=admin'), {
             method,
             body,
           });
-          await expectFetchError(promise);
+
+          if (type === 'local') {
+            await expectBypassedResponse(responsePromise);
+          } else {
+            await expectFetchError(responsePromise);
+          }
 
           requests = await promiseIfRemote(handler.requests(), interceptor);
           expect(requests).toHaveLength(1);
@@ -679,11 +727,16 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
           new HttpSearchParams<SearchParamsSchema>(),
           undefined,
         ]) {
-          const promise = fetch(joinURL(baseURL, '/users?tag=admin'), {
+          const responsePromise = fetch(joinURL(baseURL, '/users?tag=admin'), {
             method,
             body,
           });
-          await expectFetchError(promise);
+
+          if (type === 'local') {
+            await expectBypassedResponse(responsePromise);
+          } else {
+            await expectFetchError(responsePromise);
+          }
 
           requests = await promiseIfRemote(handler.requests(), interceptor);
           expect(requests).toHaveLength(2);
@@ -736,11 +789,16 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
         expect(requests).toHaveLength(1);
 
         for (const body of ['more-content', 'cont', '']) {
-          const promise = fetch(joinURL(baseURL, '/users'), {
+          const responsePromise = fetch(joinURL(baseURL, '/users'), {
             method,
             body,
           });
-          await expectFetchError(promise);
+
+          if (type === 'local') {
+            await expectBypassedResponse(responsePromise);
+          } else {
+            await expectFetchError(responsePromise);
+          }
 
           requests = await promiseIfRemote(handler.requests(), interceptor);
           expect(requests).toHaveLength(1);
@@ -802,11 +860,16 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
         expect(requests).toHaveLength(2);
 
         for (const body of ['cont', '']) {
-          const promise = fetch(joinURL(baseURL, '/users'), {
+          const responsePromise = fetch(joinURL(baseURL, '/users'), {
             method,
             body,
           });
-          await expectFetchError(promise);
+
+          if (type === 'local') {
+            await expectBypassedResponse(responsePromise);
+          } else {
+            await expectFetchError(responsePromise);
+          }
 
           requests = await promiseIfRemote(handler.requests(), interceptor);
           expect(requests).toHaveLength(2);
@@ -869,11 +932,16 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
           new File([], 'file.bin', { type: 'application/octet-stream' }),
           new File([], ''),
         ]) {
-          const promise = fetch(joinURL(baseURL, '/users'), {
+          const responsePromise = fetch(joinURL(baseURL, '/users'), {
             method,
             body,
           });
-          await expectFetchError(promise);
+
+          if (type === 'local') {
+            await expectBypassedResponse(responsePromise);
+          } else {
+            await expectFetchError(responsePromise);
+          }
 
           requests = await promiseIfRemote(handler.requests(), interceptor);
           expect(requests).toHaveLength(1);
@@ -945,11 +1013,16 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
           new File([], 'file.bin', { type: 'application/octet-stream' }),
           new File([], ''),
         ]) {
-          const promise = fetch(joinURL(baseURL, '/users'), {
+          const responsePromise = fetch(joinURL(baseURL, '/users'), {
             method,
             body,
           });
-          await expectFetchError(promise);
+
+          if (type === 'local') {
+            await expectBypassedResponse(responsePromise);
+          } else {
+            await expectFetchError(responsePromise);
+          }
 
           requests = await promiseIfRemote(handler.requests(), interceptor);
           expect(requests).toHaveLength(2);

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/unhandledRequests.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/unhandledRequests.ts
@@ -68,15 +68,15 @@ export function declareUnhandledRequestHttpInterceptorTests(options: RuntimeShar
       { overrideDefault: 'factory' as const },
       { overrideDefault: 'factory-undefined-log' as const },
     ])('Logging enabled: override default $overrideDefault', ({ overrideDefault }) => {
-      const logWarning = overrideDefault?.endsWith('undefined-log') ? undefined : true;
+      const log = overrideDefault?.endsWith('undefined-log') ? undefined : true;
 
       const localOnUnhandledRequest: UnhandledRequestStrategy.LocalDeclaration = {
         action: 'bypass',
-        log: logWarning,
+        log,
       };
       const remoteOnUnhandledRequest: UnhandledRequestStrategy.RemoteDeclaration = {
         action: 'reject',
-        log: logWarning,
+        log,
       };
 
       beforeEach(() => {
@@ -259,7 +259,9 @@ export function declareUnhandledRequestHttpInterceptorTests(options: RuntimeShar
       }
 
       it(`should show an error when logging is enabled and ${method} requests with no body are unhandled and rejected`, async () => {
-        localOnUnhandledRequest.action = 'reject';
+        if (overrideDefault) {
+          localOnUnhandledRequest.action = 'reject';
+        }
 
         await usingHttpInterceptor<{
           '/users': {
@@ -338,7 +340,9 @@ export function declareUnhandledRequestHttpInterceptorTests(options: RuntimeShar
 
       if (methodCanHaveRequestBody(method)) {
         it(`should show an error when logging is enabled and ${method} requests with body are unhandled and rejected`, async () => {
-          localOnUnhandledRequest.action = 'reject';
+          if (overrideDefault) {
+            localOnUnhandledRequest.action = 'reject';
+          }
 
           await usingHttpInterceptor<{
             '/users': {
@@ -525,7 +529,9 @@ export function declareUnhandledRequestHttpInterceptorTests(options: RuntimeShar
       }
 
       it(`should not show an error when logging is disabled and ${method} requests are unhandled and rejected`, async () => {
-        localOnUnhandledRequest.action = 'reject';
+        if (overrideDefault) {
+          localOnUnhandledRequest.action = 'reject';
+        }
 
         const extendedInterceptorOptions: HttpInterceptorOptions = {
           ...interceptorOptions,
@@ -938,7 +944,7 @@ export function declareUnhandledRequestHttpInterceptorTests(options: RuntimeShar
             numberOfRequestsIncludingPreflight * 2,
           );
 
-          if (type === 'local') {
+          if (defaultStrategy.action === 'bypass') {
             expect(spies.warn).toHaveBeenCalledTimes(1);
             expect(spies.error).toHaveBeenCalledTimes(numberOfRequestsIncludingPreflight);
 
@@ -1082,7 +1088,7 @@ export function declareUnhandledRequestHttpInterceptorTests(options: RuntimeShar
             numberOfRequestsIncludingPreflight * 2,
           );
 
-          if (type === 'local') {
+          if (defaultStrategy.action === 'bypass') {
             expect(spies.warn).toHaveBeenCalledTimes(1);
             expect(spies.error).toHaveBeenCalledTimes(numberOfRequestsIncludingPreflight);
 

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/unhandledRequests.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/unhandledRequests.ts
@@ -393,13 +393,9 @@ export function declareUnhandledRequestHttpInterceptorTests(options: RuntimeShar
                   body: JSON.stringify({ message: 'ok' }),
                 });
                 const requestClone = request.clone();
-                const responsePromise = fetch(request);
 
-                if (overridesPreflightResponse) {
-                  await expectPreflightResponse(responsePromise);
-                } else {
-                  await expectFetchError(responsePromise);
-                }
+                const responsePromise = fetch(request);
+                await expectFetchError(responsePromise);
 
                 requests = await promiseIfRemote(handler.requests(), interceptor);
                 expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/unhandledRequests.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/unhandledRequests.ts
@@ -74,8 +74,14 @@ export function declareUnhandledRequestHttpInterceptorTests(options: RuntimeShar
       beforeEach(() => {
         const logWarning = overrideDefault?.endsWith('undefined-log') ? undefined : true;
 
-        const localOnUnhandledRequest: UnhandledRequestStrategy.LocalDeclaration = { action: 'bypass', logWarning };
-        const remoteOnUnhandledRequest: UnhandledRequestStrategy.RemoteDeclaration = { action: 'reject', logWarning };
+        const localOnUnhandledRequest: UnhandledRequestStrategy.LocalDeclaration = {
+          action: 'bypass',
+          log: logWarning,
+        };
+        const remoteOnUnhandledRequest: UnhandledRequestStrategy.RemoteDeclaration = {
+          action: 'reject',
+          log: logWarning,
+        };
 
         if (overrideDefault?.startsWith('static')) {
           if (type === 'local') {
@@ -120,7 +126,7 @@ export function declareUnhandledRequestHttpInterceptorTests(options: RuntimeShar
             {
               ...interceptorOptions,
               type,
-              onUnhandledRequest: overrideDefault ? undefined : { action: 'bypass', logWarning: true },
+              onUnhandledRequest: overrideDefault ? undefined : { action: 'bypass', log: true },
             },
             async (interceptor) => {
               const handler = await promiseIfRemote(
@@ -190,7 +196,7 @@ export function declareUnhandledRequestHttpInterceptorTests(options: RuntimeShar
             {
               ...interceptorOptions,
               type,
-              onUnhandledRequest: overrideDefault ? undefined : { action: 'bypass', logWarning: true },
+              onUnhandledRequest: overrideDefault ? undefined : { action: 'bypass', log: true },
             },
             async (interceptor) => {
               const handler = await promiseIfRemote(
@@ -269,7 +275,7 @@ export function declareUnhandledRequestHttpInterceptorTests(options: RuntimeShar
             {
               ...interceptorOptions,
               type,
-              onUnhandledRequest: overrideDefault ? undefined : { action: 'reject', logWarning: true },
+              onUnhandledRequest: overrideDefault ? undefined : { action: 'reject', log: true },
             },
             async (interceptor) => {
               const handler = await promiseIfRemote(
@@ -341,7 +347,7 @@ export function declareUnhandledRequestHttpInterceptorTests(options: RuntimeShar
             {
               ...interceptorOptions,
               type,
-              onUnhandledRequest: overrideDefault ? undefined : { action: 'reject', logWarning: true },
+              onUnhandledRequest: overrideDefault ? undefined : { action: 'reject', log: true },
             },
             async (interceptor) => {
               const handler = await promiseIfRemote(
@@ -416,8 +422,14 @@ export function declareUnhandledRequestHttpInterceptorTests(options: RuntimeShar
       async ({ overrideDefault }) => {
         const logWarning = false;
 
-        const localOnUnhandledRequest: UnhandledRequestStrategy.LocalDeclaration = { action: 'bypass', logWarning };
-        const remoteOnUnhandledRequest: UnhandledRequestStrategy.RemoteDeclaration = { action: 'reject', logWarning };
+        const localOnUnhandledRequest: UnhandledRequestStrategy.LocalDeclaration = {
+          action: 'bypass',
+          log: logWarning,
+        };
+        const remoteOnUnhandledRequest: UnhandledRequestStrategy.RemoteDeclaration = {
+          action: 'reject',
+          log: logWarning,
+        };
 
         if (overrideDefault === 'static') {
           if (type === 'local') {
@@ -450,12 +462,12 @@ export function declareUnhandledRequestHttpInterceptorTests(options: RuntimeShar
             ? {
                 ...interceptorOptions,
                 type,
-                onUnhandledRequest: overrideDefault ? undefined : { action: 'bypass', logWarning: false },
+                onUnhandledRequest: overrideDefault ? undefined : { action: 'bypass', log: false },
               }
             : {
                 ...interceptorOptions,
                 type,
-                onUnhandledRequest: overrideDefault ? undefined : { action: 'reject', logWarning: false },
+                onUnhandledRequest: overrideDefault ? undefined : { action: 'reject', log: false },
               };
 
         await usingHttpInterceptor<{
@@ -516,7 +528,7 @@ export function declareUnhandledRequestHttpInterceptorTests(options: RuntimeShar
         (request) => {
           const url = new URL(request.url);
 
-          return { action: 'bypass', logWarning: !url.searchParams.has('name') };
+          return { action: 'bypass', log: !url.searchParams.has('name') };
         },
       );
 
@@ -524,7 +536,7 @@ export function declareUnhandledRequestHttpInterceptorTests(options: RuntimeShar
         (request) => {
           const url = new URL(request.url);
 
-          return { action: 'reject', logWarning: !url.searchParams.has('name') };
+          return { action: 'reject', log: !url.searchParams.has('name') };
         },
       );
 
@@ -632,7 +644,7 @@ export function declareUnhandledRequestHttpInterceptorTests(options: RuntimeShar
             throw error;
           }
 
-          return { action: 'bypass', logWarning: false };
+          return { action: 'bypass', log: false };
         },
       );
 
@@ -644,7 +656,7 @@ export function declareUnhandledRequestHttpInterceptorTests(options: RuntimeShar
             throw error;
           }
 
-          return { action: 'reject', logWarning: false };
+          return { action: 'reject', log: false };
         },
       );
 

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/unhandledRequests.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/unhandledRequests.ts
@@ -739,10 +739,30 @@ export function declareUnhandledRequestHttpInterceptorTests(options: RuntimeShar
           expect(extendedInterceptorOptions.onUnhandledRequest).toHaveBeenCalledTimes(
             numberOfRequestsIncludingPreflight * 2,
           );
-          expect(spies.warn).toHaveBeenCalledTimes(0);
-          expect(spies.error).toHaveBeenCalledTimes(numberOfRequestsIncludingPreflight);
 
-          expect(spies.error).toHaveBeenCalledWith(error);
+          if (type === 'local') {
+            expect(spies.warn).toHaveBeenCalledTimes(1);
+            expect(spies.error).toHaveBeenCalledTimes(numberOfRequestsIncludingPreflight);
+
+            expect(spies.error).toHaveBeenCalledWith(error);
+
+            await verifyUnhandledRequestMessage(spies.warn.mock.calls[0].join(' '), {
+              type: 'warn',
+              platform,
+              request,
+            });
+          } else {
+            expect(spies.warn).toHaveBeenCalledTimes(0);
+            expect(spies.error).toHaveBeenCalledTimes(numberOfRequestsIncludingPreflight * 2);
+
+            expect(spies.error).toHaveBeenNthCalledWith(1, error);
+
+            await verifyUnhandledRequestMessage(spies.error.mock.calls[1].join(' '), {
+              type: 'error',
+              platform,
+              request,
+            });
+          }
         });
       });
     });

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/unhandledRequests.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/unhandledRequests.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
 
 import HttpSearchParams from '@/http/searchParams/HttpSearchParams';
 import { HTTP_METHODS, HttpSchema } from '@/http/types/schema';
@@ -8,17 +8,13 @@ import LocalHttpRequestHandler from '@/interceptor/http/requestHandler/LocalHttp
 import RemoteHttpRequestHandler from '@/interceptor/http/requestHandler/RemoteHttpRequestHandler';
 import { AccessControlHeaders, DEFAULT_ACCESS_CONTROL_HEADERS } from '@/interceptor/server/constants';
 import { methodCanHaveRequestBody } from '@/utils/http';
+import { waitForDelay } from '@/utils/time';
 import { joinURL } from '@/utils/urls';
 import { usingIgnoredConsole } from '@tests/utils/console';
 import { expectFetchErrorOrPreflightResponse } from '@tests/utils/fetch';
 import { assessPreflightInterference, usingHttpInterceptor } from '@tests/utils/interceptors';
 
-import {
-  HttpInterceptorOptions,
-  LocalHttpInterceptorOptions,
-  RemoteHttpInterceptorOptions,
-  UnhandledRequestStrategy,
-} from '../../types/options';
+import { HttpInterceptorOptions, UnhandledRequestStrategy } from '../../types/options';
 import { RuntimeSharedHttpInterceptorTestsOptions, verifyUnhandledRequestMessage } from './utils';
 
 export function declareUnhandledRequestHttpInterceptorTests(options: RuntimeSharedHttpInterceptorTestsOptions) {
@@ -70,19 +66,19 @@ export function declareUnhandledRequestHttpInterceptorTests(options: RuntimeShar
       { overrideDefault: 'static-undefined-log' as const },
       { overrideDefault: 'factory' as const },
       { overrideDefault: 'factory-undefined-log' as const },
-    ])('Logging enabled or disabled: override default $overrideDefault', ({ overrideDefault }) => {
+    ])('Logging enabled: override default $overrideDefault', ({ overrideDefault }) => {
+      const logWarning = overrideDefault?.endsWith('undefined-log') ? undefined : true;
+
+      const localOnUnhandledRequest: UnhandledRequestStrategy.LocalDeclaration = {
+        action: 'bypass',
+        log: logWarning,
+      };
+      const remoteOnUnhandledRequest: UnhandledRequestStrategy.RemoteDeclaration = {
+        action: 'reject',
+        log: logWarning,
+      };
+
       beforeEach(() => {
-        const logWarning = overrideDefault?.endsWith('undefined-log') ? undefined : true;
-
-        const localOnUnhandledRequest: UnhandledRequestStrategy.LocalDeclaration = {
-          action: 'bypass',
-          log: logWarning,
-        };
-        const remoteOnUnhandledRequest: UnhandledRequestStrategy.RemoteDeclaration = {
-          action: 'reject',
-          log: logWarning,
-        };
-
         if (overrideDefault?.startsWith('static')) {
           if (type === 'local') {
             httpInterceptor.default.local.onUnhandledRequest = localOnUnhandledRequest;
@@ -108,6 +104,11 @@ export function declareUnhandledRequestHttpInterceptorTests(options: RuntimeShar
             expect(httpInterceptor.default.remote.onUnhandledRequest).toBe(onUnhandledRequest);
           }
         }
+      });
+
+      afterEach(() => {
+        localOnUnhandledRequest.action = 'bypass';
+        remoteOnUnhandledRequest.action = 'reject';
       });
 
       if (type === 'local') {
@@ -174,6 +175,79 @@ export function declareUnhandledRequestHttpInterceptorTests(options: RuntimeShar
                 const warnMessage = spies.warn.mock.calls[0].join(' ');
                 await verifyUnhandledRequestMessage(warnMessage, {
                   type: 'warn',
+                  platform,
+                  request,
+                });
+              });
+            },
+          );
+        });
+
+        it(`should show an error when logging is enabled and ${method} requests with no body are unhandled and rejected`, async () => {
+          localOnUnhandledRequest.action = 'reject';
+
+          await usingHttpInterceptor<{
+            '/users': {
+              GET: MethodSchemaWithoutRequestBody;
+              POST: MethodSchemaWithoutRequestBody;
+              PUT: MethodSchemaWithoutRequestBody;
+              PATCH: MethodSchemaWithoutRequestBody;
+              DELETE: MethodSchemaWithoutRequestBody;
+              HEAD: MethodSchemaWithoutRequestBody;
+              OPTIONS: MethodSchemaWithoutRequestBody;
+            };
+          }>(
+            {
+              ...interceptorOptions,
+              type,
+              onUnhandledRequest: overrideDefault ? undefined : { action: 'reject', log: true },
+            },
+            async (interceptor) => {
+              const handler = await promiseIfRemote(
+                interceptor[lowerMethod]('/users')
+                  .with({ headers: { 'x-value': '1' } })
+                  .respond({
+                    status: 200,
+                    headers: DEFAULT_ACCESS_CONTROL_HEADERS,
+                  }),
+                interceptor,
+              );
+              expect(handler).toBeInstanceOf(Handler);
+
+              let requests = await promiseIfRemote(handler.requests(), interceptor);
+              expect(requests).toHaveLength(0);
+
+              await usingIgnoredConsole(['warn', 'error'], async (spies) => {
+                const response = await fetch(joinURL(baseURL, '/users'), {
+                  method,
+                  headers: { 'x-value': '1' },
+                });
+                expect(response.status).toBe(200);
+
+                requests = await promiseIfRemote(handler.requests(), interceptor);
+                expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+                const interceptedRequest = requests[numberOfRequestsIncludingPreflight - 1];
+                expectTypeOf(interceptedRequest.body).toEqualTypeOf<null>();
+                expect(interceptedRequest.body).toBe(null);
+
+                expect(spies.warn).toHaveBeenCalledTimes(0);
+                expect(spies.error).toHaveBeenCalledTimes(0);
+
+                const request = new Request(joinURL(baseURL, '/users'), { method });
+                const promise = fetch(request);
+                await expectFetchErrorOrPreflightResponse(promise, {
+                  shouldBePreflight: overridesPreflightResponse,
+                });
+
+                requests = await promiseIfRemote(handler.requests(), interceptor);
+                expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+
+                expect(spies.warn).toHaveBeenCalledTimes(0);
+                expect(spies.error).toHaveBeenCalledTimes(numberOfRequestsIncludingPreflight);
+
+                const errorMessage = spies.error.mock.calls[0].join(' ');
+                await verifyUnhandledRequestMessage(errorMessage, {
+                  type: 'error',
                   platform,
                   request,
                 });
@@ -250,6 +324,82 @@ export function declareUnhandledRequestHttpInterceptorTests(options: RuntimeShar
                 const warnMessage = spies.warn.mock.calls[0].join(' ');
                 await verifyUnhandledRequestMessage(warnMessage, {
                   type: 'warn',
+                  platform,
+                  request: requestClone,
+                });
+              });
+            },
+          );
+        });
+
+        it(`should show an error when logging is enabled and ${method} requests with body are unhandled and rejected`, async () => {
+          localOnUnhandledRequest.action = 'reject';
+
+          await usingHttpInterceptor<{
+            '/users': {
+              POST: MethodSchemaWithRequestBody;
+              PUT: MethodSchemaWithRequestBody;
+              PATCH: MethodSchemaWithRequestBody;
+              DELETE: MethodSchemaWithRequestBody;
+            };
+          }>(
+            {
+              ...interceptorOptions,
+              type,
+              onUnhandledRequest: overrideDefault ? undefined : { action: 'reject', log: true },
+            },
+            async (interceptor) => {
+              const handler = await promiseIfRemote(
+                interceptor[lowerMethod]('/users')
+                  .with({ headers: { 'x-value': '1' } })
+                  .respond({
+                    status: 200,
+                    headers: DEFAULT_ACCESS_CONTROL_HEADERS,
+                  }),
+                interceptor,
+              );
+              expect(handler).toBeInstanceOf(Handler);
+
+              let requests = await promiseIfRemote(handler.requests(), interceptor);
+              expect(requests).toHaveLength(0);
+
+              await usingIgnoredConsole(['warn', 'error'], async (spies) => {
+                const response = await fetch(joinURL(baseURL, '/users'), {
+                  method,
+                  headers: { 'x-value': '1', 'content-type': 'application/json' },
+                  body: JSON.stringify({ message: 'ok' }),
+                });
+                expect(response.status).toBe(200);
+
+                requests = await promiseIfRemote(handler.requests(), interceptor);
+                expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+                const interceptedRequest = requests[numberOfRequestsIncludingPreflight - 1];
+                expectTypeOf(interceptedRequest.body).toEqualTypeOf<{ message: string }>();
+                expect(interceptedRequest.body).toEqual({ message: 'ok' });
+
+                expect(spies.warn).toHaveBeenCalledTimes(0);
+                expect(spies.error).toHaveBeenCalledTimes(0);
+
+                const request = new Request(joinURL(baseURL, '/users'), {
+                  method,
+                  headers: { 'content-type': 'application/json' },
+                  body: JSON.stringify({ message: 'ok' }),
+                });
+                const requestClone = request.clone();
+                const promise = fetch(request);
+                await expectFetchErrorOrPreflightResponse(promise, {
+                  shouldBePreflight: overridesPreflightResponse,
+                });
+
+                requests = await promiseIfRemote(handler.requests(), interceptor);
+                expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+
+                expect(spies.warn).toHaveBeenCalledTimes(0);
+                expect(spies.error).toHaveBeenCalledTimes(numberOfRequestsIncludingPreflight);
+
+                const errorMessage = spies.error.mock.calls[0].join(' ');
+                await verifyUnhandledRequestMessage(errorMessage, {
+                  type: 'error',
                   platform,
                   request: requestClone,
                 });
@@ -413,13 +563,12 @@ export function declareUnhandledRequestHttpInterceptorTests(options: RuntimeShar
       }
     });
 
-    it.each([
+    describe.each([
       { overrideDefault: undefined },
       { overrideDefault: 'static' as const },
       { overrideDefault: 'factory' as const },
-    ])(
-      `should not show a warning or error when logging is disabled and ${method} requests are unhandled: override default $overrideDefault`,
-      async ({ overrideDefault }) => {
+    ])('Logging disabled: override default $overrideDefault', ({ overrideDefault }) => {
+      beforeEach(() => {
         const logWarning = false;
 
         const localOnUnhandledRequest: UnhandledRequestStrategy.LocalDeclaration = {
@@ -456,7 +605,9 @@ export function declareUnhandledRequestHttpInterceptorTests(options: RuntimeShar
             expect(httpInterceptor.default.remote.onUnhandledRequest).toBe(onUnhandledRequest);
           }
         }
+      });
 
+      it(`should not show a warning or error when logging is disabled and ${method} requests are unhandled: override default $overrideDefault`, async () => {
         const extendedInterceptorOptions: HttpInterceptorOptions =
           type === 'local'
             ? {
@@ -520,25 +671,25 @@ export function declareUnhandledRequestHttpInterceptorTests(options: RuntimeShar
             expect(spies.error).toHaveBeenCalledTimes(0);
           });
         });
-      },
-    );
+      });
+    });
 
-    it(`should support a custom unhandled ${method} request factory`, async () => {
-      const localOnUnhandledRequest = vi.fn<Extract<LocalHttpInterceptorOptions['onUnhandledRequest'], Function>>(
-        (request) => {
-          const url = new URL(request.url);
+    it(`should support a synchronous unhandled ${method} request factory`, async () => {
+      const localOnUnhandledRequest = vi.fn<UnhandledRequestStrategy.LocalDeclarationFactory>((request) => {
+        const url = new URL(request.url);
+        return {
+          action: 'bypass',
+          log: !url.searchParams.has('name'),
+        };
+      });
 
-          return { action: 'bypass', log: !url.searchParams.has('name') };
-        },
-      );
-
-      const remoteOnUnhandledRequest = vi.fn<Extract<RemoteHttpInterceptorOptions['onUnhandledRequest'], Function>>(
-        (request) => {
-          const url = new URL(request.url);
-
-          return { action: 'reject', log: !url.searchParams.has('name') };
-        },
-      );
+      const remoteOnUnhandledRequest = vi.fn<UnhandledRequestStrategy.RemoteDeclarationFactory>((request) => {
+        const url = new URL(request.url);
+        return {
+          action: 'reject',
+          log: !url.searchParams.has('name'),
+        };
+      });
 
       const extendedInterceptorOptions = (
         type === 'local'
@@ -633,32 +784,278 @@ export function declareUnhandledRequestHttpInterceptorTests(options: RuntimeShar
       });
     });
 
-    it(`should log an error if a custom unhandled ${method} request handler throws`, async () => {
+    it(`should support an asynchronous unhandled ${method} request factory`, async () => {
+      const localOnUnhandledRequest = vi.fn<UnhandledRequestStrategy.LocalDeclarationFactory>(async (request) => {
+        const url = new URL(request.url);
+
+        await waitForDelay(10);
+
+        return {
+          action: 'bypass',
+          log: !url.searchParams.has('name'),
+        };
+      });
+
+      const remoteOnUnhandledRequest = vi.fn<UnhandledRequestStrategy.RemoteDeclarationFactory>(async (request) => {
+        const url = new URL(request.url);
+
+        await waitForDelay(10);
+
+        return {
+          action: 'reject',
+          log: !url.searchParams.has('name'),
+        };
+      });
+
+      const extendedInterceptorOptions = (
+        type === 'local'
+          ? { ...interceptorOptions, type, onUnhandledRequest: localOnUnhandledRequest }
+          : { ...interceptorOptions, type, onUnhandledRequest: remoteOnUnhandledRequest }
+      ) satisfies HttpInterceptorOptions;
+
+      await usingHttpInterceptor<{
+        '/users': {
+          GET: MethodSchemaWithoutRequestBody;
+          POST: MethodSchemaWithoutRequestBody;
+          PUT: MethodSchemaWithoutRequestBody;
+          PATCH: MethodSchemaWithoutRequestBody;
+          DELETE: MethodSchemaWithoutRequestBody;
+          HEAD: MethodSchemaWithoutRequestBody;
+          OPTIONS: MethodSchemaWithoutRequestBody;
+        };
+      }>(extendedInterceptorOptions, async (interceptor) => {
+        const handler = await promiseIfRemote(
+          interceptor[lowerMethod]('/users')
+            .with({ searchParams: { 'x-value': '1' } })
+            .respond({
+              status: 200,
+              headers: DEFAULT_ACCESS_CONTROL_HEADERS,
+            }),
+          interceptor,
+        );
+        expect(handler).toBeInstanceOf(Handler);
+
+        let requests = await promiseIfRemote(handler.requests(), interceptor);
+        expect(requests).toHaveLength(0);
+
+        await usingIgnoredConsole(['warn', 'error'], async (spies) => {
+          const searchParams = new HttpSearchParams<{
+            'x-value': string;
+            name?: string;
+          }>({ 'x-value': '1' });
+
+          const response = await fetch(joinURL(baseURL, `/users?${searchParams.toString()}`), { method });
+          expect(response.status).toBe(200);
+
+          requests = await promiseIfRemote(handler.requests(), interceptor);
+          expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+
+          expect(extendedInterceptorOptions.onUnhandledRequest).toHaveBeenCalledTimes(0);
+          expect(spies.warn).toHaveBeenCalledTimes(0);
+          expect(spies.error).toHaveBeenCalledTimes(0);
+
+          searchParams.set('x-value', '2');
+          searchParams.set('name', 'User 1');
+
+          let promise = fetch(joinURL(baseURL, `/users?${searchParams.toString()}`), {
+            method,
+            headers: { 'x-value': '1' },
+          });
+          await expectFetchErrorOrPreflightResponse(promise, {
+            shouldBePreflight: overridesPreflightResponse,
+          });
+
+          requests = await promiseIfRemote(handler.requests(), interceptor);
+          expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+
+          expect(extendedInterceptorOptions.onUnhandledRequest).toHaveBeenCalledTimes(
+            numberOfRequestsIncludingPreflight,
+          );
+          expect(spies.warn).toHaveBeenCalledTimes(0);
+          expect(spies.error).toHaveBeenCalledTimes(0);
+
+          const request = new Request(joinURL(baseURL, '/users'), { method });
+          promise = fetch(request);
+          await expectFetchErrorOrPreflightResponse(promise, {
+            shouldBePreflight: overridesPreflightResponse,
+          });
+
+          requests = await promiseIfRemote(handler.requests(), interceptor);
+          expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+
+          expect(extendedInterceptorOptions.onUnhandledRequest).toHaveBeenCalledTimes(
+            numberOfRequestsIncludingPreflight * 2,
+          );
+          const messageType = type === 'local' ? 'warn' : 'error';
+          expect(spies.warn).toHaveBeenCalledTimes(messageType === 'warn' ? numberOfRequestsIncludingPreflight : 0);
+          expect(spies.error).toHaveBeenCalledTimes(messageType === 'error' ? numberOfRequestsIncludingPreflight : 0);
+
+          const errorMessage = spies[messageType].mock.calls[0].join(' ');
+          await verifyUnhandledRequestMessage(errorMessage, {
+            type: messageType,
+            platform,
+            request,
+          });
+        });
+      });
+    });
+
+    it(`should log an error if a synchronous unhandled ${method} request factory throws`, async () => {
       const error = new Error('Unhandled request.');
 
-      const localOnUnhandledRequest = vi.fn<Extract<LocalHttpInterceptorOptions['onUnhandledRequest'], Function>>(
-        (request) => {
-          const url = new URL(request.url);
+      const localOnUnhandledRequest = vi.fn<UnhandledRequestStrategy.LocalDeclarationFactory>((request) => {
+        const url = new URL(request.url);
 
-          if (!url.searchParams.has('name')) {
-            throw error;
+        if (!url.searchParams.has('name')) {
+          throw error;
+        }
+
+        return { action: 'bypass', log: false };
+      });
+
+      const remoteOnUnhandledRequest = vi.fn<UnhandledRequestStrategy.RemoteDeclarationFactory>((request) => {
+        const url = new URL(request.url);
+
+        if (!url.searchParams.has('name')) {
+          throw error;
+        }
+
+        return { action: 'reject', log: false };
+      });
+
+      const extendedInterceptorOptions = (
+        type === 'local'
+          ? { ...interceptorOptions, type, onUnhandledRequest: localOnUnhandledRequest }
+          : { ...interceptorOptions, type, onUnhandledRequest: remoteOnUnhandledRequest }
+      ) satisfies HttpInterceptorOptions;
+
+      await usingHttpInterceptor<{
+        '/users': {
+          GET: MethodSchemaWithoutRequestBody;
+          POST: MethodSchemaWithoutRequestBody;
+          PUT: MethodSchemaWithoutRequestBody;
+          PATCH: MethodSchemaWithoutRequestBody;
+          DELETE: MethodSchemaWithoutRequestBody;
+          HEAD: MethodSchemaWithoutRequestBody;
+          OPTIONS: MethodSchemaWithoutRequestBody;
+        };
+      }>(extendedInterceptorOptions, async (interceptor) => {
+        const handler = await promiseIfRemote(
+          interceptor[lowerMethod]('/users')
+            .with({ searchParams: { 'x-value': '1' } })
+            .respond({
+              status: 200,
+              headers: DEFAULT_ACCESS_CONTROL_HEADERS,
+            }),
+          interceptor,
+        );
+        expect(handler).toBeInstanceOf(Handler);
+
+        let requests = await promiseIfRemote(handler.requests(), interceptor);
+        expect(requests).toHaveLength(0);
+
+        await usingIgnoredConsole(['warn', 'error'], async (spies) => {
+          const searchParams = new HttpSearchParams<{
+            'x-value': string;
+            name?: string;
+          }>({ 'x-value': '1' });
+
+          const response = await fetch(joinURL(baseURL, `/users?${searchParams.toString()}`), { method });
+          expect(response.status).toBe(200);
+
+          requests = await promiseIfRemote(handler.requests(), interceptor);
+          expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+
+          expect(extendedInterceptorOptions.onUnhandledRequest).toHaveBeenCalledTimes(0);
+          expect(spies.warn).toHaveBeenCalledTimes(0);
+          expect(spies.error).toHaveBeenCalledTimes(0);
+
+          searchParams.set('x-value', '2');
+          searchParams.set('name', 'User 1');
+
+          let promise = fetch(joinURL(baseURL, `/users?${searchParams.toString()}`), {
+            method,
+            headers: { 'x-value': '1' },
+          });
+          await expectFetchErrorOrPreflightResponse(promise, {
+            shouldBePreflight: overridesPreflightResponse,
+          });
+
+          requests = await promiseIfRemote(handler.requests(), interceptor);
+          expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+
+          expect(extendedInterceptorOptions.onUnhandledRequest).toHaveBeenCalledTimes(
+            numberOfRequestsIncludingPreflight,
+          );
+          expect(spies.warn).toHaveBeenCalledTimes(0);
+          expect(spies.error).toHaveBeenCalledTimes(0);
+
+          const request = new Request(joinURL(baseURL, '/users'), { method });
+          promise = fetch(request);
+          await expectFetchErrorOrPreflightResponse(promise, {
+            shouldBePreflight: overridesPreflightResponse,
+          });
+
+          requests = await promiseIfRemote(handler.requests(), interceptor);
+          expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+
+          expect(extendedInterceptorOptions.onUnhandledRequest).toHaveBeenCalledTimes(
+            numberOfRequestsIncludingPreflight * 2,
+          );
+
+          if (type === 'local') {
+            expect(spies.warn).toHaveBeenCalledTimes(1);
+            expect(spies.error).toHaveBeenCalledTimes(numberOfRequestsIncludingPreflight);
+
+            expect(spies.error).toHaveBeenCalledWith(error);
+
+            await verifyUnhandledRequestMessage(spies.warn.mock.calls[0].join(' '), {
+              type: 'warn',
+              platform,
+              request,
+            });
+          } else {
+            expect(spies.warn).toHaveBeenCalledTimes(0);
+            expect(spies.error).toHaveBeenCalledTimes(numberOfRequestsIncludingPreflight * 2);
+
+            expect(spies.error).toHaveBeenNthCalledWith(1, error);
+
+            await verifyUnhandledRequestMessage(spies.error.mock.calls[1].join(' '), {
+              type: 'error',
+              platform,
+              request,
+            });
           }
+        });
+      });
+    });
 
-          return { action: 'bypass', log: false };
-        },
-      );
+    it(`should log an error if an asynchronous unhandled ${method} request factory rejects`, async () => {
+      const error = new Error('Unhandled request.');
 
-      const remoteOnUnhandledRequest = vi.fn<Extract<RemoteHttpInterceptorOptions['onUnhandledRequest'], Function>>(
-        (request) => {
-          const url = new URL(request.url);
+      const localOnUnhandledRequest = vi.fn<UnhandledRequestStrategy.LocalDeclarationFactory>(async (request) => {
+        const url = new URL(request.url);
 
-          if (!url.searchParams.has('name')) {
-            throw error;
-          }
+        await waitForDelay(10);
 
-          return { action: 'reject', log: false };
-        },
-      );
+        if (!url.searchParams.has('name')) {
+          throw error;
+        }
+
+        return { action: 'bypass', log: false };
+      });
+
+      const remoteOnUnhandledRequest = vi.fn<UnhandledRequestStrategy.RemoteDeclarationFactory>(async (request) => {
+        const url = new URL(request.url);
+
+        await waitForDelay(10);
+
+        if (!url.searchParams.has('name')) {
+          throw error;
+        }
+
+        return { action: 'reject', log: false };
+      });
 
       const extendedInterceptorOptions = (
         type === 'local'

--- a/packages/zimic/src/interceptor/http/interceptor/types/options.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/types/options.ts
@@ -60,15 +60,6 @@ export namespace UnhandledRequestStrategy {
    *
    * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#unhandled-requests Unhandled requests}
    */
-  export type DeclarationFactorySync<DeclarationAction extends Action = Action> = (
-    request: HttpRequest,
-  ) => Declaration<DeclarationAction>;
-
-  /**
-   * A factory to create dynamic unhandled request strategies based on the intercepted request.
-   *
-   * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#unhandled-requests Unhandled requests}
-   */
   export type DeclarationFactory<DeclarationAction extends Action = Action> = (
     request: HttpRequest,
   ) => PossiblePromise<Declaration<DeclarationAction>>;
@@ -104,20 +95,8 @@ export namespace UnhandledRequestStrategy {
   /** The static declaration or a factory of the strategy to use for unhandled requests in local interceptors. */
   export type Local = LocalDeclaration | LocalDeclarationFactory;
 
-  /**
-   * The static declaration or a synchronous factory of the strategy to use for unhandled requests in local
-   * interceptors.
-   */
-  export type LocalSync = LocalDeclaration | DeclarationFactorySync;
-
   /** The static declaration or a factory of the strategy to use for unhandled requests in remote interceptors. */
   export type Remote = RemoteDeclaration | RemoteDeclarationFactory;
-
-  /**
-   * The static declaration or a synchronous factory of the strategy to use for unhandled requests in remote
-   * interceptors.
-   */
-  export type RemoteSync = RemoteDeclaration | DeclarationFactorySync;
 }
 
 export type UnhandledRequestStrategy = UnhandledRequestStrategy.Local | UnhandledRequestStrategy.Remote;

--- a/packages/zimic/src/interceptor/http/interceptor/types/options.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/types/options.ts
@@ -52,8 +52,17 @@ export namespace UnhandledRequestStrategy {
      *
      * @default true
      */
-    logWarning?: boolean;
+    log?: boolean;
   }
+
+  /**
+   * A factory to create dynamic unhandled request strategies based on the intercepted request.
+   *
+   * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#unhandled-requests Unhandled requests}
+   */
+  export type DeclarationFactorySync<DeclarationAction extends Action = Action> = (
+    request: HttpRequest,
+  ) => Declaration<DeclarationAction>;
 
   /**
    * A factory to create dynamic unhandled request strategies based on the intercepted request.
@@ -69,14 +78,14 @@ export namespace UnhandledRequestStrategy {
    *
    * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#unhandled-requests Unhandled requests}
    */
-  export type LocalDeclaration = Declaration<Extract<Action, 'bypass'>>;
+  export type LocalDeclaration = Declaration;
 
   /**
    * A factory to create dynamic unhandled request strategies based on the intercepted request in local interceptors.
    *
    * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#unhandled-requests Unhandled requests}
    */
-  export type LocalDeclarationFactory = DeclarationFactory<Extract<Action, 'bypass'>>;
+  export type LocalDeclarationFactory = DeclarationFactory;
 
   /**
    * A static declaration of the strategy to use for unhandled requests in remote interceptors.
@@ -95,8 +104,20 @@ export namespace UnhandledRequestStrategy {
   /** The static declaration or a factory of the strategy to use for unhandled requests in local interceptors. */
   export type Local = LocalDeclaration | LocalDeclarationFactory;
 
+  /**
+   * The static declaration or a synchronous factory of the strategy to use for unhandled requests in local
+   * interceptors.
+   */
+  export type LocalSync = LocalDeclaration | DeclarationFactorySync;
+
   /** The static declaration or a factory of the strategy to use for unhandled requests in remote interceptors. */
   export type Remote = RemoteDeclaration | RemoteDeclarationFactory;
+
+  /**
+   * The static declaration or a synchronous factory of the strategy to use for unhandled requests in remote
+   * interceptors.
+   */
+  export type RemoteSync = RemoteDeclaration | DeclarationFactorySync;
 }
 
 export type UnhandledRequestStrategy = UnhandledRequestStrategy.Local | UnhandledRequestStrategy.Remote;

--- a/packages/zimic/src/interceptor/http/interceptorWorker/HttpInterceptorWorker.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/HttpInterceptorWorker.ts
@@ -121,12 +121,8 @@ abstract class HttpInterceptorWorker {
   ): PossiblePromise<void>;
 
   protected async handleUnhandledRequest(request: Request, strategy: UnhandledRequestStrategy.Declaration) {
-    try {
-      if (strategy.log) {
-        await HttpInterceptorWorker.logUnhandledRequestWarning(request, strategy.action);
-      }
-    } catch (error) {
-      console.error(error);
+    if (strategy.log) {
+      await HttpInterceptorWorker.logUnhandledRequestWarning(request, strategy.action);
     }
   }
 

--- a/packages/zimic/src/interceptor/http/interceptorWorker/HttpInterceptorWorker.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/HttpInterceptorWorker.ts
@@ -182,17 +182,16 @@ abstract class HttpInterceptorWorker {
       const defaultDeclarationOrFactory = this.store.defaultOnUnhandledRequest(interceptorType);
 
       const requestClone = request.clone();
-      const otherRequestClone = request.clone();
 
       const customDefaultStrategy =
         typeof defaultDeclarationOrFactory === 'function'
-          ? defaultDeclarationOrFactory(requestClone)
+          ? defaultDeclarationOrFactory(request)
           : defaultDeclarationOrFactory;
 
       const { declarationOrFactory = null } = this.findUnhandledRequestStrategy(requestURL) ?? {};
 
       const interceptorStrategy =
-        typeof declarationOrFactory === 'function' ? declarationOrFactory(otherRequestClone) : declarationOrFactory;
+        typeof declarationOrFactory === 'function' ? declarationOrFactory(requestClone) : declarationOrFactory;
 
       return [originalDefaultStrategy, customDefaultStrategy, interceptorStrategy].filter(isDefined);
     } catch (error) {

--- a/packages/zimic/src/interceptor/http/interceptorWorker/HttpInterceptorWorkerStore.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/HttpInterceptorWorkerStore.ts
@@ -3,7 +3,7 @@ import { DEFAULT_UNHANDLED_REQUEST_STRATEGY } from './constants';
 
 class HttpInterceptorWorkerStore {
   private static _defaultOnUnhandledRequest: {
-    local: UnhandledRequestStrategy.LocalSync;
+    local: UnhandledRequestStrategy.Local;
     remote: UnhandledRequestStrategy.Remote;
   } = {
     local: { ...DEFAULT_UNHANDLED_REQUEST_STRATEGY.local },
@@ -12,19 +12,19 @@ class HttpInterceptorWorkerStore {
 
   private class = HttpInterceptorWorkerStore;
 
-  defaultOnUnhandledRequest(interceptorType: 'local'): UnhandledRequestStrategy.LocalSync;
+  defaultOnUnhandledRequest(interceptorType: 'local'): UnhandledRequestStrategy.Local;
   defaultOnUnhandledRequest(interceptorType: 'remote'): UnhandledRequestStrategy.Remote;
   defaultOnUnhandledRequest(interceptorType: HttpInterceptorType): UnhandledRequestStrategy;
   defaultOnUnhandledRequest(interceptorType: HttpInterceptorType) {
     return this.class._defaultOnUnhandledRequest[interceptorType];
   }
 
-  setDefaultOnUnhandledRequest(interceptorType: 'local', strategy: UnhandledRequestStrategy.LocalSync): void;
+  setDefaultOnUnhandledRequest(interceptorType: 'local', strategy: UnhandledRequestStrategy.Local): void;
   setDefaultOnUnhandledRequest(interceptorType: 'remote', strategy: UnhandledRequestStrategy.Remote): void;
   setDefaultOnUnhandledRequest(interceptorType: HttpInterceptorType, strategy: UnhandledRequestStrategy): void;
   setDefaultOnUnhandledRequest(interceptorType: HttpInterceptorType, strategy: UnhandledRequestStrategy) {
     if (interceptorType === 'local') {
-      this.class._defaultOnUnhandledRequest[interceptorType] = strategy as UnhandledRequestStrategy.LocalSync;
+      this.class._defaultOnUnhandledRequest[interceptorType] = strategy as UnhandledRequestStrategy.Local;
     } else {
       this.class._defaultOnUnhandledRequest[interceptorType] = strategy as UnhandledRequestStrategy.Remote;
     }

--- a/packages/zimic/src/interceptor/http/interceptorWorker/HttpInterceptorWorkerStore.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/HttpInterceptorWorkerStore.ts
@@ -3,7 +3,7 @@ import { DEFAULT_UNHANDLED_REQUEST_STRATEGY } from './constants';
 
 class HttpInterceptorWorkerStore {
   private static _defaultOnUnhandledRequest: {
-    local: UnhandledRequestStrategy.Local;
+    local: UnhandledRequestStrategy.LocalSync;
     remote: UnhandledRequestStrategy.Remote;
   } = {
     local: { ...DEFAULT_UNHANDLED_REQUEST_STRATEGY.local },
@@ -12,19 +12,19 @@ class HttpInterceptorWorkerStore {
 
   private class = HttpInterceptorWorkerStore;
 
-  defaultOnUnhandledRequest(interceptorType: 'local'): UnhandledRequestStrategy.Local;
+  defaultOnUnhandledRequest(interceptorType: 'local'): UnhandledRequestStrategy.LocalSync;
   defaultOnUnhandledRequest(interceptorType: 'remote'): UnhandledRequestStrategy.Remote;
   defaultOnUnhandledRequest(interceptorType: HttpInterceptorType): UnhandledRequestStrategy;
   defaultOnUnhandledRequest(interceptorType: HttpInterceptorType) {
     return this.class._defaultOnUnhandledRequest[interceptorType];
   }
 
-  setDefaultOnUnhandledRequest(interceptorType: 'local', strategy: UnhandledRequestStrategy.Local): void;
+  setDefaultOnUnhandledRequest(interceptorType: 'local', strategy: UnhandledRequestStrategy.LocalSync): void;
   setDefaultOnUnhandledRequest(interceptorType: 'remote', strategy: UnhandledRequestStrategy.Remote): void;
   setDefaultOnUnhandledRequest(interceptorType: HttpInterceptorType, strategy: UnhandledRequestStrategy): void;
   setDefaultOnUnhandledRequest(interceptorType: HttpInterceptorType, strategy: UnhandledRequestStrategy) {
     if (interceptorType === 'local') {
-      this.class._defaultOnUnhandledRequest[interceptorType] = strategy as UnhandledRequestStrategy.Local;
+      this.class._defaultOnUnhandledRequest[interceptorType] = strategy as UnhandledRequestStrategy.LocalSync;
     } else {
       this.class._defaultOnUnhandledRequest[interceptorType] = strategy as UnhandledRequestStrategy.Remote;
     }

--- a/packages/zimic/src/interceptor/http/interceptorWorker/LocalHttpInterceptorWorker.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/LocalHttpInterceptorWorker.ts
@@ -71,8 +71,16 @@ class LocalHttpInterceptorWorker extends HttpInterceptorWorker {
 
       const sharedOptions: MSWWorkerSharedOptions = {
         onUnhandledRequest: (request, print) => {
-          const { partialStrategy, defaultStrategy } = super.getUnhandledRequestStrategy(request, 'local');
-          const strategy: UnhandledRequestStrategy.Declaration = { ...defaultStrategy, ...partialStrategy };
+          const { originalDefaultStrategy, customDefaultStrategy, customStrategy } = super.getUnhandledRequestStrategy(
+            request,
+            'local',
+          );
+
+          const strategy: UnhandledRequestStrategy.Declaration = {
+            ...originalDefaultStrategy,
+            ...customDefaultStrategy,
+            ...customStrategy,
+          };
 
           // MSW does not support async callbacks for `onUnhandledRequest`.
           // As a workaround, we can only support synchronous code.
@@ -213,8 +221,16 @@ class LocalHttpInterceptorWorker extends HttpInterceptorWorker {
       }
 
       if (!result?.response) {
-        const { partialStrategy, defaultStrategy } = super.getUnhandledRequestStrategy(requestClone, 'local');
-        const strategy: UnhandledRequestStrategy.Declaration = { ...defaultStrategy, ...partialStrategy };
+        const { originalDefaultStrategy, customDefaultStrategy, customStrategy } = super.getUnhandledRequestStrategy(
+          requestClone,
+          'local',
+        );
+
+        const strategy: UnhandledRequestStrategy.Declaration = {
+          ...originalDefaultStrategy,
+          ...customDefaultStrategy,
+          ...customStrategy,
+        };
 
         if (strategy.action === 'reject') {
           return Response.error();

--- a/packages/zimic/src/interceptor/http/interceptorWorker/LocalHttpInterceptorWorker.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/LocalHttpInterceptorWorker.ts
@@ -133,7 +133,10 @@ class LocalHttpInterceptorWorker extends HttpInterceptorWorker {
 
     class RejectedUnhandledRequestError extends InternalError {
       constructor() {
-        super('Request was not handled and was rejected.');
+        super(
+          'Request was not handled and was rejected because `action` is set to `reject`.\n' +
+            'Learn more: https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#unhandled-requests',
+        );
         this.name = 'RejectedUnhandledRequestError';
       }
     }

--- a/packages/zimic/src/interceptor/http/interceptorWorker/LocalHttpInterceptorWorker.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/LocalHttpInterceptorWorker.ts
@@ -192,7 +192,7 @@ class LocalHttpInterceptorWorker extends HttpInterceptorWorker {
   private async bypassOrRejectUnhandledRequest(request: HttpRequest) {
     const requestClone = request.clone();
 
-    const strategy = super.getUnhandledRequestStrategy(request, 'local');
+    const strategy = await super.getUnhandledRequestStrategy(request, 'local');
     await super.handleUnhandledRequest(requestClone, strategy);
 
     if (strategy.action === 'reject') {

--- a/packages/zimic/src/interceptor/http/interceptorWorker/RemoteHttpInterceptorWorker.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/RemoteHttpInterceptorWorker.ts
@@ -13,7 +13,7 @@ import WebSocketClient from '@/webSocket/WebSocketClient';
 import NotStartedHttpInterceptorError from '../interceptor/errors/NotStartedHttpInterceptorError';
 import UnknownHttpInterceptorPlatformError from '../interceptor/errors/UnknownHttpInterceptorPlatformError';
 import HttpInterceptorClient, { AnyHttpInterceptorClient } from '../interceptor/HttpInterceptorClient';
-import { HttpInterceptorPlatform, UnhandledRequestStrategy } from '../interceptor/types/options';
+import { HttpInterceptorPlatform } from '../interceptor/types/options';
 import HttpInterceptorWorker from './HttpInterceptorWorker';
 import { RemoteHttpInterceptorWorkerOptions } from './types/options';
 import { HttpResponseFactory, HttpResponseFactoryContext } from './types/requests';
@@ -82,24 +82,7 @@ class RemoteHttpInterceptorWorker extends HttpInterceptorWorker {
       console.error(error);
     }
 
-    const {
-      originalDefaultStrategy: originalDefaultStrategyOrPromise,
-      customDefaultStrategy: customDefaultStrategyOrPromise,
-      customStrategy: customStrategyOrPromise,
-    } = super.getUnhandledRequestStrategy(request, 'remote');
-
-    const [originalDefaultStrategy, customDefaultStrategy, customStrategy] = await Promise.all([
-      originalDefaultStrategyOrPromise,
-      customDefaultStrategyOrPromise,
-      customStrategyOrPromise,
-    ]);
-
-    const strategy: UnhandledRequestStrategy.Declaration = {
-      ...originalDefaultStrategy,
-      ...customDefaultStrategy,
-      ...customStrategy,
-    };
-
+    const strategy = await super.getUnhandledRequestStrategy(request, 'remote');
     await super.handleUnhandledRequest(request, strategy);
 
     return { response: null };

--- a/packages/zimic/src/interceptor/http/interceptorWorker/__tests__/shared/methods.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/__tests__/shared/methods.ts
@@ -8,7 +8,7 @@ import { PossiblePromise } from '@/types/utils';
 import { fetchWithTimeout } from '@/utils/fetch';
 import { waitForDelay } from '@/utils/time';
 import { joinURL, DuplicatedPathParamError, createURL, InvalidURLError, createRegexFromURL } from '@/utils/urls';
-import { expectFetchError, expectFetchErrorOrPreflightResponse } from '@tests/utils/fetch';
+import { expectBypassedResponse, expectPreflightResponse, expectFetchError } from '@tests/utils/fetch';
 import {
   assessPreflightInterference,
   createInternalHttpInterceptor,
@@ -467,11 +467,15 @@ export function declareMethodHttpInterceptorWorkerTests(options: SharedHttpInter
 
           const urlExpectedToFail = joinURL(baseURL, path.fetch);
 
-          const fetchPromise = fetchWithTimeout(urlExpectedToFail, { method, timeout: 200 });
-          await expectFetchErrorOrPreflightResponse(fetchPromise, {
-            shouldBePreflight: overridesPreflightResponse,
-            canBeAborted: true,
-          });
+          const responsePromise = fetchWithTimeout(urlExpectedToFail, { method, timeout: 500 });
+
+          if (overridesPreflightResponse) {
+            await expectPreflightResponse(responsePromise);
+          } else if (defaultWorkerOptions.type === 'local') {
+            await expectBypassedResponse(responsePromise);
+          } else {
+            await expectFetchError(responsePromise, { canBeAborted: true });
+          }
 
           expect(spiedRequestHandler).not.toHaveBeenCalled();
         });
@@ -501,11 +505,15 @@ export function declareMethodHttpInterceptorWorkerTests(options: SharedHttpInter
 
           const urlExpectedToFail = joinURL(baseURL, paths.fetch);
 
-          const fetchPromise = fetchWithTimeout(urlExpectedToFail, { method, timeout: 200 });
-          await expectFetchErrorOrPreflightResponse(fetchPromise, {
-            shouldBePreflight: overridesPreflightResponse,
-            canBeAborted: true,
-          });
+          const responsePromise = fetchWithTimeout(urlExpectedToFail, { method, timeout: 500 });
+
+          if (overridesPreflightResponse) {
+            await expectPreflightResponse(responsePromise);
+          } else if (defaultWorkerOptions.type === 'local') {
+            await expectBypassedResponse(responsePromise);
+          } else {
+            await expectFetchError(responsePromise, { canBeAborted: true });
+          }
 
           expect(spiedRequestHandler).not.toHaveBeenCalled();
         });
@@ -521,10 +529,15 @@ export function declareMethodHttpInterceptorWorkerTests(options: SharedHttpInter
 
         expect(emptySpiedRequestHandler).not.toHaveBeenCalled();
 
-        const fetchPromise = fetch(baseURL, { method });
-        await expectFetchErrorOrPreflightResponse(fetchPromise, {
-          shouldBePreflight: overridesPreflightResponse,
-        });
+        const responsePromise = fetch(baseURL, { method });
+
+        if (overridesPreflightResponse) {
+          await expectPreflightResponse(responsePromise);
+        } else if (defaultWorkerOptions.type === 'local') {
+          await expectBypassedResponse(responsePromise);
+        } else {
+          await expectFetchError(responsePromise);
+        }
 
         expect(emptySpiedRequestHandler).toHaveBeenCalledTimes(numberOfRequestsIncludingPreflight);
 
@@ -546,11 +559,11 @@ export function declareMethodHttpInterceptorWorkerTests(options: SharedHttpInter
 
         expect(delayedSpiedRequestHandler).not.toHaveBeenCalled();
 
-        let fetchPromise = fetchWithTimeout(baseURL, { method, timeout: 20 });
-        await expectFetchError(fetchPromise, { canBeAborted: true });
+        let responsePromise = fetchWithTimeout(baseURL, { method, timeout: 20 });
+        await expectFetchError(responsePromise, { canBeAborted: true });
 
-        fetchPromise = fetchWithTimeout(baseURL, { method, timeout: 500 });
-        await expect(fetchPromise).resolves.toBeInstanceOf(Response);
+        responsePromise = fetchWithTimeout(baseURL, { method, timeout: 500 });
+        await expect(responsePromise).resolves.toBeInstanceOf(Response);
 
         expect(delayedSpiedRequestHandler).toHaveBeenCalledTimes(numberOfRequestsIncludingPreflight + 1);
 
@@ -570,11 +583,15 @@ export function declareMethodHttpInterceptorWorkerTests(options: SharedHttpInter
 
         expect(spiedRequestHandler).not.toHaveBeenCalled();
 
-        const fetchPromise = fetchWithTimeout(baseURL, { method, timeout: 200 });
-        await expectFetchErrorOrPreflightResponse(fetchPromise, {
-          shouldBePreflight: overridesPreflightResponse,
-          canBeAborted: true,
-        });
+        const responsePromise = fetchWithTimeout(baseURL, { method, timeout: 500 });
+
+        if (overridesPreflightResponse) {
+          await expectPreflightResponse(responsePromise);
+        } else if (defaultWorkerOptions.type === 'local') {
+          await expectBypassedResponse(responsePromise);
+        } else {
+          await expectFetchError(responsePromise, { canBeAborted: true });
+        }
 
         expect(spiedRequestHandler).not.toHaveBeenCalled();
       });
@@ -587,11 +604,15 @@ export function declareMethodHttpInterceptorWorkerTests(options: SharedHttpInter
 
         await worker.stop();
 
-        const fetchPromise = fetchWithTimeout(baseURL, { method, timeout: 200 });
-        await expectFetchErrorOrPreflightResponse(fetchPromise, {
-          shouldBePreflight: overridesPreflightResponse,
-          canBeAborted: true,
-        });
+        const responsePromise = fetchWithTimeout(baseURL, { method, timeout: 500 });
+
+        if (overridesPreflightResponse) {
+          await expectPreflightResponse(responsePromise);
+        } else if (defaultWorkerOptions.type === 'local') {
+          await expectBypassedResponse(responsePromise);
+        } else {
+          await expectFetchError(responsePromise, { canBeAborted: true });
+        }
 
         expect(spiedRequestHandler).not.toHaveBeenCalled();
       });
@@ -605,11 +626,15 @@ export function declareMethodHttpInterceptorWorkerTests(options: SharedHttpInter
         await worker.stop();
         await worker.start();
 
-        const fetchPromise = fetchWithTimeout(baseURL, { method, timeout: 200 });
-        await expectFetchErrorOrPreflightResponse(fetchPromise, {
-          shouldBePreflight: overridesPreflightResponse,
-          canBeAborted: true,
-        });
+        const responsePromise = fetchWithTimeout(baseURL, { method, timeout: 500 });
+
+        if (overridesPreflightResponse) {
+          await expectPreflightResponse(responsePromise);
+        } else if (defaultWorkerOptions.type === 'local') {
+          await expectBypassedResponse(responsePromise);
+        } else {
+          await expectFetchError(responsePromise, { canBeAborted: true });
+        }
 
         expect(spiedRequestHandler).not.toHaveBeenCalled();
       });
@@ -622,11 +647,15 @@ export function declareMethodHttpInterceptorWorkerTests(options: SharedHttpInter
 
         await promiseIfRemote(worker.clearHandlers(), worker);
 
-        const fetchPromise = fetchWithTimeout(baseURL, { method, timeout: 200 });
-        await expectFetchErrorOrPreflightResponse(fetchPromise, {
-          shouldBePreflight: overridesPreflightResponse,
-          canBeAborted: true,
-        });
+        const responsePromise = fetchWithTimeout(baseURL, { method, timeout: 500 });
+
+        if (overridesPreflightResponse) {
+          await expectPreflightResponse(responsePromise);
+        } else if (defaultWorkerOptions.type === 'local') {
+          await expectBypassedResponse(responsePromise);
+        } else {
+          await expectFetchError(responsePromise, { canBeAborted: true });
+        }
 
         expect(spiedRequestHandler).not.toHaveBeenCalled();
 
@@ -719,11 +748,15 @@ export function declareMethodHttpInterceptorWorkerTests(options: SharedHttpInter
         interceptorsWithHandlers = worker.interceptorsWithHandlers();
         expect(interceptorsWithHandlers).toHaveLength(0);
 
-        const fetchPromise = fetchWithTimeout(baseURL, { method, timeout: 200 });
-        await expectFetchErrorOrPreflightResponse(fetchPromise, {
-          shouldBePreflight: overridesPreflightResponse,
-          canBeAborted: true,
-        });
+        const responsePromise = fetchWithTimeout(baseURL, { method, timeout: 500 });
+
+        if (overridesPreflightResponse) {
+          await expectPreflightResponse(responsePromise);
+        } else if (defaultWorkerOptions.type === 'local') {
+          await expectBypassedResponse(responsePromise);
+        } else {
+          await expectFetchError(responsePromise, { canBeAborted: true });
+        }
 
         expect(okSpiedRequestHandler).toHaveBeenCalledTimes(numberOfRequestsIncludingPreflight * 2);
         expect(noContentSpiedRequestHandler).toHaveBeenCalledTimes(numberOfRequestsIncludingPreflight);

--- a/packages/zimic/src/interceptor/http/interceptorWorker/constants.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/constants.ts
@@ -3,10 +3,10 @@ import { HttpInterceptorType, UnhandledRequestStrategy } from '../interceptor/ty
 export const DEFAULT_UNHANDLED_REQUEST_STRATEGY = Object.freeze({
   local: Object.freeze<UnhandledRequestStrategy.LocalDeclaration>({
     action: 'bypass',
-    logWarning: true,
+    log: true,
   }),
   remote: Object.freeze<UnhandledRequestStrategy.RemoteDeclaration>({
     action: 'reject',
-    logWarning: true,
+    log: true,
   }),
 } satisfies Record<HttpInterceptorType, Readonly<UnhandledRequestStrategy.Declaration>>);

--- a/packages/zimic/src/interceptor/http/interceptorWorker/types/requests.ts
+++ b/packages/zimic/src/interceptor/http/interceptorWorker/types/requests.ts
@@ -11,19 +11,9 @@ export interface HttpResponseFactoryContext<Body extends HttpBody = HttpBody> {
   request: HttpRequest<Body>;
 }
 
-export interface EffectiveHttpResponseFactoryResult<Body extends HttpBody = HttpBody> {
-  bypass?: never;
-  response: HttpResponse<Body>;
+export interface HttpResponseFactoryResult<Body extends HttpBody = HttpBody> {
+  response: HttpResponse<Body> | null;
 }
-
-export interface BypassedHttpResponseFactoryResult {
-  bypass: true;
-  response?: never;
-}
-
-export type HttpResponseFactoryResult<Body extends HttpBody = HttpBody> =
-  | EffectiveHttpResponseFactoryResult<Body>
-  | BypassedHttpResponseFactoryResult;
 
 export type HttpResponseFactory<RequestBody extends HttpBody = HttpBody, ResponseBody extends HttpBody = HttpBody> = (
   context: HttpResponseFactoryContext<RequestBody>,

--- a/packages/zimic/src/interceptor/http/namespace/HttpInterceptorNamespace.ts
+++ b/packages/zimic/src/interceptor/http/namespace/HttpInterceptorNamespace.ts
@@ -15,8 +15,8 @@ export class HttpInterceptorNamespaceDefault {
      *
      * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#unhandled-requests Unhandled requests}
      */
-    get onUnhandledRequest(): UnhandledRequestStrategy.LocalSync;
-    set onUnhandledRequest(strategy: UnhandledRequestStrategy.LocalSync);
+    get onUnhandledRequest(): UnhandledRequestStrategy.Local;
+    set onUnhandledRequest(strategy: UnhandledRequestStrategy.Local);
   };
 
   remote: {
@@ -41,7 +41,7 @@ export class HttpInterceptorNamespaceDefault {
       get onUnhandledRequest() {
         return workerStore.defaultOnUnhandledRequest('local');
       },
-      set onUnhandledRequest(strategy: UnhandledRequestStrategy.LocalSync) {
+      set onUnhandledRequest(strategy: UnhandledRequestStrategy.Local) {
         workerStore.setDefaultOnUnhandledRequest('local', strategy);
       },
     };

--- a/packages/zimic/src/interceptor/http/namespace/HttpInterceptorNamespace.ts
+++ b/packages/zimic/src/interceptor/http/namespace/HttpInterceptorNamespace.ts
@@ -15,8 +15,8 @@ export class HttpInterceptorNamespaceDefault {
      *
      * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#unhandled-requests Unhandled requests}
      */
-    get onUnhandledRequest(): UnhandledRequestStrategy.Local;
-    set onUnhandledRequest(strategy: UnhandledRequestStrategy.Local);
+    get onUnhandledRequest(): UnhandledRequestStrategy.LocalSync;
+    set onUnhandledRequest(strategy: UnhandledRequestStrategy.LocalSync);
   };
 
   remote: {
@@ -41,7 +41,7 @@ export class HttpInterceptorNamespaceDefault {
       get onUnhandledRequest() {
         return workerStore.defaultOnUnhandledRequest('local');
       },
-      set onUnhandledRequest(strategy: UnhandledRequestStrategy.Local) {
+      set onUnhandledRequest(strategy: UnhandledRequestStrategy.LocalSync) {
         workerStore.setDefaultOnUnhandledRequest('local', strategy);
       },
     };

--- a/packages/zimic/tests/setup/global/browser.ts
+++ b/packages/zimic/tests/setup/global/browser.ts
@@ -1,22 +1,31 @@
 import type InterceptorServer from '@/interceptor/server/InterceptorServer';
 
-let server: InterceptorServer | undefined;
+import { setup as sharedSetup, teardown as sharedTeardown } from './shared';
 
-export const GLOBAL_SETUP_SERVER_HOSTNAME = 'localhost';
-export const GLOBAL_SETUP_SERVER_PORT = 3001;
+let interceptorServer: InterceptorServer | undefined;
+
+export const GLOBAL_INTERCEPTOR_SERVER_HOSTNAME = 'localhost';
+export const GLOBAL_INTERCEPTOR_SERVER_PORT = 3001;
+
+// We cannot start interceptor servers in browser environments, so we need to use a global setup script to start the
+// server before the browser tests. The server will be reused across all browser tests.
 
 export async function setup() {
+  await sharedSetup();
+
   const { default: InterceptorServer } = await import('@/interceptor/server/InterceptorServer');
 
-  server = new InterceptorServer({
-    hostname: GLOBAL_SETUP_SERVER_HOSTNAME,
-    port: GLOBAL_SETUP_SERVER_PORT,
+  interceptorServer = new InterceptorServer({
+    hostname: GLOBAL_INTERCEPTOR_SERVER_HOSTNAME,
+    port: GLOBAL_INTERCEPTOR_SERVER_PORT,
     logUnhandledRequests: false,
   });
 
-  await server.start();
+  await interceptorServer.start();
 }
 
 export async function teardown() {
-  await server?.stop();
+  await sharedTeardown();
+
+  await interceptorServer?.stop();
 }

--- a/packages/zimic/tests/setup/global/node.ts
+++ b/packages/zimic/tests/setup/global/node.ts
@@ -1,0 +1,9 @@
+import { setup as sharedSetup, teardown as sharedTeardown } from './shared';
+
+export async function setup() {
+  await sharedSetup();
+}
+
+export async function teardown() {
+  await sharedTeardown();
+}

--- a/packages/zimic/tests/setup/global/shared.ts
+++ b/packages/zimic/tests/setup/global/shared.ts
@@ -1,0 +1,47 @@
+import type { Server } from 'http';
+
+import { HttpHeaders } from '@/http';
+import { startHttpServer, stopHttpServer } from '@/utils/http';
+
+let fallbackServer: Server | undefined;
+
+export const GLOBAL_FALLBACK_SERVER_HOSTNAME = 'localhost';
+export const GLOBAL_FALLBACK_SERVER_PORT = Number(process.env.GLOBAL_FALLBACK_SERVER_PORT);
+
+export const GLOBAL_FALLBACK_SERVER_RESPONSE_STATUS = 200;
+export const GLOBAL_FALLBACK_SERVER_HEADERS = { 'x-global-fallback': 'true' };
+
+// This server is used as a fallback in tests that check if unhandled requests are bypassed. When a request is bypassed,
+// this server will handle it. If the request is rejected, it should not reach this server.
+//
+// By comparing the responses in the tests, we can use this to check if a request was correctly bypassed and reached the
+// real network or was rejected before that.
+
+export async function setup() {
+  const [http, { DEFAULT_ACCESS_CONTROL_HEADERS }] = await Promise.all([
+    import('http'),
+    import('@/interceptor/server'),
+  ]);
+
+  const headers = new HttpHeaders({
+    ...DEFAULT_ACCESS_CONTROL_HEADERS,
+    ...GLOBAL_FALLBACK_SERVER_HEADERS,
+  });
+
+  fallbackServer = http.createServer((_request, response) => {
+    response.setHeaders(headers);
+    response.statusCode = GLOBAL_FALLBACK_SERVER_RESPONSE_STATUS;
+    response.end();
+  });
+
+  await startHttpServer(fallbackServer, {
+    hostname: GLOBAL_FALLBACK_SERVER_HOSTNAME,
+    port: GLOBAL_FALLBACK_SERVER_PORT,
+  });
+}
+
+export async function teardown() {
+  if (fallbackServer) {
+    await stopHttpServer(fallbackServer);
+  }
+}

--- a/packages/zimic/tests/setup/shared.ts
+++ b/packages/zimic/tests/setup/shared.ts
@@ -5,11 +5,11 @@ import { httpInterceptor } from '@/interceptor/http';
 beforeEach(() => {
   httpInterceptor.default.local.onUnhandledRequest = {
     action: 'bypass',
-    logWarning: false,
+    log: false,
   };
 
   httpInterceptor.default.remote.onUnhandledRequest = {
     action: 'reject',
-    logWarning: false,
+    log: false,
   };
 });

--- a/packages/zimic/tests/utils/interceptors.ts
+++ b/packages/zimic/tests/utils/interceptors.ts
@@ -24,22 +24,23 @@ import InterceptorServer from '@/interceptor/server/InterceptorServer';
 import { PossiblePromise } from '@/types/utils';
 import { importCrypto } from '@/utils/crypto';
 import { createURL, ExtendedURL, joinURL } from '@/utils/urls';
-import { GLOBAL_SETUP_SERVER_HOSTNAME, GLOBAL_SETUP_SERVER_PORT } from '@tests/setup/global/browser';
+import { GLOBAL_INTERCEPTOR_SERVER_HOSTNAME, GLOBAL_INTERCEPTOR_SERVER_PORT } from '@tests/setup/global/browser';
+import { GLOBAL_FALLBACK_SERVER_PORT } from '@tests/setup/global/shared';
 
-export async function getBrowserBaseURL(workerType: HttpInterceptorType) {
-  if (workerType === 'local') {
-    return createURL('http://localhost:3000');
+export async function getBrowserBaseURL(type: HttpInterceptorType) {
+  if (type === 'local') {
+    return createURL(`http://localhost:${GLOBAL_FALLBACK_SERVER_PORT}`);
   }
 
   const crypto = await importCrypto();
   const pathPrefix = `path-${crypto.randomUUID()}`;
-  const baseURL = joinURL(`http://${GLOBAL_SETUP_SERVER_HOSTNAME}:${GLOBAL_SETUP_SERVER_PORT}`, pathPrefix);
+  const baseURL = joinURL(`http://${GLOBAL_INTERCEPTOR_SERVER_HOSTNAME}:${GLOBAL_INTERCEPTOR_SERVER_PORT}`, pathPrefix);
   return createURL(baseURL);
 }
 
 export async function getNodeBaseURL(type: HttpInterceptorType, server: InterceptorServer) {
   if (type === 'local') {
-    return createURL('http://localhost:3000');
+    return createURL(`http://localhost:${GLOBAL_FALLBACK_SERVER_PORT}`);
   }
 
   const hostname = server.hostname();

--- a/packages/zimic/vitest.workspace.mts
+++ b/packages/zimic/vitest.workspace.mts
@@ -14,6 +14,10 @@ export default defineWorkspace([
       environment: 'node',
       include: ['./{src,tests,scripts}/**/*.test.ts', './{src,tests,scripts}/**/*.node.test.ts'],
       exclude: ['**/*.browser.test.ts'],
+      globalSetup: './tests/setup/global/node.ts',
+    },
+    define: {
+      'process.env.GLOBAL_FALLBACK_SERVER_PORT': "'3002'",
     },
   },
   ...browserNames.flatMap((browserName) => [
@@ -32,6 +36,9 @@ export default defineWorkspace([
           headless: true,
           screenshotFailures: false,
         },
+      },
+      define: {
+        'process.env.GLOBAL_FALLBACK_SERVER_PORT': "'3003'",
       },
     },
   ]),

--- a/packages/zimic/vitest.workspace.mts
+++ b/packages/zimic/vitest.workspace.mts
@@ -1,11 +1,5 @@
 import { defineWorkspace } from 'vitest/config';
 
-const shouldIncludeExtendedBrowsers = process.env.CI === 'true' || process.env.ALL_BROWSERS === 'true';
-
-const baseBrowserNames = ['chromium'] as const;
-const extendedBrowserNames = [] as const;
-const browserNames = [...baseBrowserNames, ...(shouldIncludeExtendedBrowsers ? extendedBrowserNames : [])];
-
 export default defineWorkspace([
   {
     extends: 'vitest.config.mts',
@@ -20,26 +14,26 @@ export default defineWorkspace([
       'process.env.GLOBAL_FALLBACK_SERVER_PORT': "'3002'",
     },
   },
-  ...browserNames.flatMap((browserName) => [
-    {
-      extends: 'vitest.config.mts',
-      test: {
-        name: `browser-${browserName}`,
-        environment: undefined,
-        include: ['./{src,tests,scripts}/**/*.test.ts', './{src,tests,scripts}/**/*.browser.test.ts'],
-        exclude: ['**/*.node.test.ts'],
-        globalSetup: './tests/setup/global/browser.ts',
-        browser: {
-          name: browserName,
-          provider: 'playwright',
-          enabled: true,
-          headless: true,
-          screenshotFailures: false,
-        },
-      },
-      define: {
-        'process.env.GLOBAL_FALLBACK_SERVER_PORT': "'3003'",
+
+  {
+    extends: 'vitest.config.mts',
+    test: {
+      name: 'browser',
+      environment: undefined,
+      include: ['./{src,tests,scripts}/**/*.test.ts', './{src,tests,scripts}/**/*.browser.test.ts'],
+      exclude: ['**/*.node.test.ts'],
+      globalSetup: './tests/setup/global/browser.ts',
+      browser: {
+        name: 'chromium',
+        provider: 'playwright',
+        enabled: true,
+        headless: true,
+        screenshotFailures: false,
+        fileParallelism: false,
       },
     },
-  ]),
+    define: {
+      'process.env.GLOBAL_FALLBACK_SERVER_PORT': "'3003'",
+    },
+  },
 ]);


### PR DESCRIPTION
### Features
- [#zimic] Added support to reject local unhandled requests with `action: 'reject'`. Previously, local interceptors could only bypass requests.
- [#zimic] Renamed the property `logWarning` to `log` when declaring an unhandled request strategy.

### Tests
- [#zimic] Created a fallback server to differentiate bypassed from rejected requests in local interceptors.

Closes #387.