### PR TITLE
refactor(#zimic-http): replace `zimic` by `@zimic/interceptor` (#565)

### DIFF
--- a/.github/actions/zimic-release-npm-test/action.yaml
+++ b/.github/actions/zimic-release-npm-test/action.yaml
@@ -41,6 +41,10 @@ runs:
     - name: Change package versions for testing
       shell: bash
       run: |
+        sed -i \
+          's/link-workspace-packages = true/link-workspace-packages = false/' \
+          .npmrc
+
         echo "Using ${{ inputs.project-name }}@${{ steps.zimic-version.outputs.value }} for testing..."
 
         internalPackageNames=(zimic @zimic/http @zimic/fetch @zimic/interceptor)

--- a/.github/actions/zimic-release-npm-test/action.yaml
+++ b/.github/actions/zimic-release-npm-test/action.yaml
@@ -43,8 +43,10 @@ runs:
       run: |
         echo "Using ${{ inputs.project-name }}@${{ steps.zimic-version.outputs.value }} for testing..."
 
+        internalPackageNames=(zimic @zimic/http @zimic/fetch @zimic/interceptor)
+
         for packageFile in apps/*/package.json examples/package.json examples/*/package.json; do
-          for packageName in zimic @zimic/http @zimic/fetch; do
+          for packageName in "${internalPackageNames[@]}"; do
             sed -i -E \
               "s;\"$packageName\": \"(latest|workspace:.*)\";\"$packageName\": \"workspace:*\";" \
               "$packageFile"
@@ -56,7 +58,7 @@ runs:
         done
 
         for packageFile in packages/*/package.json; do
-          for packageName in zimic @zimic/http @zimic/fetch; do
+          for packageName in "${internalPackageNames[@]}"; do
             sed -i -E \
               "s;\"$packageName\": \"(latest|workspace:.*|.+-canary\..+)\";\"$packageName\": \"workspace:*\";" \
               "$packageFile"

--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,5 @@
 auto-install-peers = true
 engine-strict = true
 side-effects-cache = false
+ignore-workspace-cycles = true
 link-workspace-packages = true

--- a/apps/zimic-test-client/turbo.json
+++ b/apps/zimic-test-client/turbo.json
@@ -3,7 +3,6 @@
   "extends": ["//"],
   "tasks": {
     "test:turbo": {
-      "dependsOn": ["^build"],
       "inputs": ["{src,tests}/**/*.{ts,json}", "{package,tsconfig}.json", "vitest.config.mts"]
     },
 

--- a/packages/zimic-http/package.json
+++ b/packages/zimic-http/package.json
@@ -93,7 +93,7 @@
     "@vitest/browser": "^3.0.6",
     "@vitest/coverage-istanbul": "^3.0.6",
     "@zimic/eslint-config-node": "workspace:*",
-    "@zimic/interceptor": "0.14.0-canary.14",
+    "@zimic/interceptor": "workspace:*",
     "@zimic/lint-staged-config": "workspace:*",
     "@zimic/tsconfig": "workspace:*",
     "dotenv-cli": "^8.0.0",

--- a/packages/zimic-http/package.json
+++ b/packages/zimic-http/package.json
@@ -93,6 +93,7 @@
     "@vitest/browser": "^3.0.6",
     "@vitest/coverage-istanbul": "^3.0.6",
     "@zimic/eslint-config-node": "workspace:*",
+    "@zimic/interceptor": "0.14.0-canary.14",
     "@zimic/lint-staged-config": "workspace:*",
     "@zimic/tsconfig": "workspace:*",
     "dotenv-cli": "^8.0.0",
@@ -104,8 +105,7 @@
     "tsup": "^8.3.6",
     "tsx": "^4.19.3",
     "typescript": "^5.7.3",
-    "vitest": "^3.0.6",
-    "zimic": "^0.13.2"
+    "vitest": "^3.0.6"
   },
   "peerDependencies": {
     "typescript": ">=4.8.0"

--- a/packages/zimic-http/src/cli/typegen/__tests__/openapi.node.test.ts
+++ b/packages/zimic-http/src/cli/typegen/__tests__/openapi.node.test.ts
@@ -1,10 +1,9 @@
+import { httpInterceptor } from '@zimic/interceptor/http';
 import chalk from 'chalk';
 import filesystem from 'fs/promises';
 import path from 'path';
 import prettier, { Options } from 'prettier';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, MockInstance, vi } from 'vitest';
-// TODO: Replace by the actual @zimic/interceptor on package.json
-import { httpInterceptor } from 'zimic/interceptor/http';
 
 import runCLI from '@/cli/cli';
 import { isDefined } from '@/utils/data';

--- a/packages/zimic-http/turbo.json
+++ b/packages/zimic-http/turbo.json
@@ -17,7 +17,6 @@
     },
 
     "test:turbo": {
-      "dependsOn": ["^build"],
       "inputs": ["{src,tests}/**/*.{ts,json}", "{package,tsconfig}.json", "vitest.config.mts"]
     },
 

--- a/packages/zimic-http/turbo.json
+++ b/packages/zimic-http/turbo.json
@@ -3,6 +3,7 @@
   "extends": ["//"],
   "tasks": {
     "build": {
+      "dependsOn": [],
       "inputs": [
         "{src,scripts}/**/*.{ts,json}",
         "{package,tsconfig}.json",

--- a/packages/zimic/turbo.json
+++ b/packages/zimic/turbo.json
@@ -3,7 +3,6 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "dependsOn": ["^build"],
       "inputs": [
         "{src,scripts}/**/*.{ts,json}",
         "{package,tsconfig}.json",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -731,8 +731,8 @@ importers:
         specifier: workspace:*
         version: link:../eslint-config-node
       '@zimic/interceptor':
-        specifier: 0.14.0-canary.14
-        version: 0.14.0-canary.14(@types/node@22.13.5)(@zimic/http@packages+zimic-http)(typescript@5.7.3)
+        specifier: workspace:*
+        version: link:../zimic-interceptor
       '@zimic/lint-staged-config':
         specifier: workspace:*
         version: link:../lint-staged-config
@@ -2466,17 +2466,6 @@ packages:
   '@whatwg-node/server@0.9.68':
     resolution: {integrity: sha512-0Ibl8Q6pUrO36g5xllshsccYVzsaybZqyQ+vAqewWtIeHCmkB0dpyzmux/xcOO5C+mLPy12g4yaNHsBRTJ0YOw==}
     engines: {node: '>=18.0.0'}
-
-  '@zimic/interceptor@0.14.0-canary.14':
-    resolution: {integrity: sha512-8ClgpGQsEsJSD7Fc+yHnv/8vy2OjMXedH/Q5Qm5Hlx2ZEjBT2+JbWLC6MoqXiZ7yDJOKN5kbJlsc34M+4fCxgw==}
-    engines: {node: '>=18.13.0'}
-    hasBin: true
-    peerDependencies:
-      '@zimic/http': ^0.1.0 || ^0.1.0-canary.0
-      typescript: '>=4.8.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
 
   JSONStream@1.3.5:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
@@ -7625,23 +7614,6 @@ snapshots:
       '@whatwg-node/disposablestack': 0.0.5
       '@whatwg-node/fetch': 0.10.4
       tslib: 2.8.1
-
-  '@zimic/interceptor@0.14.0-canary.14(@types/node@22.13.5)(@zimic/http@packages+zimic-http)(typescript@5.7.3)':
-    dependencies:
-      '@whatwg-node/server': 0.9.68
-      '@zimic/http': link:packages/zimic-http
-      chalk: 4.1.2
-      execa: 9.5.2
-      isomorphic-ws: 5.0.0(ws@8.18.1(bufferutil@4.0.9))
-      msw: 2.7.1(@types/node@22.13.5)(typescript@5.7.3)
-      ws: 8.18.1(bufferutil@4.0.9)
-      yargs: 17.7.2
-    optionalDependencies:
-      bufferutil: 4.0.9
-      typescript: 5.7.3
-    transitivePeerDependencies:
-      - '@types/node'
-      - utf-8-validate
 
   JSONStream@1.3.5:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -730,6 +730,9 @@ importers:
       '@zimic/eslint-config-node':
         specifier: workspace:*
         version: link:../eslint-config-node
+      '@zimic/interceptor':
+        specifier: 0.14.0-canary.14
+        version: 0.14.0-canary.14(@types/node@22.13.5)(@zimic/http@packages+zimic-http)(typescript@5.7.3)
       '@zimic/lint-staged-config':
         specifier: workspace:*
         version: link:../lint-staged-config
@@ -766,9 +769,6 @@ importers:
       vitest:
         specifier: ^3.0.6
         version: 3.0.6(@types/debug@4.1.12)(@types/node@22.13.5)(@vitest/browser@3.0.6)(jiti@2.4.2)(jsdom@20.0.3(bufferutil@4.0.9))(lightningcss@1.29.1)(msw@2.7.1(@types/node@22.13.5)(typescript@5.7.3))(tsx@4.19.3)(yaml@2.7.0)
-      zimic:
-        specifier: ^0.13.2
-        version: 0.13.2(@types/node@22.13.5)(typescript@5.7.3)
 
   packages/zimic-interceptor:
     dependencies:
@@ -2463,13 +2463,20 @@ packages:
     resolution: {integrity: sha512-Wibb7IQyMNhNc4GBepKWWDdAYyduU5UY2NOtiQMPZnUn7tMBJKugVIrGBBTZp5OqxtM+tccSO/LzNTH0S4c0qw==}
     engines: {node: '>=18.0.0'}
 
-  '@whatwg-node/server@0.9.67':
-    resolution: {integrity: sha512-s7gqiQ/B0p4WdqPtI5WuXp9K37DtuOlk/KF7mK+gy/cmXcqfdSAjSweDpwxtmb2lDmzxDgtrT4mpOUaddSNpCw==}
-    engines: {node: '>=18.0.0'}
-
   '@whatwg-node/server@0.9.68':
     resolution: {integrity: sha512-0Ibl8Q6pUrO36g5xllshsccYVzsaybZqyQ+vAqewWtIeHCmkB0dpyzmux/xcOO5C+mLPy12g4yaNHsBRTJ0YOw==}
     engines: {node: '>=18.0.0'}
+
+  '@zimic/interceptor@0.14.0-canary.14':
+    resolution: {integrity: sha512-8ClgpGQsEsJSD7Fc+yHnv/8vy2OjMXedH/Q5Qm5Hlx2ZEjBT2+JbWLC6MoqXiZ7yDJOKN5kbJlsc34M+4fCxgw==}
+    engines: {node: '>=18.13.0'}
+    hasBin: true
+    peerDependencies:
+      '@zimic/http': ^0.1.0 || ^0.1.0-canary.0
+      typescript: '>=4.8.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   JSONStream@1.3.5:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
@@ -4632,16 +4639,6 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  msw@2.7.0:
-    resolution: {integrity: sha512-BIodwZ19RWfCbYTxWTUfTXc+sg4OwjCAgxU1ZsgmggX/7S3LdUifsbUPJs61j0rWb19CZRGY5if77duhc0uXzw==}
-    engines: {node: '>=18'}
-    hasBin: true
-    peerDependencies:
-      typescript: '>= 4.8.x'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   msw@2.7.1:
     resolution: {integrity: sha512-TVT65uoWt9LE4lMTLBdClHBQVwvZv5ofac1YyE119nCrNyXf4ktdeVnWH9Fyt94Ifmiedhw6Npp4DSuVRSuRpw==}
     engines: {node: '>=18'}
@@ -6002,16 +5999,6 @@ packages:
   yoctocolors@2.1.1:
     resolution: {integrity: sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==}
     engines: {node: '>=18'}
-
-  zimic@0.13.2:
-    resolution: {integrity: sha512-o2OnX49rl56ORrSez3zVZg7JAFLAqL0i+zaIrb0Mj4md6xGvVpRRy/bF46hA0u5w/gB7g6njE7eBJ+RrnWJC/w==}
-    engines: {node: '>=18.13.0'}
-    hasBin: true
-    peerDependencies:
-      typescript: '>=4.8.0'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
 
   zod@3.24.2:
     resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
@@ -7633,17 +7620,28 @@ snapshots:
       busboy: 1.6.0
       tslib: 2.8.1
 
-  '@whatwg-node/server@0.9.67':
-    dependencies:
-      '@whatwg-node/disposablestack': 0.0.5
-      '@whatwg-node/fetch': 0.10.4
-      tslib: 2.8.1
-
   '@whatwg-node/server@0.9.68':
     dependencies:
       '@whatwg-node/disposablestack': 0.0.5
       '@whatwg-node/fetch': 0.10.4
       tslib: 2.8.1
+
+  '@zimic/interceptor@0.14.0-canary.14(@types/node@22.13.5)(@zimic/http@packages+zimic-http)(typescript@5.7.3)':
+    dependencies:
+      '@whatwg-node/server': 0.9.68
+      '@zimic/http': link:packages/zimic-http
+      chalk: 4.1.2
+      execa: 9.5.2
+      isomorphic-ws: 5.0.0(ws@8.18.1(bufferutil@4.0.9))
+      msw: 2.7.1(@types/node@22.13.5)(typescript@5.7.3)
+      ws: 8.18.1(bufferutil@4.0.9)
+      yargs: 17.7.2
+    optionalDependencies:
+      bufferutil: 4.0.9
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - '@types/node'
+      - utf-8-validate
 
   JSONStream@1.3.5:
     dependencies:
@@ -9475,10 +9473,6 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  isomorphic-ws@5.0.0(ws@8.18.0(bufferutil@4.0.9)):
-    dependencies:
-      ws: 8.18.0(bufferutil@4.0.9)
-
   isomorphic-ws@5.0.0(ws@8.18.1(bufferutil@4.0.9)):
     dependencies:
       ws: 8.18.1(bufferutil@4.0.9)
@@ -10333,31 +10327,6 @@ snapshots:
   mrmime@2.0.1: {}
 
   ms@2.1.3: {}
-
-  msw@2.7.0(@types/node@22.13.5)(typescript@5.7.3):
-    dependencies:
-      '@bundled-es-modules/cookie': 2.0.1
-      '@bundled-es-modules/statuses': 1.0.1
-      '@bundled-es-modules/tough-cookie': 0.1.6
-      '@inquirer/confirm': 5.1.6(@types/node@22.13.5)
-      '@mswjs/interceptors': 0.37.6
-      '@open-draft/deferred-promise': 2.2.0
-      '@open-draft/until': 2.1.0
-      '@types/cookie': 0.6.0
-      '@types/statuses': 2.0.5
-      graphql: 16.10.0
-      headers-polyfill: 4.0.3
-      is-node-process: 1.2.0
-      outvariant: 1.4.3
-      path-to-regexp: 6.3.0
-      picocolors: 1.1.1
-      strict-event-emitter: 0.5.1
-      type-fest: 4.35.0
-      yargs: 17.7.2
-    optionalDependencies:
-      typescript: 5.7.3
-    transitivePeerDependencies:
-      - '@types/node'
 
   msw@2.7.1(@types/node@22.13.5)(typescript@5.7.3):
     dependencies:
@@ -11866,22 +11835,5 @@ snapshots:
   yoctocolors-cjs@2.1.2: {}
 
   yoctocolors@2.1.1: {}
-
-  zimic@0.13.2(@types/node@22.13.5)(typescript@5.7.3):
-    dependencies:
-      '@whatwg-node/server': 0.9.67
-      chalk: 4.1.2
-      execa: 9.5.2
-      isomorphic-ws: 5.0.0(ws@8.18.0(bufferutil@4.0.9))
-      msw: 2.7.0(@types/node@22.13.5)(typescript@5.7.3)
-      openapi-typescript: 7.6.1(typescript@5.7.3)
-      ws: 8.18.0(bufferutil@4.0.9)
-      yargs: 17.7.2
-    optionalDependencies:
-      bufferutil: 4.0.9
-      typescript: 5.7.3
-    transitivePeerDependencies:
-      - '@types/node'
-      - utf-8-validate
 
   zod@3.24.2: {}


### PR DESCRIPTION
- refactor(#zimic-http): replace `zimic` by `@zimic/interceptor`
- chore(root): ignore workspace cycles
- chore(ci): include `@zimic/interceptor` in internal package list
- fix(#zimic-http): use local `@zimic/interceptor` without build cycle
- fix(ci): unlink workspace packages when testing release
- refactor(root): remove redundant `dependsOn` keys

Part of #565.