### PR TITLE
docs(example-vitest-browser): remove unnecessary import

### DIFF
--- a/examples/with-vitest-browser/README.md
+++ b/examples/with-vitest-browser/README.md
@@ -32,12 +32,6 @@ where the repository is found and another where it is not.
 - Test setup file: [`tests/setup.ts`](./tests/setup.ts)
 - Vitest configuration: [`vitest.config.mts`](./vitest.config.mts)
 
-> [!IMPORTANT]
->
-> As a workaround, the setup file must be imported from each test file. Currently, Browser Mode is experimental and
-> Vitest runs the setup file in a different process than the test files, so the worker started on
-> [`tests/setup.ts`](./tests/setup.ts) is not shared between them.
-
 ## Running
 
 1. Clone this example:

--- a/examples/with-vitest-browser/tests/example.test.ts
+++ b/examples/with-vitest-browser/tests/example.test.ts
@@ -5,8 +5,6 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import renderApp, { GitHubRepository } from '../src/app';
 import githubInterceptor from './interceptors/github';
 
-import './setup';
-
 describe('Example tests', () => {
   const ownerName = 'owner';
   const repositoryName = 'example';


### PR DESCRIPTION
The vitest-browser example had an explicit import to the test setup file, as was necessary up to Vitest 2. [This import was explained in the README](https://github.com/zimicjs/zimic/blob/1d09b6632951be2623a1db3fa6378371e55ac444/examples/with-vitest-browser/README.md?plain=1#L35-L39) and apparently is no longer necessary. The tests continue to pass without it.