### PR TITLE
fix(#zimic): abort pending messages from closed sockets

### DIFF
--- a/packages/zimic/src/interceptor/server/InterceptorServer.ts
+++ b/packages/zimic/src/interceptor/server/InterceptorServer.ts
@@ -333,14 +333,22 @@ class InterceptorServer implements PublicInterceptorServer {
     const handler = this.findHttpHandlerByRequestBaseURL(request);
 
     if (handler) {
-      const { wasLogged: wasRequestLoggedByRemoteInterceptor } = await webSocketServer.request(
-        'interceptors/responses/unhandled',
-        { request: serializedRequest },
-        { sockets: [handler.socket] },
-      );
+      try {
+        const { wasLogged: wasRequestLoggedByRemoteInterceptor } = await webSocketServer.request(
+          'interceptors/responses/unhandled',
+          { request: serializedRequest },
+          { sockets: [handler.socket] },
+        );
 
-      if (wasRequestLoggedByRemoteInterceptor) {
-        return;
+        if (wasRequestLoggedByRemoteInterceptor) {
+          return;
+        }
+      } catch (error) {
+        const isMessageAbortError = error instanceof WebSocketMessageAbortError;
+
+        if (!isMessageAbortError) {
+          throw error;
+        }
       }
     }
 

--- a/packages/zimic/src/interceptor/server/InterceptorServer.ts
+++ b/packages/zimic/src/interceptor/server/InterceptorServer.ts
@@ -344,8 +344,12 @@ class InterceptorServer implements PublicInterceptorServer {
           return;
         }
       } catch (error) {
+        /* istanbul ignore next -- @preserve
+         * This try..catch is for the case when the remote interceptor web socket client is closed before responding.
+         * Since simulating this scenario is difficult, we are ignoring this branch fow now. */
         const isMessageAbortError = error instanceof WebSocketMessageAbortError;
 
+        /* istanbul ignore next -- @preserve */
         if (!isMessageAbortError) {
           throw error;
         }

--- a/packages/zimic/src/webSocket/WebSocketHandler.ts
+++ b/packages/zimic/src/webSocket/WebSocketHandler.ts
@@ -179,6 +179,7 @@ abstract class WebSocketHandler<Schema extends WebSocket.ServiceSchema> {
   }
 
   private removeSocket(socket: ClientSocket) {
+    this.abortSocketMessages([socket]);
     this.sockets.delete(socket);
   }
 


### PR DESCRIPTION
Zimic is sometimes throwing `WebSocketMesageTimeoutError` instances in highly concurrent tests using remote interceptors. This is likely caused by our current server web socket implementation not aborting pending replies when the client web socket is closed unexpectedly. This pull request fixes that.