### PR TITLE
chore(#zimic): deprecate `handler.bypass()` (#498)

### DIFF
--- a/apps/zimic-test-client/tests/interceptor/thirdParty/shared/default.ts
+++ b/apps/zimic-test-client/tests/interceptor/thirdParty/shared/default.ts
@@ -683,6 +683,7 @@ async function declareDefaultClientTests(options: ClientTestOptionsByWorkerType)
         expectTypeOf(listRequests[0].response.raw.json).toEqualTypeOf<() => Promise<Notification[]>>();
         expect(await listRequests[0].response.raw.json()).toEqual([notification]);
 
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         await listHandler.bypass();
 
         response = await listNotifications(notification.userId);

--- a/docs/wiki/api‐zimic‐interceptor‐http.md
+++ b/docs/wiki/api‐zimic‐interceptor‐http.md
@@ -413,7 +413,10 @@ When targeting a browser environment with a local interceptor, make sure to foll
 
 ### HTTP `interceptor.stop()`
 
-Stops the interceptor. Stopping an interceptor will also clear its registered handlers and responses.
+Stops the interceptor, preventing it from intercepting HTTP requests. Stopped interceptors are automatically cleared,
+exactly as if
+[`interceptor.clear()`](https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-interceptorclear) had been
+called.
 
 ```ts
 await interceptor.stop();
@@ -576,9 +579,9 @@ await fetch('http://localhost:3000/users/1', { method: 'PUT' });
 
 ### HTTP `interceptor.clear()`
 
-Clears all of the [`HttpRequestHandler`](#httprequesthandler) instances created by this interceptor, including their
-registered responses and intercepted requests. After calling this method, the interceptor will no longer intercept any
-requests until new mock responses are registered.
+Clears the interceptor and all of its [`HttpRequestHandler`](#httprequesthandler) instances, including their registered
+responses and intercepted requests. After calling this method, the interceptor will no longer intercept any requests
+until new mock responses are registered.
 
 This method is useful to reset the interceptor mocks between tests.
 

--- a/docs/wiki/api‐zimic‐interceptor‐http.md
+++ b/docs/wiki/api‐zimic‐interceptor‐http.md
@@ -446,13 +446,19 @@ const platform = interceptor.platform();
 ### HTTP `interceptor.<method>(path)`
 
 Creates an [`HttpRequestHandler`](#httprequesthandler) for the given method and path. The path and method must be
-declared in the interceptor schema.
-
-The supported methods are: `get`, `post`, `put`, `patch`, `delete`, `head`, and `options`.
+declared in the interceptor schema. The supported methods are: `get`, `post`, `put`, `patch`, `delete`, `head`, and
+`options`.
 
 When using a [remote interceptor](getting‐started#remote-http-interceptors), creating a handler is an asynchronous
 operation, so you need to `await` it. You can also chain any number of operations and apply them by awaiting the
 handler.
+
+To decide which handler to use when intercepting a request, Zimic finds a handler that matches the request considering
+the interceptor base URL, method, path, and [restrictions](#http-handlerwithrestriction). The handlers are checked from
+the **last** created to the first, so new handlers have preference over old ones. This allows you to declare generic and
+specific handlers based on their order of creation. For example, a generic handler for `GET /users` can return an empty
+list, while a specific handler in a test case can return a list with some users. In this case, the specific handler will
+be considered first as long as it is created **after** the generic one.
 
 <table><tr><td width="900px" valign="top"><details open><summary><b>Using a local interceptor</b></summary>
 
@@ -1431,6 +1437,13 @@ To make the handler match requests again, register a new response with
 This method is useful to skip a handler. It is more gentle than [`handler.clear()`](#http-handlerclear), as it only
 removed the response, keeping restrictions and intercepted requests.
 
+> [!IMPORTANT]
+>
+> This method is deprecated and will be removed soon. You can achieve an equivalent behavior by controlling the order in
+> which handlers are created. Since new handlers are always considered before old ones, you can replace `bypass()` calls
+> with new handler declarations describing your new responses. Learn more at the
+> [`interceptor.<method>(path)` API reference](#http-interceptormethodpath).
+
 <table><tr><td width="900px" valign="top"><details open><summary><b>Using a local interceptor</b></summary>
 
 ```ts
@@ -1475,9 +1488,6 @@ stop matching requests. The next handler, created before this one, that matches 
 present. If not, the requests of the method and path will not be intercepted.
 
 To make the handler match requests again, register a new response with `handler.respond()`.
-
-This method is useful to reset handlers to a clean state between tests. It is more aggressive than
-[`handler.bypass()`](#http-handlerbypass), as it also clears restrictions and intercepted requests.
 
 <table><tr><td width="900px" valign="top"><details open><summary><b>Using a local interceptor</b></summary>
 

--- a/packages/zimic/src/interceptor/http/interceptor/HttpInterceptorClient.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/HttpInterceptorClient.ts
@@ -256,7 +256,7 @@ class HttpInterceptorClient<
     const clearResults: PossiblePromise<AnyHttpRequestHandlerClient | void>[] = [];
 
     for (const method of HTTP_METHODS) {
-      clearResults.push(...this.bypassMethodHandlers(method));
+      clearResults.push(...this.clearMethodHandlers(method));
       this.handlerClientsByMethod[method].clear();
     }
 
@@ -268,16 +268,16 @@ class HttpInterceptorClient<
     }
   }
 
-  private bypassMethodHandlers(method: HttpMethod) {
-    const bypassResults: PossiblePromise<AnyHttpRequestHandlerClient>[] = [];
+  private clearMethodHandlers(method: HttpMethod) {
+    const clearResults: PossiblePromise<AnyHttpRequestHandlerClient>[] = [];
 
     for (const handlers of this.handlerClientsByMethod[method].values()) {
       for (const handler of handlers) {
-        bypassResults.push(handler.bypass());
+        clearResults.push(handler.clear());
       }
     }
 
-    return bypassResults;
+    return clearResults;
   }
 }
 

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/bypass.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/bypass.ts
@@ -60,6 +60,7 @@ export function declareBypassHttpInterceptorTests(options: RuntimeSharedHttpInte
               status: 200,
               headers: DEFAULT_ACCESS_CONTROL_HEADERS,
             })
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
             .bypass(),
           interceptor,
         );
@@ -139,6 +140,7 @@ export function declareBypassHttpInterceptorTests(options: RuntimeSharedHttpInte
         expectTypeOf(withMessageRequest.response.body).toEqualTypeOf<null>();
         expect(withMessageRequest.response.body).toBe(null);
 
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         await promiseIfRemote(noContentHandler.bypass(), interceptor);
 
         response = await fetch(joinURL(baseURL, '/users'), { method });

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/clear.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/clear.ts
@@ -79,7 +79,7 @@ export function declareClearHttpInterceptorTests(options: RuntimeSharedHttpInter
         }
 
         requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+        expect(requests).toHaveLength(0);
       });
     });
 

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/lifeCycle.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/lifeCycle.ts
@@ -92,7 +92,7 @@ export function declareLifeCycleHttpInterceptorTests(options: RuntimeSharedHttpI
         }
 
         requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+        expect(requests).toHaveLength(0);
 
         await interceptor.start();
         expect(interceptor.isRunning()).toBe(true);
@@ -106,7 +106,7 @@ export function declareLifeCycleHttpInterceptorTests(options: RuntimeSharedHttpI
         }
 
         requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+        expect(requests).toHaveLength(0);
       });
     });
 
@@ -160,7 +160,7 @@ export function declareLifeCycleHttpInterceptorTests(options: RuntimeSharedHttpI
           }
 
           requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+          expect(requests).toHaveLength(0);
 
           await interceptor.start();
           expect(interceptor.isRunning()).toBe(true);
@@ -175,7 +175,7 @@ export function declareLifeCycleHttpInterceptorTests(options: RuntimeSharedHttpI
           }
 
           requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+          expect(requests).toHaveLength(0);
         });
       });
     });

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/pathParams.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/pathParams.ts
@@ -97,6 +97,7 @@ export async function declarePathParamsHttpInterceptorTests(options: RuntimeShar
         expectTypeOf(genericRequest.response.body).toEqualTypeOf<null>();
         expect(genericRequest.response.body).toBe(null);
 
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
         await promiseIfRemote(genericHandler.bypass(), interceptor);
 
         const specificHandler = await promiseIfRemote(

--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/unhandledRequests.logging.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/unhandledRequests.logging.ts
@@ -174,6 +174,7 @@ export async function declareUnhandledRequestLoggingHttpInterceptorTests(
                 expect(spies.warn).toHaveBeenCalledTimes(0);
                 expect(spies.error).toHaveBeenCalledTimes(0);
 
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 await promiseIfRemote(handler.bypass(), interceptor);
 
                 const request = new Request(joinURL(baseURL, '/users'), { method });
@@ -233,6 +234,7 @@ export async function declareUnhandledRequestLoggingHttpInterceptorTests(
                 expect(spies.warn).toHaveBeenCalledTimes(0);
                 expect(spies.error).toHaveBeenCalledTimes(0);
 
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 await promiseIfRemote(handler.bypass(), interceptor);
 
                 const request = new Request(joinURL(baseURL, '/users'), {
@@ -453,6 +455,7 @@ export async function declareUnhandledRequestLoggingHttpInterceptorTests(
               expect(spies.warn).toHaveBeenCalledTimes(0);
               expect(spies.error).toHaveBeenCalledTimes(0);
 
+              // eslint-disable-next-line @typescript-eslint/no-deprecated
               await promiseIfRemote(handler.bypass(), interceptor);
 
               const request = new Request(joinURL(baseURL, '/users'), {
@@ -515,6 +518,7 @@ export async function declareUnhandledRequestLoggingHttpInterceptorTests(
                 expect(spies.warn).toHaveBeenCalledTimes(0);
                 expect(spies.error).toHaveBeenCalledTimes(0);
 
+                // eslint-disable-next-line @typescript-eslint/no-deprecated
                 await promiseIfRemote(handler.bypass(), interceptor);
 
                 const request = new Request(joinURL(baseURL, '/users'), {

--- a/packages/zimic/src/interceptor/http/interceptor/types/public.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/types/public.ts
@@ -43,17 +43,20 @@ export interface HttpInterceptor<_Schema extends HttpSchema> {
   start: () => Promise<void>;
 
   /**
-   * Stops the interceptor, preventing it from intercepting HTTP requests.
+   * Stops the interceptor, preventing it from intercepting HTTP requests. Stopped interceptors are automatically
+   * cleared, exactly as if
+   * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-interceptorclear `interceptor.clear()`}
+   * had been called.
    *
    * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-interceptorstop `interceptor.stop()` API reference}
    */
   stop: () => Promise<void>;
 
   /**
-   * Clears all of the
+   * Clears the interceptor and all of its
    * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#httprequesthandler `HttpRequestHandler`}
-   * instances created by this interceptor. After calling this method, the interceptor will no longer intercept any
-   * requests until new mock responses are registered.
+   * instances, including their registered responses and intercepted requests. After calling this method, the
+   * interceptor will no longer intercept any requests until new mock responses are registered.
    *
    * This method is useful to reset the interceptor mocks between tests.
    *

--- a/packages/zimic/src/interceptor/http/requestHandler/HttpRequestHandlerClient.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/HttpRequestHandlerClient.ts
@@ -54,9 +54,7 @@ class HttpRequestHandlerClient<
     return this._path;
   }
 
-  with(
-    restriction: HttpRequestHandlerRestriction<Schema, Method, Path>,
-  ): HttpRequestHandlerClient<Schema, Method, Path, StatusCode> {
+  with(restriction: HttpRequestHandlerRestriction<Schema, Method, Path>): this {
     this.restrictions.push(restriction);
     return this;
   }
@@ -86,15 +84,17 @@ class HttpRequestHandlerClient<
     return typeof declaration === 'function';
   }
 
-  bypass(): HttpRequestHandlerClient<Schema, Method, Path, StatusCode> {
+  /** @deprecated */
+  bypass(): this {
     this.createResponseDeclaration = undefined;
     return this;
   }
 
-  clear(): HttpRequestHandlerClient<Schema, Method, Path, StatusCode> {
+  clear(): this {
     this.restrictions = [];
     this.interceptedRequests = [];
-    return this.bypass();
+    this.createResponseDeclaration = undefined;
+    return this;
   }
 
   async matchesRequest(request: HttpInterceptorRequest<Path, Default<Schema[Path][Method]>>): Promise<boolean> {

--- a/packages/zimic/src/interceptor/http/requestHandler/LocalHttpRequestHandler.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/LocalHttpRequestHandler.ts
@@ -55,6 +55,7 @@ class LocalHttpRequestHandler<
     return newThis;
   }
 
+  /** @deprecated */
   bypass(): this {
     this._client.bypass();
     return this;

--- a/packages/zimic/src/interceptor/http/requestHandler/LocalHttpRequestHandler.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/LocalHttpRequestHandler.ts
@@ -57,6 +57,7 @@ class LocalHttpRequestHandler<
 
   /** @deprecated */
   bypass(): this {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     this._client.bypass();
     return this;
   }

--- a/packages/zimic/src/interceptor/http/requestHandler/RemoteHttpRequestHandler.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/RemoteHttpRequestHandler.ts
@@ -89,6 +89,7 @@ class RemoteHttpRequestHandler<
     return newUnsyncedThis;
   }
 
+  /** @deprecated */
   bypass(): this {
     this._client.bypass();
     return this.unsynced;

--- a/packages/zimic/src/interceptor/http/requestHandler/RemoteHttpRequestHandler.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/RemoteHttpRequestHandler.ts
@@ -91,6 +91,7 @@ class RemoteHttpRequestHandler<
 
   /** @deprecated */
   bypass(): this {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     this._client.bypass();
     return this.unsynced;
   }

--- a/packages/zimic/src/interceptor/http/requestHandler/__tests__/shared/default.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/__tests__/shared/default.ts
@@ -98,6 +98,7 @@ export function declareDefaultHttpRequestHandlerTests(
     const parsedRequest = await HttpInterceptorWorker.parseRawRequest<'/users', MethodSchema>(request);
     expect(await handler.matchesRequest(parsedRequest)).toBe(false);
 
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     await promiseIfRemote(handler.bypass(), interceptor);
     expect(await handler.matchesRequest(parsedRequest)).toBe(false);
 
@@ -110,6 +111,7 @@ export function declareDefaultHttpRequestHandlerTests(
     );
     expect(await handler.matchesRequest(parsedRequest)).toBe(true);
 
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     await promiseIfRemote(handler.bypass(), interceptor);
     expect(await handler.matchesRequest(parsedRequest)).toBe(false);
 
@@ -420,6 +422,7 @@ export function declareDefaultHttpRequestHandlerTests(
     const parsedRequest = await HttpInterceptorWorker.parseRawRequest<'/users', MethodSchema>(request);
     expect(await handler.matchesRequest(parsedRequest)).toBe(false);
 
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     await promiseIfRemote(handler.bypass(), interceptor);
     expect(await handler.matchesRequest(parsedRequest)).toBe(false);
 
@@ -434,6 +437,7 @@ export function declareDefaultHttpRequestHandlerTests(
     );
     expect(await handler.matchesRequest(parsedRequest)).toBe(false);
 
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     await promiseIfRemote(handler.bypass(), interceptor);
     expect(await handler.matchesRequest(parsedRequest)).toBe(false);
 

--- a/packages/zimic/src/interceptor/http/requestHandler/types/public.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/types/public.ts
@@ -240,6 +240,10 @@ export interface LocalHttpRequestHandler<
    * [`handler.clear()`](https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlerclear), as it only
    * removed the response, keeping restrictions and intercepted requests.
    *
+   * @deprecated This method is deprecated and will be removed soon. You can achieve an equivalent behavior by
+   *   controlling the order in which handlers are created. Since new handlers are always considered before old ones,
+   *   you can replace `bypass()` calls with new handler declarations describing your new responses. Learn more at the
+   *   {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-interceptormethodpath `interceptor.<method>(path)` API reference}.
    * @returns The same handler, now without a declared responses.
    * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlerbypass `handler.bypass()` API reference}
    */
@@ -256,10 +260,6 @@ export interface LocalHttpRequestHandler<
    *
    * To make the handler match requests again, register a new response with
    * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlerrespond `handler.respond()`}.
-   *
-   * This method is useful to reset handlers to a clean state between tests. It is more aggressive than
-   * [`handler.bypass()`](https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlerbypass), as it
-   * also clears restrictions and intercepted requests.
    *
    * @returns The same handler, now cleared of any declared responses, restrictions, and intercepted requests.
    * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlerclear `handler.clear()` API reference}
@@ -346,6 +346,10 @@ export interface SyncedRemoteHttpRequestHandler<
    * [`handler.clear()`](https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlerclear), as it only
    * removed the response, keeping restrictions and intercepted requests.
    *
+   * @deprecated This method is deprecated and will be removed soon. You can achieve an equivalent behavior by
+   *   controlling the order in which handlers are created. Since new handlers are always considered before old ones,
+   *   you can replace `bypass()` calls with new handler declarations describing your new responses. Learn more at the
+   *   {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-interceptormethodpath `interceptor.<method>(path)` API reference}.
    * @returns The same handler, now without a declared responses.
    * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlerbypass `handler.bypass()` API reference}
    */
@@ -362,10 +366,6 @@ export interface SyncedRemoteHttpRequestHandler<
    *
    * To make the handler match requests again, register a new response with
    * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlerrespond `handler.respond()`}.
-   *
-   * This method is useful to reset handlers to a clean state between tests. It is more aggressive than
-   * [`handler.bypass()`](https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlerbypass), as it
-   * also clears restrictions and intercepted requests.
    *
    * @returns The same handler, now cleared of any declared responses, restrictions, and intercepted requests.
    * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlerclear `handler.clear()` API reference}


### PR DESCRIPTION
Closes #498.