### PR TITLE
fix(#zimic): discard pending replies after interceptor is stopped

### DIFF
--- a/packages/zimic/src/webSocket/WebSocketHandler.ts
+++ b/packages/zimic/src/webSocket/WebSocketHandler.ts
@@ -272,7 +272,11 @@ abstract class WebSocketHandler<Schema extends WebSocket.ServiceSchema> {
     },
   ) {
     const reply = await this.createReplyMessage(request, replyData);
-    this.sendMessage(reply, options.sockets);
+
+    // If this handler received a request and was stopped before responding, discard any pending replies.
+    if (this.isRunning()) {
+      this.sendMessage(reply, options.sockets);
+    }
   }
 
   private async createReplyMessage<Channel extends WebSocket.EventWithReplyServiceChannel<Schema>>(


### PR DESCRIPTION
If a remote interceptor is stopped before responding to an interceptor server with a response declaration, Zimic currently logs a `NotStartedWebSocketHandlerError`. This log is unnecessary and Zimic should instead discard pending web socket replies after the interceptor is stopped.