### PR TITLE
docs(wiki): move `interceptor.clear()` to `beforeEach()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,13 +127,15 @@ beforeAll(async () => {
   await myInterceptor.start();
 });
 
-afterEach(() => {
-  // 4.2. Check that all expected requests were made
-  // https://bit.ly/zimic-interceptor-http#http-interceptorchecktimes
-  myInterceptor.checkTimes();
-
-  // 4.3. Clear interceptors so that no tests affect each other
+beforeEach(() => {
+  // 4.2. Clear interceptors so that no tests affect each other
   // https://bit.ly/zimic-interceptor-http#http-interceptorclear
+  myInterceptor.clear();
+});
+
+afterEach(() => {
+  // 4.3. Check that all expected requests were made
+  // https://bit.ly/zimic-interceptor-http#http-interceptorchecktimes
   myInterceptor.clear();
 });
 

--- a/apps/zimic-test-client/tests/interceptor/thirdParty/shared/default.ts
+++ b/apps/zimic-test-client/tests/interceptor/thirdParty/shared/default.ts
@@ -62,16 +62,18 @@ async function declareDefaultClientTests(options: ClientTestOptionsByWorkerType)
     );
   });
 
+  beforeEach(async () => {
+    await Promise.all(
+      interceptors.map(async (interceptor) => {
+        await interceptor.clear();
+      }),
+    );
+  });
+
   afterEach(async () => {
     await Promise.all(
       interceptors.map(async (interceptor) => {
         await interceptor.checkTimes();
-      }),
-    );
-
-    await Promise.all(
-      interceptors.map(async (interceptor) => {
-        await interceptor.clear();
       }),
     );
   });

--- a/docs/wiki/getting‐started.md
+++ b/docs/wiki/getting‐started.md
@@ -304,14 +304,16 @@ use remote interceptors.
      await myInterceptor.start();
    });
 
+   beforeEach(() => {
+     // Clear interceptors so that no tests affect each other
+     // https://bit.ly/zimic-interceptor-http#http-interceptorclear
+     myInterceptor.clear();
+   });
+
    afterEach(() => {
      // Check that all expected requests were made
      // https://bit.ly/zimic-interceptor-http#http-interceptorchecktimes
      myInterceptor.checkTimes();
-
-     // Clear interceptors so that no tests affect each other
-     // https://bit.ly/zimic-interceptor-http#http-interceptorclear
-     myInterceptor.clear();
    });
 
    afterAll(async () => {
@@ -331,14 +333,16 @@ use remote interceptors.
      await myInterceptor.start();
    });
 
+   beforeEach(() => {
+     // Clear interceptors so that no tests affect each other
+     // https://bit.ly/zimic-interceptor-http#http-interceptorclear
+     await myInterceptor.clear();
+   });
+
    afterEach(() => {
      // Check that all expected requests were made
      // https://bit.ly/zimic-interceptor-http#http-interceptorchecktimes
      await myInterceptor.checkTimes();
-
-     // Clear interceptors so that no tests affect each other
-     // https://bit.ly/zimic-interceptor-http#http-interceptorclear
-     await myInterceptor.clear();
    });
 
    afterAll(async () => {

--- a/docs/wiki/guides‐testing.md
+++ b/docs/wiki/guides‐testing.md
@@ -43,13 +43,17 @@ beforeAll(async () => {
   );
 });
 
+beforeEach(() => {
+  for (const interceptor of interceptors) {
+    // Clear interceptors so that no tests affect each other
+    interceptor.clear();
+  }
+});
+
 afterEach(() => {
   for (const interceptor of interceptors) {
     // Check that all expected requests were made
     interceptor.checkTimes();
-
-    // Clear interceptors so that no tests affect each other
-    interceptor.clear();
   }
 });
 
@@ -81,13 +85,20 @@ beforeAll(async () => {
   );
 });
 
-// Clear all interceptors so that no tests affect each other
-afterEach(async () => {
-  // Important: clearing remote interceptors is asynchronous
+beforeEach(() => {
   await Promise.all(
     interceptors.map(async (interceptor) => {
-      await interceptor.checkTimes();
+      // Clear interceptors so that no tests affect each other
       await interceptor.clear();
+    }),
+  );
+});
+
+afterEach(() => {
+  await Promise.all(
+    interceptors.map(async (interceptor) => {
+      // Check that all expected requests were made
+      await interceptor.checkTimes();
     }),
   );
 });

--- a/examples/with-jest-jsdom/tests/setup.ts
+++ b/examples/with-jest-jsdom/tests/setup.ts
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom/jest-globals';
 
-import { beforeAll, afterEach, afterAll } from '@jest/globals';
+import { beforeAll, afterEach, afterAll, beforeEach } from '@jest/globals';
 
 import githubInterceptor from './interceptors/github';
 
@@ -8,9 +8,12 @@ beforeAll(async () => {
   await githubInterceptor.start();
 });
 
+beforeEach(() => {
+  githubInterceptor.clear();
+});
+
 afterEach(() => {
   githubInterceptor.checkTimes();
-  githubInterceptor.clear();
 });
 
 afterAll(async () => {

--- a/examples/with-jest-node/tests/setup.ts
+++ b/examples/with-jest-node/tests/setup.ts
@@ -1,4 +1,4 @@
-import { beforeAll, afterEach, afterAll } from '@jest/globals';
+import { beforeAll, afterEach, afterAll, beforeEach } from '@jest/globals';
 
 import githubInterceptor from './interceptors/github';
 
@@ -6,9 +6,12 @@ beforeAll(async () => {
   await githubInterceptor.start();
 });
 
+beforeEach(() => {
+  githubInterceptor.clear();
+});
+
 afterEach(() => {
   githubInterceptor.checkTimes();
-  githubInterceptor.clear();
 });
 
 afterAll(async () => {

--- a/examples/with-openapi-typegen/tests/setup.ts
+++ b/examples/with-openapi-typegen/tests/setup.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, afterEach } from 'vitest';
+import { afterAll, beforeAll, afterEach, beforeEach } from 'vitest';
 
 import githubInterceptor from './interceptors/github';
 
@@ -6,9 +6,12 @@ beforeAll(async () => {
   await githubInterceptor.start();
 });
 
+beforeEach(() => {
+  githubInterceptor.clear();
+});
+
 afterEach(() => {
   githubInterceptor.checkTimes();
-  githubInterceptor.clear();
 });
 
 afterAll(async () => {

--- a/examples/with-vitest-browser/tests/setup.ts
+++ b/examples/with-vitest-browser/tests/setup.ts
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom';
 
-import { beforeAll, afterEach, afterAll } from 'vitest';
+import { beforeAll, beforeEach, afterEach, afterAll } from 'vitest';
 
 import githubInterceptor from './interceptors/github';
 
@@ -8,9 +8,12 @@ beforeAll(async () => {
   await githubInterceptor.start();
 });
 
+beforeEach(() => {
+  githubInterceptor.clear();
+});
+
 afterEach(() => {
   githubInterceptor.checkTimes();
-  githubInterceptor.clear();
 });
 
 afterAll(async () => {

--- a/examples/with-vitest-jsdom/tests/setup.ts
+++ b/examples/with-vitest-jsdom/tests/setup.ts
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom';
 
-import { beforeAll, afterEach, afterAll } from 'vitest';
+import { beforeAll, beforeEach, afterEach, afterAll } from 'vitest';
 
 import githubInterceptor from './interceptors/github';
 
@@ -8,9 +8,12 @@ beforeAll(async () => {
   await githubInterceptor.start();
 });
 
+beforeEach(() => {
+  githubInterceptor.clear();
+});
+
 afterEach(() => {
   githubInterceptor.checkTimes();
-  githubInterceptor.clear();
 });
 
 afterAll(async () => {

--- a/examples/with-vitest-node/tests/setup.ts
+++ b/examples/with-vitest-node/tests/setup.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, afterEach } from 'vitest';
+import { afterAll, beforeAll, afterEach, beforeEach } from 'vitest';
 
 import githubInterceptor from './interceptors/github';
 
@@ -6,9 +6,12 @@ beforeAll(async () => {
   await githubInterceptor.start();
 });
 
+beforeEach(() => {
+  githubInterceptor.clear();
+});
+
 afterEach(() => {
   githubInterceptor.checkTimes();
-  githubInterceptor.clear();
 });
 
 afterAll(async () => {


### PR DESCRIPTION
After the new `checkTimes()` API, introduced in https://github.com/zimicjs/zimic/issues/398, the initial examples showed `interceptor.clear()` being called after `interceptor.checkTimes()`. This is not optimal because `checkTimes()` throws an error if some handler has intercepted fewer or more than the defined requests, causing the `clear()` to not run. Because of that, any subsequent test would also fail on the `checkTimes()` call. This PR changes the examples to use `interceptor.clear()` in a `beforeEach` hook, leaving only `interceptor.checkTimes()` in the `afterEach`, making sure one does not block the other from running.

Another strategy is to use a `try..finally` and use a single `afterEach`.

```ts
afterEach(() => {
  try {
    interceptor.checkTimes()
  } finally {
    interceptor.clear()
  }
})
```

We're opting into `beforeEach` + `afterEach` to keep the test hooks flat (minimize nesting) and keep the examples readable and simple.