### PR TITLE
fix(#zimic): prevent stack errors when serializing data

### DIFF
--- a/packages/zimic/package.json
+++ b/packages/zimic/package.json
@@ -98,6 +98,7 @@
     "typegen:fixtures": "tsx ./scripts/dev/typegen/generateFixtureTypes.js",
     "deps:install-playwright": "playwright install chromium",
     "deps:init-msw": "msw init ./public --no-save",
+    "deps:init": "pnpm deps:install-playwright && pnpm deps:init-msw",
     "postinstall": "node -e \"try{require('./dist/scripts/postinstall')}catch(error){console.error(error)}\"",
     "prepublish:patch-relative-paths": "sed -E -i 's/\\]\\(\\.\\/([^\\)]+)\\)/](..\\/..\\/\\1)/g;s/\"\\.\\/([^\"]+)\"/\"..\\/..\\/\\1\"/g'",
     "prepublishOnly": "cp ../../README.md ../../LICENSE.md . && pnpm prepublish:patch-relative-paths README.md"

--- a/packages/zimic/scripts/dev/typegen/generateFixtureTypes.ts
+++ b/packages/zimic/scripts/dev/typegen/generateFixtureTypes.ts
@@ -68,7 +68,9 @@ async function generateFixtureCasesTypes({ fixtureType, fixtureNames }: FixtureT
       batchFixtureCases.map((fixtureCase) => generateFixtureCaseTypes(fixtureType, fixtureCase)),
     );
 
-    outputFilePaths.push(...newOutputFilePaths);
+    for (const outputFilePath of newOutputFilePaths) {
+      outputFilePaths.push(outputFilePath);
+    }
   }
 
   await lintGeneratedFiles(outputFilePaths);

--- a/packages/zimic/src/interceptor/http/interceptor/HttpInterceptorClient.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/HttpInterceptorClient.ts
@@ -274,7 +274,12 @@ class HttpInterceptorClient<
     const clearResults: PossiblePromise<AnyHttpRequestHandlerClient | void>[] = [];
 
     for (const method of HTTP_METHODS) {
-      clearResults.push(...this.clearMethodHandlers(method));
+      const newClearResults = this.clearMethodHandlers(method);
+
+      for (const result of newClearResults) {
+        clearResults.push(result);
+      }
+
       const handlersByPath = this.handlerClientsByMethod[method];
       handlersByPath.clear();
     }

--- a/packages/zimic/src/typegen/openapi/generate.ts
+++ b/packages/zimic/src/typegen/openapi/generate.ts
@@ -149,7 +149,10 @@ async function generateTypesFromOpenAPI({
   const nodes = normalizeRawNodes(rawNodes, context, { prune });
 
   const importDeclarations = createImportDeclarations(context);
-  nodes.unshift(...importDeclarations);
+
+  for (const declaration of importDeclarations) {
+    nodes.unshift(declaration);
+  }
 
   const typeOutput = await convertTypesToString(nodes, { includeComments });
   const formattedOutput = prepareTypeOutputToSave(typeOutput);

--- a/packages/zimic/src/utils/data.ts
+++ b/packages/zimic/src/utils/data.ts
@@ -14,7 +14,15 @@ export async function blobContains(blob: Blob, otherBlob: Blob) {
 
 export function convertArrayBufferToBase64(buffer: ArrayBuffer) {
   if (isClientSide()) {
-    const bufferAsString = String.fromCharCode(...new Uint8Array(buffer));
+    const bufferBytes = new Uint8Array(buffer);
+
+    const bufferAsStringArray = [];
+    for (const byte of bufferBytes) {
+      const byteCode = String.fromCharCode(byte);
+      bufferAsStringArray.push(byteCode);
+    }
+    const bufferAsString = bufferAsStringArray.join('');
+
     return btoa(bufferAsString);
   } else {
     return Buffer.from(buffer).toString('base64');

--- a/packages/zimic/vitest.config.mts
+++ b/packages/zimic/vitest.config.mts
@@ -9,7 +9,7 @@ export default defineConfig({
     hookTimeout: 5000,
     retry: process.env.CI === 'true' ? 1 : 0,
     setupFiles: ['./tests/setup/shared.ts'],
-    maxWorkers: process.env.CI === 'true' ? '100%' : '50%',
+    maxWorkers: process.env.CI === 'true' ? '100%' : '25%',
     minWorkers: 1,
     clearMocks: true,
     coverage: {


### PR DESCRIPTION
The existing code to serialize requests and responses in remote interceptors is as follows:

```ts
const bufferAsString = String.fromCharCode(...new Uint8Array(buffer));
return btoa(bufferAsString);
```

If the buffer is large enough, the argument destructuring `String.fromCharCode(...new Uint8Array(buffer))` may cause a `Max stack size exceeded` error. This changes this code to be a simpler for loop and also updates other parts of the code base to a similar structure.
