### PR TITLE
refactor(#zimic): `error.stack` to `error.cause` in times check errors

### DIFF
--- a/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/times.ts
+++ b/packages/zimic/src/interceptor/http/interceptor/__tests__/shared/times.ts
@@ -79,6 +79,7 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
               firstLine: `Expected exactly ${
                 numberOfRequestsIncludingPreflight
               } request${numberOfRequestsIncludingPreflight === 1 ? '' : 's'}, but got 0.`,
+              numberOfRequests: numberOfRequestsIncludingPreflight,
             },
           );
 
@@ -139,7 +140,10 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
             async () => {
               await promiseIfRemote(interceptor.checkTimes(), interceptor);
             },
-            { firstLine: `Expected exactly ${numberOfRequestsIncludingPreflight * 2} requests, but got 0.` },
+            {
+              firstLine: `Expected exactly ${numberOfRequestsIncludingPreflight * 2} requests, but got 0.`,
+              numberOfRequests: numberOfRequestsIncludingPreflight * 2,
+            },
           );
 
           let response = await fetch(joinURL(baseURL, '/users'), { method });
@@ -156,6 +160,7 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
               firstLine: `Expected exactly ${
                 numberOfRequestsIncludingPreflight * 2
               } requests, but got ${numberOfRequestsIncludingPreflight}.`,
+              numberOfRequests: numberOfRequestsIncludingPreflight * 2,
             },
           );
 
@@ -183,6 +188,7 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
               firstLine: `Expected exactly ${
                 numberOfRequestsIncludingPreflight * 4
               } requests, but got ${numberOfRequestsIncludingPreflight * 3}.`,
+              numberOfRequests: numberOfRequestsIncludingPreflight * 4,
             },
           );
         });
@@ -219,6 +225,7 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
               firstLine: `Expected exactly ${
                 numberOfRequestsIncludingPreflight
               } request${numberOfRequestsIncludingPreflight === 1 ? '' : 's'}, but got 0.`,
+              numberOfRequests: numberOfRequestsIncludingPreflight,
             },
           );
 
@@ -254,6 +261,7 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
               } request${numberOfRequestsIncludingPreflight === 1 ? '' : 's'}, but got ${
                 numberOfRequestsIncludingPreflight * 2
               }.`,
+              numberOfRequests: numberOfRequestsIncludingPreflight,
             },
           );
 
@@ -278,6 +286,7 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
               } request${numberOfRequestsIncludingPreflight === 1 ? '' : 's'}, but got ${
                 numberOfRequestsIncludingPreflight * 3
               }.`,
+              numberOfRequests: numberOfRequestsIncludingPreflight,
             },
           );
         });
@@ -367,6 +376,8 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
               firstLine: `Expected at least ${
                 numberOfRequestsIncludingPreflight * 2
               } and at most ${numberOfRequestsIncludingPreflight * 3} requests, but got 0.`,
+              minNumberOfRequests: numberOfRequestsIncludingPreflight * 2,
+              maxNumberOfRequests: numberOfRequestsIncludingPreflight * 3,
             },
           );
 
@@ -386,6 +397,8 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
               } and at most ${numberOfRequestsIncludingPreflight * 3} requests, but got ${
                 numberOfRequestsIncludingPreflight
               }.`,
+              minNumberOfRequests: numberOfRequestsIncludingPreflight * 2,
+              maxNumberOfRequests: numberOfRequestsIncludingPreflight * 3,
             },
           );
 
@@ -493,6 +506,8 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
               } and at most ${numberOfRequestsIncludingPreflight * 3} requests, but got ${
                 numberOfRequestsIncludingPreflight * 4
               }.`,
+              minNumberOfRequests: numberOfRequestsIncludingPreflight * 2,
+              maxNumberOfRequests: numberOfRequestsIncludingPreflight * 3,
             },
           );
         });
@@ -526,6 +541,8 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
               firstLine: `Expected exactly ${numberOfRequestsIncludingPreflight} request${
                 numberOfRequestsIncludingPreflight === 1 ? '' : 's'
               }, but got 0.`,
+              minNumberOfRequests: numberOfRequestsIncludingPreflight,
+              maxNumberOfRequests: numberOfRequestsIncludingPreflight,
             },
           );
 
@@ -559,6 +576,8 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
               firstLine: `Expected exactly ${numberOfRequestsIncludingPreflight} request${
                 numberOfRequestsIncludingPreflight === 1 ? '' : 's'
               }, but got ${numberOfRequestsIncludingPreflight * 2}.`,
+              minNumberOfRequests: numberOfRequestsIncludingPreflight,
+              maxNumberOfRequests: numberOfRequestsIncludingPreflight,
             },
           );
         });
@@ -594,7 +613,7 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
             async () => {
               await promiseIfRemote(interceptor.checkTimes(), interceptor);
             },
-            { firstLine: 'Expected exactly 1 request, but got 0.' },
+            { firstLine: 'Expected exactly 1 request, but got 0.', numberOfRequests: 1 },
           );
 
           const responsePromise = fetch(joinURL(baseURL, '/users'), { method });
@@ -612,7 +631,7 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
             async () => {
               await promiseIfRemote(interceptor.checkTimes(), interceptor);
             },
-            { firstLine: 'Expected exactly 1 request, but got 0.' },
+            { firstLine: 'Expected exactly 1 request, but got 0.', numberOfRequests: 1 },
           );
         });
       });
@@ -639,7 +658,7 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
             async () => {
               await promiseIfRemote(interceptor.checkTimes(), interceptor);
             },
-            { firstLine: 'Expected exactly 1 request, but got 0.' },
+            { firstLine: 'Expected exactly 1 request, but got 0.', numberOfRequests: 1 },
           );
 
           const responsePromise = fetch(joinURL(baseURL, '/users'), { method });
@@ -657,7 +676,7 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
             async () => {
               await promiseIfRemote(interceptor.checkTimes(), interceptor);
             },
-            { firstLine: 'Expected exactly 1 request, but got 0.' },
+            { firstLine: 'Expected exactly 1 request, but got 0.', numberOfRequests: 1 },
           );
         });
       });
@@ -690,7 +709,7 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
             async () => {
               await promiseIfRemote(interceptor.checkTimes(), interceptor);
             },
-            { firstLine: 'Expected exactly 1 request, but got 0.' },
+            { firstLine: 'Expected exactly 1 request, but got 0.', numberOfRequests: 1 },
           );
 
           const responsePromise = fetch(joinURL(baseURL, '/users/other'), { method });
@@ -708,7 +727,7 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
             async () => {
               await promiseIfRemote(interceptor.checkTimes(), interceptor);
             },
-            { firstLine: 'Expected exactly 1 request, but got 0.' },
+            { firstLine: 'Expected exactly 1 request, but got 0.', numberOfRequests: 1 },
           );
         });
       });

--- a/packages/zimic/src/interceptor/http/requestHandler/__tests__/shared/times.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/__tests__/shared/times.ts
@@ -59,7 +59,7 @@ export function declareTimesHttpRequestHandlerTests(
         async () => {
           await promiseIfRemote(handler.checkTimes(), handler);
         },
-        { firstLine: 'Expected exactly 1 request, but got 0.' },
+        { firstLine: 'Expected exactly 1 request, but got 0.', numberOfRequests: 1 },
       );
 
       const request = new Request(joinURL(baseURL, '/users'), { method: 'POST' });
@@ -86,7 +86,7 @@ export function declareTimesHttpRequestHandlerTests(
         async () => {
           await promiseIfRemote(handler.checkTimes(), handler);
         },
-        { firstLine: 'Expected exactly 2 requests, but got 0.' },
+        { firstLine: 'Expected exactly 2 requests, but got 0.', minNumberOfRequests: 2 },
       );
 
       const request = new Request(joinURL(baseURL, '/users'), { method: 'POST' });
@@ -98,7 +98,7 @@ export function declareTimesHttpRequestHandlerTests(
         async () => {
           await promiseIfRemote(handler.checkTimes(), handler);
         },
-        { firstLine: 'Expected exactly 2 requests, but got 1.' },
+        { firstLine: 'Expected exactly 2 requests, but got 1.', minNumberOfRequests: 2 },
       );
 
       expect(await handler.matchesRequest(parsedRequest)).toBe(true);
@@ -111,7 +111,7 @@ export function declareTimesHttpRequestHandlerTests(
         async () => {
           await promiseIfRemote(handler.checkTimes(), handler);
         },
-        { firstLine: 'Expected exactly 4 requests, but got 3.' },
+        { firstLine: 'Expected exactly 4 requests, but got 3.', minNumberOfRequests: 4 },
       );
     });
 
@@ -124,7 +124,7 @@ export function declareTimesHttpRequestHandlerTests(
         async () => {
           await promiseIfRemote(handler.checkTimes(), handler);
         },
-        { firstLine: 'Expected exactly 1 request, but got 0.' },
+        { firstLine: 'Expected exactly 1 request, but got 0.', numberOfRequests: 1 },
       );
 
       const request = new Request(joinURL(baseURL, '/users'), { method: 'POST' });
@@ -139,7 +139,7 @@ export function declareTimesHttpRequestHandlerTests(
         async () => {
           await promiseIfRemote(handler.checkTimes(), handler);
         },
-        { firstLine: 'Expected exactly 1 request, but got 2.' },
+        { firstLine: 'Expected exactly 1 request, but got 2.', numberOfRequests: 1 },
       );
 
       expect(await handler.matchesRequest(parsedRequest)).toBe(false);
@@ -148,7 +148,7 @@ export function declareTimesHttpRequestHandlerTests(
         async () => {
           await promiseIfRemote(handler.checkTimes(), handler);
         },
-        { firstLine: 'Expected exactly 1 request, but got 3.' },
+        { firstLine: 'Expected exactly 1 request, but got 3.', numberOfRequests: 1 },
       );
     });
   });
@@ -183,7 +183,11 @@ export function declareTimesHttpRequestHandlerTests(
         async () => {
           await promiseIfRemote(handler.checkTimes(), handler);
         },
-        { firstLine: 'Expected at least 2 and at most 3 requests, but got 0.' },
+        {
+          firstLine: 'Expected at least 2 and at most 3 requests, but got 0.',
+          minNumberOfRequests: 2,
+          maxNumberOfRequests: 3,
+        },
       );
 
       const request = new Request(joinURL(baseURL, '/users'), { method: 'POST' });
@@ -195,7 +199,11 @@ export function declareTimesHttpRequestHandlerTests(
         async () => {
           await promiseIfRemote(handler.checkTimes(), handler);
         },
-        { firstLine: 'Expected at least 2 and at most 3 requests, but got 1.' },
+        {
+          firstLine: 'Expected at least 2 and at most 3 requests, but got 1.',
+          minNumberOfRequests: 2,
+          maxNumberOfRequests: 3,
+        },
       );
 
       expect(await handler.matchesRequest(parsedRequest)).toBe(true);
@@ -235,7 +243,11 @@ export function declareTimesHttpRequestHandlerTests(
         async () => {
           await promiseIfRemote(handler.checkTimes(), handler);
         },
-        { firstLine: 'Expected at least 2 and at most 3 requests, but got 4.' },
+        {
+          firstLine: 'Expected at least 2 and at most 3 requests, but got 4.',
+          minNumberOfRequests: 2,
+          maxNumberOfRequests: 3,
+        },
       );
     });
 
@@ -258,7 +270,11 @@ export function declareTimesHttpRequestHandlerTests(
         async () => {
           await promiseIfRemote(handler.checkTimes(), handler);
         },
-        { firstLine: 'Expected at least 0 and at most 1 request, but got 2.' },
+        {
+          firstLine: 'Expected at least 0 and at most 1 request, but got 2.',
+          minNumberOfRequests: 0,
+          maxNumberOfRequests: 1,
+        },
       );
     });
 
@@ -271,7 +287,7 @@ export function declareTimesHttpRequestHandlerTests(
         async () => {
           await promiseIfRemote(handler.checkTimes(), handler);
         },
-        { firstLine: 'Expected exactly 1 request, but got 0.' },
+        { firstLine: 'Expected exactly 1 request, but got 0.', minNumberOfRequests: 1, maxNumberOfRequests: 1 },
       );
 
       const request = new Request(joinURL(baseURL, '/users'), { method: 'POST' });
@@ -286,7 +302,7 @@ export function declareTimesHttpRequestHandlerTests(
         async () => {
           await promiseIfRemote(handler.checkTimes(), handler);
         },
-        { firstLine: 'Expected exactly 1 request, but got 2.' },
+        { firstLine: 'Expected exactly 1 request, but got 2.', minNumberOfRequests: 1, maxNumberOfRequests: 1 },
       );
     });
 
@@ -299,7 +315,7 @@ export function declareTimesHttpRequestHandlerTests(
         async () => {
           await promiseIfRemote(handler.checkTimes(), handler);
         },
-        { firstLine: 'Expected exactly 2 requests, but got 0.' },
+        { firstLine: 'Expected exactly 2 requests, but got 0.', minNumberOfRequests: 2, maxNumberOfRequests: 2 },
       );
 
       const request = new Request(joinURL(baseURL, '/users'), { method: 'POST' });
@@ -311,7 +327,7 @@ export function declareTimesHttpRequestHandlerTests(
         async () => {
           await promiseIfRemote(handler.checkTimes(), handler);
         },
-        { firstLine: 'Expected exactly 2 requests, but got 1.' },
+        { firstLine: 'Expected exactly 2 requests, but got 1.', minNumberOfRequests: 2, maxNumberOfRequests: 2 },
       );
 
       expect(await handler.matchesRequest(parsedRequest)).toBe(true);
@@ -323,7 +339,7 @@ export function declareTimesHttpRequestHandlerTests(
         async () => {
           await promiseIfRemote(handler.checkTimes(), handler);
         },
-        { firstLine: 'Expected exactly 2 requests, but got 3.' },
+        { firstLine: 'Expected exactly 2 requests, but got 3.', minNumberOfRequests: 2, maxNumberOfRequests: 2 },
       );
     });
   });
@@ -339,7 +355,7 @@ export function declareTimesHttpRequestHandlerTests(
         async () => {
           await promiseIfRemote(handler.checkTimes(), handler);
         },
-        { firstLine: 'Expected exactly 1 request, but got 0.' },
+        { firstLine: 'Expected exactly 1 request, but got 0.', numberOfRequests: 1 },
       );
 
       const request = new Request(joinURL(baseURL, '/users'), { method: 'POST' });
@@ -351,7 +367,7 @@ export function declareTimesHttpRequestHandlerTests(
         async () => {
           await promiseIfRemote(handler.checkTimes(), handler);
         },
-        { firstLine: 'Expected exactly 1 request, but got 0.' },
+        { firstLine: 'Expected exactly 1 request, but got 0.', numberOfRequests: 1 },
       );
     });
 
@@ -362,7 +378,7 @@ export function declareTimesHttpRequestHandlerTests(
         async () => {
           await promiseIfRemote(handler.checkTimes(), handler);
         },
-        { firstLine: 'Expected exactly 1 request, but got 0.' },
+        { firstLine: 'Expected exactly 1 request, but got 0.', numberOfRequests: 1 },
       );
 
       const request = new Request(joinURL(baseURL, '/users'), { method: 'POST' });
@@ -374,7 +390,7 @@ export function declareTimesHttpRequestHandlerTests(
         async () => {
           await promiseIfRemote(handler.checkTimes(), handler);
         },
-        { firstLine: 'Expected exactly 1 request, but got 0.' },
+        { firstLine: 'Expected exactly 1 request, but got 0.', numberOfRequests: 1 },
       );
     });
   });
@@ -389,7 +405,7 @@ export function declareTimesHttpRequestHandlerTests(
         async () => {
           await promiseIfRemote(handler.checkTimes(), handler);
         },
-        { firstLine: 'Expected exactly 1 request, but got 0.' },
+        { firstLine: 'Expected exactly 1 request, but got 0.', numberOfRequests: 1 },
       );
 
       handler.clear();
@@ -421,7 +437,11 @@ export function declareTimesHttpRequestHandlerTests(
         async () => {
           await promiseIfRemote(handler.checkTimes(), handler);
         },
-        { firstLine: 'Expected at least 1 and at most 3 requests, but got 0.' },
+        {
+          firstLine: 'Expected at least 1 and at most 3 requests, but got 0.',
+          minNumberOfRequests: 1,
+          maxNumberOfRequests: 3,
+        },
       );
 
       handler.clear();

--- a/packages/zimic/src/interceptor/http/requestHandler/__tests__/shared/utils.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/__tests__/shared/utils.ts
@@ -25,20 +25,9 @@ export async function expectTimesCheckError(callback: () => Promise<void> | void
 
   const splitMessage = timesCheckError!.message.split('\n');
 
-  const headerLines = splitMessage.slice(0, 3);
-  expect(headerLines).toEqual([firstLine, '', 'The failed `handler.times()` was declared at: ']);
-
-  const stackTraceLines = splitMessage.slice(3, -2);
-  expect(stackTraceLines.length).toBeGreaterThan(1);
-
-  expect(stackTraceLines[0]).toEqual(expect.stringMatching(/    [^ ]+\/src\/[^ ]+\/__tests__\/[^ ]+\.ts:\d+:\d+/));
-
-  for (const stackTraceLine of stackTraceLines.slice(1)) {
-    expect(stackTraceLine).toEqual(expect.stringMatching(/    at .+/));
-  }
-
-  expect(splitMessage.at(-2)).toBe('');
-  expect(splitMessage.at(-1)).toBe(
+  expect(splitMessage).toEqual([
+    firstLine,
+    '',
     'Learn more: https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlertimes',
-  );
+  ]);
 }

--- a/packages/zimic/src/interceptor/http/requestHandler/errors/TimesCheckError.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/errors/TimesCheckError.ts
@@ -4,10 +4,8 @@ class TimesCheckError extends TypeError {
   constructor(options: {
     numberOfRequests: number;
     limits: { min: number; max: number };
-    timesStack: string | undefined;
+    declarationError: Error | undefined;
   }) {
-    const timesStackWithoutInternalCalls = options.timesStack?.replace(/([^\n]+\n\s*){4}at /, '');
-
     const message = [
       'Expected ',
       options.limits.min === options.limits.max ? 'exactly ' : 'at least ',
@@ -21,11 +19,7 @@ class TimesCheckError extends TypeError {
 
       ', but got ',
       options.numberOfRequests,
-
-      '.\n\n',
-
-      timesStackWithoutInternalCalls &&
-        `The failed \`handler.times()\` was declared at: \n    ${timesStackWithoutInternalCalls}`,
+      '.',
 
       '\n\nLearn more: https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlertimes',
     ]
@@ -34,6 +28,7 @@ class TimesCheckError extends TypeError {
 
     super(message);
     this.name = 'TimesCheckError';
+    this.cause = options.declarationError;
   }
 }
 

--- a/packages/zimic/src/interceptor/http/requestHandler/errors/TimesDeclarationError.ts
+++ b/packages/zimic/src/interceptor/http/requestHandler/errors/TimesDeclarationError.ts
@@ -1,0 +1,10 @@
+class TimesDeclarationError extends Error {
+  constructor(minNumberOfRequests: number, maxNumberOfRequests?: number) {
+    super('declared at:');
+    this.name = `handler.times(${minNumberOfRequests}${
+      maxNumberOfRequests === undefined ? '' : `, ${maxNumberOfRequests}`
+    })`;
+  }
+}
+
+export default TimesDeclarationError;

--- a/packages/zimic/src/utils/runtime.ts
+++ b/packages/zimic/src/utils/runtime.ts
@@ -1,3 +1,0 @@
-export function getCurrentStack() {
-  return new Error().stack;
-}


### PR DESCRIPTION
Following https://github.com/vitest-dev/vitest/issues/7370, `error.stack` has proven to be unreliable in [Vitest browser mode](https://vitest.dev/guide/browser). The value in that property does not point to the correct line and column in most cases, and the logged stack trace is not very helpful because it contains `http://...` links instead of file paths.

This PR refactors the code to no longer depend on `error.stack`. Instead, we create a `TimesDeclarationError` when `handler.times()` is called, in order to save the correct stack trace. The declaration error is then used as `cause` in `TImesCheckError` instances, which are printed correctly by Vitest.

<details>
<summary>Example error log in Vitest (browser mode on):</summary>

```
 FAIL   chromium  tests/example.test.ts > Example tests > should render a GitHub repository, if found
TimesCheckError: Expected exactly 2 requests, but got 1.

Learn more: https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlertimes
 ❯ tests/setup.ts:16:20
     14| 
     15| afterEach(() => {
     16|   githubInterceptor.checkTimes();
       |                    ^
     17| });
     18| 

Caused by: handler.times(2): declared at:
 ❯ tests/example.test.ts:31:7
```

</details>

<details>
<summary>Example error log in Vitest (browser mode off):</summary>

```
 FAIL  tests/example.test.ts > Example tests > should render a GitHub repository, if found
TimesCheckError: Expected exactly 2 requests, but got 1.

Learn more: https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlertimes
 ❯ HttpRequestHandlerClient.checkTimes ../../packages/zimic/src/interceptor/http/requestHandler/HttpRequestHandlerClient.ts:119:13
 ❯ HttpInterceptorClient.checkTimes ../../packages/zimic/src/interceptor/http/interceptor/HttpInterceptorClient.ts:263:19
 ❯ LocalHttpInterceptor.checkTimes ../../packages/zimic/src/interceptor/http/interceptor/LocalHttpInterceptor.ts:99:18
 ❯ tests/setup.ts:16:21
     14| 
     15| afterEach(() => {
     16|   githubInterceptor.checkTimes();
       |                     ^
     17| });
     18| 

Caused by: handler.times(2): declared at:
 ❯ HttpRequestHandlerClient.times ../../packages/zimic/src/interceptor/http/requestHandler/HttpRequestHandlerClient.ts:108:34
 ❯ LocalHttpRequestHandler.times ../../packages/zimic/src/interceptor/http/requestHandler/LocalHttpRequestHandler.ts:59:18
 ❯ tests/example.test.ts:29:8
```

</details>

<details>
<summary>Example error log in Jest:</summary>

```
  ● Example tests › should return a GitHub repository, if found

    TimesCheckError: Expected exactly 2 requests, but got 1.

    Learn more: https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlertimes

      117 |
      118 |     if (!isWithinLimits) {
    > 119 |       throw new TimesCheckError({
          |             ^
      120 |         limits: this.limits.numberOfRequests,
      121 |         numberOfRequests: this.numberOfMatchedRequests,
      122 |         declarationError: this.timesDeclarationError,

      at _class8.checkTimes (../../packages/zimic/src/interceptor/http/requestHandler/HttpRequestHandlerClient.ts:119:13)
      at _class15.checkTimes (../../packages/zimic/src/interceptor/http/interceptor/HttpInterceptorClient.ts:263:19)
      at _class26.checkTimes (../../packages/zimic/src/interceptor/http/interceptor/LocalHttpInterceptor.ts:99:18)
      at Object.checkTimes (tests/setup.ts:14:21)

    Cause:
    handler.times(2): declared at:

      106 |     };
      107 |
    > 108 |     this.timesDeclarationError = new TimesDeclarationError(minNumberOfRequests, maxNumberOfRequests);
          |                                  ^
      109 |
      110 |     return this;
      111 |   }

      at _class8.times (../../packages/zimic/src/interceptor/http/requestHandler/HttpRequestHandlerClient.ts:108:34)
      at _class9.times (../../packages/zimic/src/interceptor/http/requestHandler/LocalHttpRequestHandler.ts:59:18)
      at Object.times (tests/example.test.ts:32:8)
```

</details>