### PR TITLE
fix(ci): read commit user details as inputs (#565)

### DIFF
--- a/.github/actions/zimic-bump-version/action.yaml
+++ b/.github/actions/zimic-bump-version/action.yaml
@@ -75,7 +75,7 @@ runs:
         echo 'Pushing changes...'
 
         numberOfPushRetries=0
-        maxNumberOfPushRetries=3
+        maxNumberOfPushRetries=5
 
         git config pull.rebase true
 

--- a/.github/actions/zimic-release-docs/action.yaml
+++ b/.github/actions/zimic-release-docs/action.yaml
@@ -28,6 +28,7 @@ runs:
       id: zimic-version
       uses: ./zimic/.github/actions/zimic-version
       with:
+        project-name: ${{ inputs.project-name }}
         project-directory: zimic/${{ inputs.project-directory }}
         validate-ref-name: ${{ inputs.ref_name }}
 

--- a/.github/actions/zimic-release-docs/action.yaml
+++ b/.github/actions/zimic-release-docs/action.yaml
@@ -62,7 +62,7 @@ runs:
         echo 'Pushing changes...'
 
         numberOfPushRetries=0
-        maxNumberOfPushRetries=3
+        maxNumberOfPushRetries=5
 
         until git push -u origin HEAD --no-verify; do
           if [[ $numberOfPushRetries -gt $maxNumberOfPushRetries ]]; then

--- a/.github/actions/zimic-release-docs/action.yaml
+++ b/.github/actions/zimic-release-docs/action.yaml
@@ -14,6 +14,12 @@ inputs:
   wiki-ssh-key:
     description: The SSH key to push to the wiki repository
     required: true
+  commit-user-name:
+    description: Commit user name
+    required: true
+  commit-user-email:
+    description: Commit user email
+    required: true
 
 runs:
   using: composite
@@ -23,7 +29,7 @@ runs:
       uses: ./zimic/.github/actions/zimic-version
       with:
         project-directory: zimic/${{ inputs.project-directory }}
-        validate-ref-name: ${{ github.ref_name }}
+        validate-ref-name: ${{ inputs.ref_name }}
 
     - name: Checkout wiki
       uses: actions/checkout@v4
@@ -38,19 +44,19 @@ runs:
       working-directory: zimic
       shell: bash
       run: |
-        bash scripts/docs/sync-wiki.sh '${{ github.ref_name }}'
+        bash scripts/docs/sync-wiki.sh '${{ inputs.ref_name }}'
 
     - name: Commit and push wiki changes
       if: ${{ steps.zimic-version.outputs.label == 'latest' }}
       working-directory: zimic.wiki
       shell: bash
       run: |
-        git config user.name '${{ vars.RELEASE_COMMIT_USER_NAME }}'
-        git config user.email '${{ vars.RELEASE_COMMIT_USER_EMAIL }}'
+        git config user.name '${{ inputs.commit-user-name }}'
+        git config user.email '${{ inputs.commit-user-email }}'
 
         echo 'Committing changes...'
 
-        git add .
+        git add --all
         git commit -m 'docs(wiki): ${{ inputs.project-name }}@${{ steps.zimic-version.outputs.value }}'
           
         echo 'Pushing changes...'

--- a/.github/actions/zimic-release-npm-test/action.yaml
+++ b/.github/actions/zimic-release-npm-test/action.yaml
@@ -20,7 +20,7 @@ runs:
       uses: ./.github/actions/zimic-version
       with:
         project-directory: ${{ inputs.project-directory }}
-        validate-ref-name: ${{ github.ref_name }}
+        validate-ref-name: ${{ inputs.ref_name }}
 
     - name: Set up Zimic
       uses: ./.github/actions/zimic-setup

--- a/.github/actions/zimic-release-npm-test/action.yaml
+++ b/.github/actions/zimic-release-npm-test/action.yaml
@@ -19,6 +19,7 @@ runs:
       id: zimic-version
       uses: ./.github/actions/zimic-version
       with:
+        project-name: ${{ inputs.project-name }}
         project-directory: ${{ inputs.project-directory }}
         validate-ref-name: ${{ inputs.ref_name }}
 

--- a/.github/actions/zimic-release-npm/action.yaml
+++ b/.github/actions/zimic-release-npm/action.yaml
@@ -22,6 +22,7 @@ runs:
       id: zimic-version
       uses: ./.github/actions/zimic-version
       with:
+        project-name: ${{ inputs.project-name }}
         project-directory: ${{ inputs.project-directory }}
         validate-ref-name: ${{ inputs.ref_name }}
 

--- a/.github/actions/zimic-version/action.yaml
+++ b/.github/actions/zimic-version/action.yaml
@@ -2,6 +2,9 @@ name: Get Zimic Version
 description: Get Zimic Version
 
 inputs:
+  project-name:
+    description: Project name
+    required: true
   project-directory:
     description: Project directory
     required: true
@@ -33,7 +36,7 @@ runs:
       if: ${{ inputs.validate-ref-name != '' }}
       working-directory: ${{ inputs.project-directory }}
       run: |
-        if [[ '${{ inputs.validate-ref-name }}' != 'v${{ steps.version.outputs.value }}' ]]; then
+        if [[ '${{ inputs.validate-ref-name }}' != 'v${{ steps.version.outputs.value }}' && '${{ inputs.validate-ref-name }}' != '${{ inputs.project-name }}@${{ steps.version.outputs.value }}' ]]; then
           echo "The ref name '${{ inputs.validate-ref-name }}' does not match the package version 'v${{ steps.version.outputs.value }}'." >&2
           exit 1
         fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,16 +16,17 @@ env:
   CI: true
 
   TURBO_TOKEN:
-    ${{ !(github.event_name == 'pull_request' && startsWith(github.event.pull_request.base.ref, 'v')) &&
-    secrets.TURBO_REMOTE_CACHE_TOKEN || '' }}
+    ${{ !(github.event_name == 'pull_request' && (startsWith(github.event.pull_request.base.ref, 'v') ||
+    startsWith(github.event.pull_request.base.ref, '@zimic/'))) && secrets.TURBO_REMOTE_CACHE_TOKEN || '' }}
   TURBO_TEAM:
-    ${{ !(github.event_name == 'pull_request' && startsWith(github.event.pull_request.base.ref, 'v')) &&
-    secrets.TURBO_REMOTE_CACHE_TEAM || '' }}
+    ${{ !(github.event_name == 'pull_request' && (startsWith(github.event.pull_request.base.ref, 'v') ||
+    startsWith(github.event.pull_request.base.ref, '@zimic/'))) && secrets.TURBO_REMOTE_CACHE_TEAM || '' }}
 
   TURBO_LOG_ORDER: stream
   TURBO_FILTERS:
-    ${{ github.event_name == 'pull_request' && startsWith(github.event.pull_request.base.ref, 'v') && '--filter
-    "./{apps,packages}/*" --filter "zimic-example*"' || '--filter "...[HEAD^1]"' }}
+    ${{ github.event_name == 'pull_request' && (startsWith(github.event.pull_request.base.ref, 'v') ||
+    startsWith(github.event.pull_request.base.ref, '@zimic/')) && '--filter "./{apps,packages}/*" --filter
+    "zimic-example*"' || '--filter "...[HEAD^1]"' }}
 
 jobs:
   ci-general:

--- a/.github/workflows/release-zimic-http-package.yaml
+++ b/.github/workflows/release-zimic-http-package.yaml
@@ -79,6 +79,8 @@ jobs:
           project-name: '@zimic/http'
           project-directory: packages/zimic-http
           wiki-ssh-key: ${{ secrets.RELEASE_GITHUB_PUSH_KEY }}
+          commit-user-name: ${{ vars.RELEASE_COMMIT_USER_NAME }}
+          commit-user-email: ${{ vars.RELEASE_COMMIT_USER_EMAIL }}
 
   publish-release-comments:
     name: Publish release comments

--- a/.github/workflows/release-zimic-http-to-github.yaml
+++ b/.github/workflows/release-zimic-http-to-github.yaml
@@ -87,7 +87,7 @@ jobs:
         if: ${{ steps.release-settings.outputs.upgrade-type != '' }}
         uses: ncipollo/release-action@v1
         with:
-          name: '@zimic/http@${{ steps.bump-version.outputs.value }}'
+          name: '@zimic/http: ${{ steps.bump-version.outputs.value }}'
           tag: '@zimic/http@${{ steps.bump-version.outputs.value }}'
           commit: ${{ steps.bump-version.outputs.commit-sha }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-zimic-package.yaml
+++ b/.github/workflows/release-zimic-package.yaml
@@ -79,6 +79,8 @@ jobs:
           project-name: zimic
           project-directory: packages/zimic
           wiki-ssh-key: ${{ secrets.RELEASE_GITHUB_PUSH_KEY }}
+          commit-user-name: ${{ vars.RELEASE_COMMIT_USER_NAME }}
+          commit-user-email: ${{ vars.RELEASE_COMMIT_USER_EMAIL }}
 
   publish-release-comments:
     name: Publish Zimic release comments


### PR DESCRIPTION
- fix(ci): read commit user details as inputs
- chore(ci): increase number of push retries
- fix(ci): support validating tags with prefix
- fix(ci): consider `@zimic/*` as production branches
- refactor(ci): improve formatting of tags with prefix

Part of #565.