### PR TITLE
chore(ci): `@zimic/fetch` deployment workflow (#565)

### DIFF
--- a/.github/workflows/release-zimic-fetch-package.yaml
+++ b/.github/workflows/release-zimic-fetch-package.yaml
@@ -1,0 +1,106 @@
+name: 'Release Package: @zimic/fetch'
+
+on:
+  release:
+    types:
+      - published
+
+concurrency:
+  group: release-zimic-fetch-${{ github.ref_name }}
+  cancel-in-progress: false
+
+env:
+  TURBO_LOG_ORDER: stream
+
+jobs:
+  release-to-npm:
+    name: Release to NPM
+    runs-on: ubuntu-latest
+    if: ${{ startsWith(github.ref_name, '@zimic/fetch@') }}
+    timeout-minutes: 7
+
+    environment: NPM
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Release to NPM
+        uses: ./.github/actions/zimic-release-npm
+        with:
+          ref-name: ${{ github.ref_name }}
+          project-name: '@zimic/fetch'
+          project-directory: packages/zimic-fetch
+          npm-token: ${{ secrets.ZIMIC_NPM_RELEASE_TOKEN }}
+
+  test-npm-release:
+    name: Test NPM release
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs:
+      - release-to-npm
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Test NPM release
+        uses: ./.github/actions/zimic-release-npm-test
+        with:
+          ref-name: ${{ github.ref_name }}
+          project-name: '@zimic/fetch'
+          project-directory: packages/zimic-fetch
+
+  release-docs:
+    name: Release documentation
+    runs-on: ubuntu-latest
+    if: ${{ startsWith(github.ref_name, '@zimic/fetch@') }}
+    timeout-minutes: 5
+
+    environment: Wiki
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          path: zimic
+
+      - name: Release documentation
+        uses: ./zimic/.github/actions/zimic-release-docs
+        with:
+          ref-name: ${{ github.ref_name }}
+          project-name: '@zimic/fetch'
+          project-directory: packages/zimic-fetch
+          wiki-ssh-key: ${{ secrets.RELEASE_GITHUB_PUSH_KEY }}
+          commit-user-name: ${{ vars.RELEASE_COMMIT_USER_NAME }}
+          commit-user-email: ${{ vars.RELEASE_COMMIT_USER_EMAIL }}
+
+  publish-release-comments:
+    name: Publish release comments
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs:
+      - release-to-npm
+      - test-npm-release
+      - release-docs
+
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Publish release comments
+        uses: ./.github/actions/zimic-release-comments
+        with:
+          ref-name: ${{ github.ref_name }}
+          project-name: '@zimic/fetch'

--- a/.github/workflows/release-zimic-fetch-to-github.yaml
+++ b/.github/workflows/release-zimic-fetch-to-github.yaml
@@ -1,0 +1,117 @@
+name: 'Release to GitHub: @zimic/fetch'
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - canary
+      - '@zimic/fetch@*'
+  workflow_dispatch:
+    inputs:
+      upgrade-type:
+        description: Upgrade type
+        type: choice
+        required: true
+        default: prerelease
+        options:
+          - prerelease
+          - stable
+          - patch
+          - minor
+          - major
+      pre-release-id:
+        description: Pre-release id
+        type: choice
+        required: true
+        default: canary
+        options:
+          - canary
+          - none
+
+concurrency:
+  group: release-to-zimic-fetch-github
+  cancel-in-progress: false
+
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_REMOTE_CACHE_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_REMOTE_CACHE_TEAM }}
+  TURBO_LOG_ORDER: stream
+
+jobs:
+  pre-release-to-github:
+    name: Pre-release to GitHub
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}
+    timeout-minutes: 5
+
+    outputs:
+      upgrade-type: ${{ steps.release-settings.outputs.upgrade-type }}
+      pre-release-id: ${{ steps.release-settings.outputs.pre-release-id }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Zimic
+        uses: ./.github/actions/zimic-setup
+        with:
+          turbo-token: ${{ env.TURBO_TOKEN }}
+          turbo-team: ${{ env.TURBO_TEAM }}
+          install: '@zimic/fetch...'
+
+      - name: Get release settings
+        id: release-settings
+        uses: ./.github/actions/zimic-get-release-settings
+        with:
+          project-name: '@zimic/fetch'
+          input-upgrade-type: ${{ inputs.upgrade-type }}
+          input-pre-release-id: ${{ inputs.pre-release-id }}
+
+  release-to-github:
+    name: Release to GitHub
+    runs-on: ubuntu-latest
+    if: ${{ needs.pre-release-to-github.outputs.upgrade-type != '' }}
+    needs:
+      - pre-release-to-github
+    timeout-minutes: 5
+
+    environment: GitHub
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ssh-key: ${{ secrets.RELEASE_GITHUB_PUSH_KEY }}
+
+      - name: Set up Zimic
+        uses: ./.github/actions/zimic-setup
+        with:
+          turbo-token: ${{ env.TURBO_TOKEN }}
+          turbo-team: ${{ env.TURBO_TEAM }}
+
+      - name: Bump version
+        id: bump-version
+        uses: ./.github/actions/zimic-bump-version
+        with:
+          project-name: '@zimic/fetch'
+          project-directory: packages/zimic-fetch
+          upgrade-type: ${{ needs.pre-release-to-github.outputs.upgrade-type }}
+          pre-release-id: ${{ needs.pre-release-to-github.outputs.pre-release-id }}
+          commit-user-name: ${{ vars.RELEASE_COMMIT_USER_NAME }}
+          commit-user-email: ${{ vars.RELEASE_COMMIT_USER_EMAIL }}
+
+      - name: Create GitHub release
+        uses: ncipollo/release-action@v1
+        with:
+          name: '@zimic/fetch: ${{ steps.bump-version.outputs.value }}'
+          tag: '@zimic/fetch@${{ steps.bump-version.outputs.value }}'
+          commit: ${{ steps.bump-version.outputs.commit-sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          makeLatest: ${{ needs.pre-release-to-github.outputs.pre-release-id == 'none' }}
+          prerelease: ${{ needs.pre-release-to-github.outputs.pre-release-id != 'node' }}
+          generateReleaseNotes: true
+          draft: true

--- a/.github/workflows/release-zimic-http-package.yaml
+++ b/.github/workflows/release-zimic-http-package.yaml
@@ -40,7 +40,7 @@ jobs:
   test-npm-release:
     name: Test NPM release
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     needs:
       - release-to-npm
 

--- a/.github/workflows/release-zimic-http-to-github.yaml
+++ b/.github/workflows/release-zimic-http-to-github.yaml
@@ -39,10 +39,41 @@ env:
   TURBO_LOG_ORDER: stream
 
 jobs:
+  pre-release-to-github:
+    name: Pre-release to GitHub
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}
+    timeout-minutes: 5
+
+    outputs:
+      upgrade-type: ${{ steps.release-settings.outputs.upgrade-type }}
+      pre-release-id: ${{ steps.release-settings.outputs.pre-release-id }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Zimic
+        uses: ./.github/actions/zimic-setup
+        with:
+          turbo-token: ${{ env.TURBO_TOKEN }}
+          turbo-team: ${{ env.TURBO_TEAM }}
+          install: '@zimic/http...'
+
+      - name: Get release settings
+        id: release-settings
+        uses: ./.github/actions/zimic-get-release-settings
+        with:
+          project-name: '@zimic/http'
+          input-upgrade-type: ${{ inputs.upgrade-type }}
+          input-pre-release-id: ${{ inputs.pre-release-id }}
+
   release-to-github:
     name: Release to GitHub
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}
+    if: ${{ needs.pre-release-to-github.outputs.upgrade-type != '' }}
+    needs:
+      - pre-release-to-github
     timeout-minutes: 5
 
     environment: GitHub
@@ -61,37 +92,26 @@ jobs:
         with:
           turbo-token: ${{ env.TURBO_TOKEN }}
           turbo-team: ${{ env.TURBO_TEAM }}
-          install: '@zimic/http...'
-
-      - name: Get release settings
-        id: release-settings
-        uses: ./.github/actions/zimic-get-release-settings
-        with:
-          project-name: '@zimic/http'
-          input-upgrade-type: ${{ inputs.upgrade-type }}
-          input-pre-release-id: ${{ inputs.pre-release-id }}
 
       - name: Bump version
         id: bump-version
-        if: ${{ steps.release-settings.outputs.upgrade-type != '' }}
         uses: ./.github/actions/zimic-bump-version
         with:
           project-name: '@zimic/http'
           project-directory: packages/zimic-http
-          upgrade-type: ${{ steps.release-settings.outputs.upgrade-type }}
-          pre-release-id: ${{ steps.release-settings.outputs.pre-release-id }}
+          upgrade-type: ${{ needs.pre-release-to-github.outputs.upgrade-type }}
+          pre-release-id: ${{ needs.pre-release-to-github.outputs.pre-release-id }}
           commit-user-name: ${{ vars.RELEASE_COMMIT_USER_NAME }}
           commit-user-email: ${{ vars.RELEASE_COMMIT_USER_EMAIL }}
 
       - name: Create GitHub release
-        if: ${{ steps.release-settings.outputs.upgrade-type != '' }}
         uses: ncipollo/release-action@v1
         with:
           name: '@zimic/http: ${{ steps.bump-version.outputs.value }}'
           tag: '@zimic/http@${{ steps.bump-version.outputs.value }}'
           commit: ${{ steps.bump-version.outputs.commit-sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          makeLatest: ${{ steps.release-settings.outputs.pre-release-id == 'none' }}
-          prerelease: ${{ steps.release-settings.outputs.pre-release-id != 'node' }}
+          makeLatest: ${{ needs.pre-release-to-github.outputs.pre-release-id == 'none' }}
+          prerelease: ${{ needs.pre-release-to-github.outputs.pre-release-id != 'node' }}
           generateReleaseNotes: true
           draft: true

--- a/.github/workflows/release-zimic-package.yaml
+++ b/.github/workflows/release-zimic-package.yaml
@@ -40,7 +40,7 @@ jobs:
   test-npm-release:
     name: Test NPM release
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     needs:
       - release-to-npm
 

--- a/.github/workflows/release-zimic-to-github.yaml
+++ b/.github/workflows/release-zimic-to-github.yaml
@@ -7,7 +7,6 @@ on:
     branches:
       - canary
       - v*
-      - zimic@*
   workflow_dispatch:
     inputs:
       upgrade-type:
@@ -40,10 +39,34 @@ env:
   TURBO_LOG_ORDER: stream
 
 jobs:
+  pre-release-to-github:
+    name: Pre-release to GitHub
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}
+    timeout-minutes: 5
+
+    outputs:
+      upgrade-type: ${{ steps.release-settings.outputs.upgrade-type }}
+      pre-release-id: ${{ steps.release-settings.outputs.pre-release-id }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Get release settings
+        id: release-settings
+        uses: ./.github/actions/zimic-get-release-settings
+        with:
+          project-name: zimic
+          input-upgrade-type: ${{ inputs.upgrade-type }}
+          input-pre-release-id: ${{ inputs.pre-release-id }}
+
   release-to-github:
     name: Release to GitHub
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}
+    if: ${{ needs.pre-release-to-github.outputs.upgrade-type != '' }}
+    needs:
+      - pre-release-to-github
     timeout-minutes: 5
 
     environment: GitHub
@@ -62,37 +85,26 @@ jobs:
         with:
           turbo-token: ${{ env.TURBO_TOKEN }}
           turbo-team: ${{ env.TURBO_TEAM }}
-          install: zimic...
-
-      - name: Get release settings
-        id: release-settings
-        uses: ./.github/actions/zimic-get-release-settings
-        with:
-          project-name: zimic
-          input-upgrade-type: ${{ inputs.upgrade-type }}
-          input-pre-release-id: ${{ inputs.pre-release-id }}
 
       - name: Bump version
         id: bump-version
-        if: ${{ steps.release-settings.outputs.upgrade-type != '' }}
         uses: ./.github/actions/zimic-bump-version
         with:
           project-name: zimic
           project-directory: packages/zimic
-          upgrade-type: ${{ steps.release-settings.outputs.upgrade-type }}
-          pre-release-id: ${{ steps.release-settings.outputs.pre-release-id }}
+          upgrade-type: ${{ needs.pre-release-to-github.outputs.upgrade-type }}
+          pre-release-id: ${{ needs.pre-release-to-github.outputs.pre-release-id }}
           commit-user-name: ${{ vars.RELEASE_COMMIT_USER_NAME }}
           commit-user-email: ${{ vars.RELEASE_COMMIT_USER_EMAIL }}
 
       - name: Create GitHub release
-        if: ${{ steps.release-settings.outputs.upgrade-type != '' }}
         uses: ncipollo/release-action@v1
         with:
           name: v${{ steps.bump-version.outputs.value }}
           tag: v${{ steps.bump-version.outputs.value }}
           commit: ${{ steps.bump-version.outputs.commit-sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          makeLatest: ${{ steps.release-settings.outputs.pre-release-id == 'none' }}
-          prerelease: ${{ steps.release-settings.outputs.pre-release-id != 'node' }}
+          makeLatest: ${{ needs.pre-release-to-github.outputs.pre-release-id == 'none' }}
+          prerelease: ${{ needs.pre-release-to-github.outputs.pre-release-id != 'node' }}
           generateReleaseNotes: true
           draft: true


### PR DESCRIPTION
### Chore
- [ci] Created a deployment workflow for `@zimic/fetch`.
- [ci] Improved the GitHub deployment workflow for `zimic`, `@zimic/http`, and `@zimic/fetch` to skip the environment assigning if the deployment is not necessary.

Part of https://github.com/zimicjs/zimic/issues/565.