### PR TITLE
chore(ci): include typescript 5.7 in ci matrix (#495)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -155,6 +155,7 @@ jobs:
           - '5.4'
           - '5.5'
           - '5.6'
+          - '5.7'
 
     env:
       TYPESCRIPT_VERSION: ${{ matrix.typescript-version }}


### PR DESCRIPTION
Closes #495.