### PR TITLE
test(zimic-test-client): verify `@zimic/fetch` (#565)

### DIFF
--- a/.github/workflows/release-zimic-fetch-package.yaml
+++ b/.github/workflows/release-zimic-fetch-package.yaml
@@ -55,6 +55,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: canary
 
       - name: Test NPM release
         uses: ./.github/actions/zimic-release-npm-test

--- a/.github/workflows/release-zimic-http-package.yaml
+++ b/.github/workflows/release-zimic-http-package.yaml
@@ -55,6 +55,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: canary
 
       - name: Test NPM release
         uses: ./.github/actions/zimic-release-npm-test

--- a/.github/workflows/release-zimic-interceptor-package.yaml
+++ b/.github/workflows/release-zimic-interceptor-package.yaml
@@ -55,6 +55,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: canary
 
       - name: Test NPM release
         uses: ./.github/actions/zimic-release-npm-test

--- a/.github/workflows/release-zimic-package.yaml
+++ b/.github/workflows/release-zimic-package.yaml
@@ -55,6 +55,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: canary
 
       - name: Test NPM release
         uses: ./.github/actions/zimic-release-npm-test

--- a/apps/zimic-test-client/tests/exports/exports.test.ts
+++ b/apps/zimic-test-client/tests/exports/exports.test.ts
@@ -176,11 +176,11 @@ describe('Exports', () => {
     expectTypeOf<FetchClientOptions<never>>().not.toBeAny();
     expectTypeOf<FetchFunction<never>>().not.toBeAny();
     expectTypeOf<FetchInput<never, never, never>>().not.toBeAny();
-    expectTypeOf<FetchRequest<never>>().not.toBeAny();
+    expectTypeOf<FetchRequest<never, never, never>>().not.toBeAny();
     expectTypeOf<FetchRequestConstructor<never>>().not.toBeAny();
     expectTypeOf<FetchRequestInit<never, never, never>>().not.toBeAny();
-    expectTypeOf<FetchResponse<never>>().not.toBeAny();
-    expectTypeOf<FetchResponseError<never>>().not.toBeAny();
+    expectTypeOf<FetchResponse<never, never, never>>().not.toBeAny();
+    expectTypeOf<FetchResponseError<never, never, never>>().not.toBeAny();
     expect(typeof FetchResponseError).toBe('function');
 
     expectTypeOf<HttpInterceptorNamespace>().not.toBeAny();

--- a/apps/zimic-test-client/tests/fetch/FetchClient.test.ts
+++ b/apps/zimic-test-client/tests/fetch/FetchClient.test.ts
@@ -1,4 +1,4 @@
-import { createFetch } from '@zimic/fetch';
+import { createFetch, FetchResponseError } from '@zimic/fetch';
 import { JSONSerialized, HttpHeaders, HttpSearchParams, HttpRequest, HttpResponse, HttpSchema } from '@zimic/http';
 import { httpInterceptor } from '@zimic/interceptor/http';
 import expectToThrow from '@zimic/utils/error/expectToThrow';
@@ -180,7 +180,8 @@ describe('Fetch client', async () => {
           .times(1);
 
         const error = await expectToThrow(createUser(invalidPayload), {
-          is: (error) => authFetch.isResponseError(error, '/users', 'POST'),
+          is: (error): error is FetchResponseError<AuthServiceSchema, 'POST', '/users'> =>
+            authFetch.isResponseError(error, 'POST', '/users'),
         });
         const { response } = error;
 
@@ -227,7 +228,8 @@ describe('Fetch client', async () => {
           .times(1);
 
         const error = await expectToThrow(createUser(conflictingPayload), {
-          is: (error) => authFetch.isResponseError(error, '/users', 'POST'),
+          is: (error): error is FetchResponseError<AuthServiceSchema, 'POST', '/users'> =>
+            authFetch.isResponseError(error, 'POST', '/users'),
         });
         const { response } = error;
 
@@ -506,7 +508,8 @@ describe('Fetch client', async () => {
           .times(1);
 
         const error = await expectToThrow(getUserById(user.id), {
-          is: (error) => authFetch.isResponseError(error, '/users/:userId', 'GET'),
+          is: (error): error is FetchResponseError<AuthServiceSchema, 'GET', '/users/:userId'> =>
+            authFetch.isResponseError(error, 'GET', '/users/:userId'),
         });
         const { response } = error;
 
@@ -602,7 +605,8 @@ describe('Fetch client', async () => {
           .times(1);
 
         const error = await expectToThrow(deleteUserById(user.id), {
-          is: (error) => authFetch.isResponseError(error, '/users/:userId', 'DELETE'),
+          is: (error): error is FetchResponseError<AuthServiceSchema, 'DELETE', '/users/:userId'> =>
+            authFetch.isResponseError(error, 'DELETE', '/users/:userId'),
         });
         const { response } = error;
 

--- a/apps/zimic-test-client/tests/fetch/FetchClient.test.ts
+++ b/apps/zimic-test-client/tests/fetch/FetchClient.test.ts
@@ -1,0 +1,730 @@
+import { createFetch } from '@zimic/fetch';
+import { JSONSerialized, HttpHeaders, HttpSearchParams, HttpRequest, HttpResponse, HttpSchema } from '@zimic/http';
+import { httpInterceptor } from '@zimic/interceptor/http';
+import expectToThrow from '@zimic/utils/error/expectToThrow';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, expectTypeOf, it } from 'vitest';
+
+import {
+  AuthServiceSchema,
+  ConflictError,
+  NotFoundError,
+  Notification,
+  NotificationServiceSchema,
+  User,
+  UserCreationRequestBody,
+  UserListSearchParams,
+  ValidationError,
+} from '@tests/types/schema';
+import { importCrypto } from '@tests/utils/crypto';
+
+describe('Fetch client', async () => {
+  const crypto = await importCrypto();
+
+  const authFetch = createFetch<AuthServiceSchema>({
+    baseURL: 'http://localhost:3000',
+  });
+
+  const authInterceptor = httpInterceptor.create<AuthServiceSchema>({
+    type: 'local',
+    baseURL: authFetch.defaults.baseURL,
+    saveRequests: true,
+  });
+
+  const notificationFetch = createFetch<NotificationServiceSchema>({
+    baseURL: 'http://localhost:3001',
+  });
+
+  const notificationInterceptor = httpInterceptor.create<NotificationServiceSchema>({
+    type: 'local',
+    baseURL: notificationFetch.defaults.baseURL,
+    saveRequests: true,
+  });
+
+  const interceptors = [authInterceptor, notificationInterceptor];
+
+  beforeAll(async () => {
+    await Promise.all(interceptors.map((interceptor) => interceptor.start()));
+  });
+
+  beforeEach(() => {
+    for (const interceptor of interceptors) {
+      interceptor.clear();
+    }
+  });
+
+  afterEach(() => {
+    for (const interceptor of interceptors) {
+      interceptor.clear();
+    }
+  });
+
+  afterAll(async () => {
+    await Promise.all(interceptors.map((interceptor) => interceptor.stop()));
+  });
+
+  function serializeUser(user: User): JSONSerialized<User> {
+    return {
+      ...user,
+      birthDate: user.birthDate.toISOString(),
+    };
+  }
+
+  describe('Users', () => {
+    const user: User = {
+      id: crypto.randomUUID(),
+      name: 'Name',
+      email: 'email@email.com',
+      birthDate: new Date(),
+    };
+
+    describe('User creation', () => {
+      const creationPayload: UserCreationRequestBody = {
+        name: user.name,
+        email: user.email,
+        password: crypto.randomUUID(),
+        birthDate: new Date().toISOString(),
+      };
+
+      async function createUser(payload: UserCreationRequestBody) {
+        const response = await authFetch('/users', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+
+        if (!response.ok) {
+          throw response.error;
+        }
+
+        return response;
+      }
+
+      it('should support creating users', async () => {
+        const creationHandler = authInterceptor
+          .post('/users')
+          .with({
+            headers: { 'content-type': 'application/json' },
+            body: creationPayload,
+          })
+          .respond((request) => {
+            expect(request.headers.get('content-type')).toBe('application/json');
+
+            const user: JSONSerialized<User> = {
+              id: crypto.randomUUID(),
+              name: request.body.name,
+              email: request.body.email,
+              birthDate: request.body.birthDate,
+            };
+
+            return {
+              status: 201,
+              headers: { 'x-user-id': user.id },
+              body: user,
+            };
+          })
+          .times(1);
+
+        const response = await createUser(creationPayload);
+        expectTypeOf(response.status).toEqualTypeOf<201>();
+        expect(response.status).toBe(201);
+
+        const createdUser = await response.json();
+        expect(createdUser).toEqual<JSONSerialized<User>>({
+          id: expect.any(String) as string,
+          name: creationPayload.name,
+          email: creationPayload.email,
+          birthDate: creationPayload.birthDate,
+        });
+
+        const creationRequests = creationHandler.requests();
+        expect(creationRequests).toHaveLength(1);
+
+        expectTypeOf(creationRequests[0].headers).toEqualTypeOf<HttpHeaders<{ 'content-type': 'application/json' }>>();
+
+        expectTypeOf(creationRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
+        expect(creationRequests[0].searchParams.size).toBe(0);
+
+        expect(response.headers.get('x-user-id')).toBe(createdUser.id);
+        expect(creationRequests[0].response.headers.get('x-user-id')).toBe(createdUser.id);
+
+        expectTypeOf(creationRequests[0].body).toEqualTypeOf<UserCreationRequestBody>();
+        expect(creationRequests[0].body).toEqual(creationPayload);
+
+        expectTypeOf(creationRequests[0].raw).toEqualTypeOf<HttpRequest<UserCreationRequestBody>>();
+        expect(creationRequests[0].raw).toBeInstanceOf(Request);
+        expectTypeOf(creationRequests[0].raw.json).toEqualTypeOf<() => Promise<UserCreationRequestBody>>();
+        expect(await creationRequests[0].raw.json()).toEqual(creationPayload);
+
+        expectTypeOf(creationRequests[0].response.body).toEqualTypeOf<JSONSerialized<User>>();
+        expect(creationRequests[0].response.body).toEqual(createdUser);
+
+        expectTypeOf(creationRequests[0].response.raw).toEqualTypeOf<HttpResponse<JSONSerialized<User>, 201>>();
+        expect(creationRequests[0].response.raw).toBeInstanceOf(Response);
+        expectTypeOf(creationRequests[0].response.raw.json).toEqualTypeOf<() => Promise<JSONSerialized<User>>>();
+        expect(await creationRequests[0].response.raw.json()).toEqual(createdUser);
+      });
+
+      it('should return an error if the payload is not valid', async () => {
+        // @ts-expect-error Forcing an invalid payload
+        const invalidPayload: UserCreationRequestBody = {};
+
+        const validationError: ValidationError = {
+          code: 'validation_error',
+          message: 'Invalid payload',
+        };
+
+        const creationHandler = authInterceptor
+          .post('/users')
+          .with({ body: invalidPayload })
+          .respond({ status: 400, body: validationError })
+          .times(1);
+
+        const error = await expectToThrow(createUser(invalidPayload), {
+          is: (error) => authFetch.isResponseError(error, '/users', 'POST'),
+        });
+        const { response } = error;
+
+        expectTypeOf(response.status).toEqualTypeOf<400 | 409 | 500>();
+        expect(response.status).toBe(400);
+
+        const creationRequests = creationHandler.requests();
+        expect(creationRequests).toHaveLength(1);
+
+        expectTypeOf(creationRequests[0].headers).toEqualTypeOf<HttpHeaders<{ 'content-type': 'application/json' }>>();
+
+        expectTypeOf(creationRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
+        expect(creationRequests[0].searchParams.size).toBe(0);
+
+        expectTypeOf(creationRequests[0].body).toEqualTypeOf<UserCreationRequestBody>();
+        expect(creationRequests[0].body).toEqual(invalidPayload);
+
+        expectTypeOf(creationRequests[0].raw).toEqualTypeOf<HttpRequest<UserCreationRequestBody>>();
+        expect(creationRequests[0].raw).toBeInstanceOf(Request);
+        expectTypeOf(creationRequests[0].raw.json).toEqualTypeOf<() => Promise<UserCreationRequestBody>>();
+        expect(await creationRequests[0].raw.json()).toEqual(invalidPayload);
+
+        expectTypeOf(creationRequests[0].response.body).toEqualTypeOf<ValidationError>();
+        expect(creationRequests[0].response.body).toEqual(validationError);
+
+        expectTypeOf(creationRequests[0].response.raw).toEqualTypeOf<HttpResponse<ValidationError, 400>>();
+        expect(creationRequests[0].response.raw).toBeInstanceOf(Response);
+        expectTypeOf(creationRequests[0].response.raw.json).toEqualTypeOf<() => Promise<ValidationError>>();
+        expect(await creationRequests[0].response.raw.json()).toEqual(validationError);
+      });
+
+      it('should return an error if the payload is not valid', async () => {
+        const conflictingPayload: UserCreationRequestBody = creationPayload;
+
+        const conflictError: ConflictError = {
+          code: 'conflict',
+          message: 'User already exists',
+        };
+
+        const creationHandler = authInterceptor
+          .post('/users')
+          .with({ body: conflictingPayload })
+          .respond({ status: 409, body: conflictError })
+          .times(1);
+
+        const error = await expectToThrow(createUser(conflictingPayload), {
+          is: (error) => authFetch.isResponseError(error, '/users', 'POST'),
+        });
+        const { response } = error;
+
+        expectTypeOf(response.status).toEqualTypeOf<400 | 409 | 500>();
+        expect(response.status).toBe(409);
+
+        const creationRequests = creationHandler.requests();
+        expect(creationRequests).toHaveLength(1);
+
+        expectTypeOf(creationRequests[0].headers).toEqualTypeOf<HttpHeaders<{ 'content-type': 'application/json' }>>();
+
+        expectTypeOf(creationRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
+        expect(creationRequests[0].searchParams.size).toBe(0);
+
+        expectTypeOf(creationRequests[0].body).toEqualTypeOf<UserCreationRequestBody>();
+        expect(creationRequests[0].body).toEqual(conflictingPayload);
+
+        expectTypeOf(creationRequests[0].raw).toEqualTypeOf<HttpRequest<UserCreationRequestBody>>();
+        expect(creationRequests[0].raw).toBeInstanceOf(Request);
+        expectTypeOf(creationRequests[0].raw.json).toEqualTypeOf<() => Promise<UserCreationRequestBody>>();
+        expect(await creationRequests[0].raw.json()).toEqual(creationPayload);
+
+        expectTypeOf(creationRequests[0].response.body).toEqualTypeOf<ConflictError>();
+        expect(creationRequests[0].response.body).toEqual(conflictError);
+
+        expectTypeOf(creationRequests[0].response.raw).toEqualTypeOf<HttpResponse<ConflictError, 409>>();
+        expect(creationRequests[0].response.raw).toBeInstanceOf(Response);
+        expectTypeOf(creationRequests[0].response.raw.json).toEqualTypeOf<() => Promise<ConflictError>>();
+        expect(await creationRequests[0].response.raw.json()).toEqual(conflictError);
+      });
+    });
+
+    describe('User list', () => {
+      const users: User[] = [
+        {
+          id: crypto.randomUUID(),
+          name: 'Name 1',
+          email: 'email1@email.com',
+          birthDate: new Date(),
+        },
+        {
+          id: crypto.randomUUID(),
+          name: 'Name 2',
+          email: 'email2@email.com',
+          birthDate: new Date(),
+        },
+        {
+          id: crypto.randomUUID(),
+          name: 'Name3',
+          email: 'email3@email.com',
+          birthDate: new Date(),
+        },
+      ];
+
+      beforeEach(() => {
+        authInterceptor.get('/users').respond({
+          status: 200,
+          body: [],
+        });
+      });
+
+      async function listUsers(filters: UserListSearchParams = {}) {
+        const response = await authFetch('/users', {
+          method: 'GET',
+          searchParams: filters,
+        });
+
+        if (!response.ok) {
+          throw response.error;
+        }
+
+        return response;
+      }
+
+      it('should list users', async () => {
+        const listHandler = authInterceptor
+          .get('/users')
+          .respond({ status: 200, body: users.map(serializeUser) })
+          .times(1);
+
+        const response = await listUsers();
+        expectTypeOf(response.status).toEqualTypeOf<200>();
+        expect(response.status).toBe(200);
+
+        const returnedUsers = await response.json();
+        expect(returnedUsers).toEqual(users.map(serializeUser));
+
+        const listRequests = listHandler.requests();
+        expect(listRequests).toHaveLength(1);
+
+        expectTypeOf(listRequests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
+
+        expectTypeOf(listRequests[0].searchParams).toEqualTypeOf<
+          HttpSearchParams<HttpSchema.SearchParams<UserListSearchParams>>
+        >();
+        expect(listRequests[0].searchParams.get('name')).toBe(null);
+        expect(listRequests[0].searchParams.getAll('orderBy')).toEqual([]);
+
+        expectTypeOf(listRequests[0].body).toEqualTypeOf<null>();
+        expect(listRequests[0].body).toBe(null);
+
+        expectTypeOf(listRequests[0].raw).toEqualTypeOf<HttpRequest<null>>();
+        expect(listRequests[0].raw).toBeInstanceOf(Request);
+        expectTypeOf(listRequests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
+        expect(await listRequests[0].raw.text()).toBe('');
+
+        expectTypeOf(listRequests[0].response.body).toEqualTypeOf<JSONSerialized<User>[]>();
+        expect(listRequests[0].response.body).toEqual(users.map(serializeUser));
+
+        expectTypeOf(listRequests[0].response.raw).toEqualTypeOf<HttpResponse<JSONSerialized<User>[], 200>>();
+        expect(listRequests[0].response.raw).toBeInstanceOf(Response);
+        expectTypeOf(listRequests[0].response.raw.json).toEqualTypeOf<() => Promise<JSONSerialized<User>[]>>();
+        expect(await listRequests[0].response.raw.json()).toEqual(users.map(serializeUser));
+      });
+
+      it('should list users filtered by name', async () => {
+        const user = users[0];
+
+        const listHandler = authInterceptor
+          .get('/users')
+          .with({ searchParams: { name: user.name } })
+          .respond({ status: 200, body: [serializeUser(user)] })
+          .times(1);
+
+        const response = await listUsers({ name: user.name });
+        expectTypeOf(response.status).toEqualTypeOf<200>();
+        expect(response.status).toBe(200);
+
+        const returnedUsers = await response.json();
+        expect(returnedUsers).toEqual([serializeUser(user)]);
+
+        const listRequests = listHandler.requests();
+        expect(listRequests).toHaveLength(1);
+
+        expectTypeOf(listRequests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
+
+        expectTypeOf(listRequests[0].searchParams).toEqualTypeOf<
+          HttpSearchParams<HttpSchema.SearchParams<UserListSearchParams>>
+        >();
+        expect(listRequests[0].searchParams.size).toBe(1);
+        expect(listRequests[0].searchParams.get('name')).toBe(user.name);
+        expect(listRequests[0].searchParams.getAll('orderBy')).toEqual([]);
+
+        expectTypeOf(listRequests[0].body).toEqualTypeOf<null>();
+        expect(listRequests[0].body).toBe(null);
+
+        expectTypeOf(listRequests[0].raw).toEqualTypeOf<HttpRequest<null>>();
+        expect(listRequests[0].raw).toBeInstanceOf(Request);
+        expectTypeOf(listRequests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
+        expect(await listRequests[0].raw.text()).toBe('');
+
+        expectTypeOf(listRequests[0].response.body).toEqualTypeOf<JSONSerialized<User>[]>();
+        expect(listRequests[0].response.body).toEqual([serializeUser(user)]);
+
+        expectTypeOf(listRequests[0].response.raw).toEqualTypeOf<HttpResponse<JSONSerialized<User>[], 200>>();
+        expect(listRequests[0].response.raw).toBeInstanceOf(Response);
+        expectTypeOf(listRequests[0].response.raw.json).toEqualTypeOf<() => Promise<JSONSerialized<User>[]>>();
+        expect(await listRequests[0].response.raw.json()).toEqual([serializeUser(user)]);
+      });
+
+      it('should list users with ordering', async () => {
+        const usersSortedByDescendingEmail = [...users].sort((user, otherUser) => {
+          return otherUser.email.localeCompare(user.email);
+        });
+
+        const listHandler = authInterceptor
+          .get('/users')
+          .with({ searchParams: { orderBy: ['email.desc'] } })
+          .respond({ status: 200, body: usersSortedByDescendingEmail.map(serializeUser) })
+          .times(1);
+
+        const response = await listUsers({
+          orderBy: ['email.desc'],
+        });
+        expectTypeOf(response.status).toEqualTypeOf<200>();
+        expect(response.status).toBe(200);
+
+        const returnedUsers = await response.json();
+        expect(returnedUsers).toEqual(usersSortedByDescendingEmail.map(serializeUser));
+
+        const listRequests = listHandler.requests();
+        expect(listRequests).toHaveLength(1);
+
+        expectTypeOf(listRequests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
+
+        expectTypeOf(listRequests[0].searchParams).toEqualTypeOf<
+          HttpSearchParams<HttpSchema.SearchParams<UserListSearchParams>>
+        >();
+        expect(listRequests[0].searchParams.size).toBe(1);
+        expect(listRequests[0].searchParams.get('name')).toBe(null);
+        expect(listRequests[0].searchParams.getAll('orderBy')).toEqual(['email.desc']);
+
+        expectTypeOf(listRequests[0].body).toEqualTypeOf<null>();
+        expect(listRequests[0].body).toBe(null);
+
+        expectTypeOf(listRequests[0].raw).toEqualTypeOf<HttpRequest<null>>();
+        expect(listRequests[0].raw).toBeInstanceOf(Request);
+        expectTypeOf(listRequests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
+        expect(await listRequests[0].raw.text()).toBe('');
+
+        expectTypeOf(listRequests[0].response.body).toEqualTypeOf<JSONSerialized<User>[]>();
+        expect(listRequests[0].response.body).toEqual(usersSortedByDescendingEmail.map(serializeUser));
+
+        expectTypeOf(listRequests[0].response.raw).toEqualTypeOf<HttpResponse<JSONSerialized<User>[], 200>>();
+        expect(listRequests[0].response.raw).toBeInstanceOf(Response);
+        expectTypeOf(listRequests[0].response.raw.json).toEqualTypeOf<() => Promise<JSONSerialized<User>[]>>();
+        expect(await listRequests[0].response.raw.json()).toEqual(usersSortedByDescendingEmail.map(serializeUser));
+      });
+    });
+
+    describe('User get by id', () => {
+      async function getUserById(userId: string) {
+        const response = await authFetch(`/users/${userId}`, { method: 'GET' });
+
+        if (!response.ok) {
+          throw response.error;
+        }
+
+        return response;
+      }
+
+      it('should support getting users by id', async () => {
+        const getHandler = authInterceptor
+          .get(`/users/${user.id}`)
+          .respond({
+            status: 200,
+            body: serializeUser(user),
+          })
+          .times(1);
+
+        const response = await getUserById(user.id);
+        expectTypeOf(response.status).toEqualTypeOf<200>();
+        expect(response.status).toBe(200);
+
+        const returnedUsers = await response.json();
+        expect(returnedUsers).toEqual(serializeUser(user));
+
+        const getRequests = getHandler.requests();
+        expect(getRequests).toHaveLength(1);
+        expect(getRequests[0].url).toBe(`${authFetch.defaults.baseURL}/users/${user.id}`);
+
+        expectTypeOf(getRequests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
+
+        expectTypeOf(getRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
+        expect(getRequests[0].searchParams.size).toBe(0);
+
+        expectTypeOf(getRequests[0].body).toEqualTypeOf<null>();
+        expect(getRequests[0].body).toBe(null);
+
+        expectTypeOf(getRequests[0].raw).toEqualTypeOf<HttpRequest<null>>();
+        expect(getRequests[0].raw).toBeInstanceOf(Request);
+        expectTypeOf(getRequests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
+        expect(await getRequests[0].raw.text()).toBe('');
+
+        expectTypeOf(getRequests[0].response.body).toEqualTypeOf<JSONSerialized<User>>();
+        expect(getRequests[0].response.body).toEqual(serializeUser(user));
+
+        expectTypeOf(getRequests[0].response.raw).toEqualTypeOf<HttpResponse<JSONSerialized<User>, 200>>();
+        expect(getRequests[0].response.raw).toBeInstanceOf(Response);
+        expectTypeOf(getRequests[0].response.raw.json).toEqualTypeOf<() => Promise<JSONSerialized<User>>>();
+        expect(await getRequests[0].response.raw.json()).toEqual(serializeUser(user));
+      });
+
+      it('should return an error if the user was not found', async () => {
+        const notFoundError: NotFoundError = {
+          code: 'not_found',
+          message: 'User not found',
+        };
+
+        const getHandler = authInterceptor
+          .get('/users/:userId')
+          .respond({
+            status: 404,
+            body: notFoundError,
+          })
+          .times(1);
+
+        const error = await expectToThrow(getUserById(user.id), {
+          is: (error) => authFetch.isResponseError(error, '/users/:userId', 'GET'),
+        });
+        const { response } = error;
+
+        expectTypeOf(response.status).toEqualTypeOf<404 | 500>();
+        expect(response.status).toBe(404);
+
+        const getRequests = getHandler.requests();
+        expect(getRequests).toHaveLength(1);
+        expect(getRequests[0].url).toBe(`${authFetch.defaults.baseURL}/users/${user.id}`);
+
+        expectTypeOf(getRequests[0].pathParams).toEqualTypeOf<{ userId: string }>();
+        expect(getRequests[0].pathParams).toEqual({ userId: user.id });
+
+        expectTypeOf(getRequests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
+
+        expectTypeOf(getRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
+        expect(getRequests[0].searchParams.size).toBe(0);
+
+        expectTypeOf(getRequests[0].body).toEqualTypeOf<null>();
+        expect(getRequests[0].body).toBe(null);
+
+        expectTypeOf(getRequests[0].raw).toEqualTypeOf<HttpRequest<null>>();
+        expect(getRequests[0].raw).toBeInstanceOf(Request);
+        expectTypeOf(getRequests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
+        expect(await getRequests[0].raw.text()).toBe('');
+
+        expectTypeOf(getRequests[0].response.body).toEqualTypeOf<NotFoundError>();
+        expect(getRequests[0].response.body).toEqual(notFoundError);
+
+        expectTypeOf(getRequests[0].response.raw).toEqualTypeOf<HttpResponse<NotFoundError, 404>>();
+        expect(getRequests[0].response.raw).toBeInstanceOf(Response);
+        expectTypeOf(getRequests[0].response.raw.json).toEqualTypeOf<() => Promise<NotFoundError>>();
+        expect(await getRequests[0].response.raw.json()).toEqual(notFoundError);
+      });
+    });
+
+    describe('User deletion', () => {
+      async function deleteUserById(userId: string) {
+        const request = new authFetch.Request(`/users/${userId}`, { method: 'DELETE' });
+        const response = await authFetch(request);
+
+        if (!response.ok) {
+          throw response.error;
+        }
+
+        return response;
+      }
+
+      it('should support deleting users by id', async () => {
+        const deleteHandler = authInterceptor.delete(`/users/${user.id}`).respond({ status: 204 }).times(1);
+
+        const response = await deleteUserById(user.id);
+        expectTypeOf(response.status).toEqualTypeOf<204>();
+        expect(response.status).toBe(204);
+
+        const deleteRequests = deleteHandler.requests();
+        expect(deleteRequests).toHaveLength(1);
+        expect(deleteRequests[0].url).toBe(`${authFetch.defaults.baseURL}/users/${user.id}`);
+
+        expectTypeOf(deleteRequests[0].pathParams).toEqualTypeOf<{ userId: string }>();
+        expect(deleteRequests[0].pathParams).toEqual({});
+
+        expectTypeOf(deleteRequests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
+
+        expectTypeOf(deleteRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
+        expect(deleteRequests[0].searchParams.size).toBe(0);
+
+        expectTypeOf(deleteRequests[0].body).toEqualTypeOf<null>();
+        expect(deleteRequests[0].body).toBe(null);
+
+        expectTypeOf(deleteRequests[0].raw).toEqualTypeOf<HttpRequest<null>>();
+        expect(deleteRequests[0].raw).toBeInstanceOf(Request);
+        expectTypeOf(deleteRequests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
+        expect(await deleteRequests[0].raw.text()).toBe('');
+
+        expectTypeOf(deleteRequests[0].response.body).toEqualTypeOf<null>();
+        expect(deleteRequests[0].response.body).toBe(null);
+
+        expectTypeOf(deleteRequests[0].response.raw).toEqualTypeOf<HttpResponse<null, 204>>();
+        expect(deleteRequests[0].response.raw).toBeInstanceOf(Response);
+        expectTypeOf(deleteRequests[0].response.raw.json).toEqualTypeOf<() => Promise<null>>();
+        expect(await deleteRequests[0].response.raw.text()).toBe('');
+      });
+
+      it('should return an error if the user was not found', async () => {
+        const notFoundError: NotFoundError = {
+          code: 'not_found',
+          message: 'User not found',
+        };
+        const getHandler = authInterceptor
+          .delete('/users/:userId')
+          .respond({ status: 404, body: notFoundError })
+          .times(1);
+
+        const error = await expectToThrow(deleteUserById(user.id), {
+          is: (error) => authFetch.isResponseError(error, '/users/:userId', 'DELETE'),
+        });
+        const { response } = error;
+
+        expectTypeOf(response.status).toEqualTypeOf<404 | 500>();
+        expect(response.status).toBe(404);
+
+        const deleteRequests = getHandler.requests();
+        expect(deleteRequests).toHaveLength(1);
+        expect(deleteRequests[0].url).toBe(`${authFetch.defaults.baseURL}/users/${user.id}`);
+
+        expectTypeOf(deleteRequests[0].pathParams).toEqualTypeOf<{ userId: string }>();
+        expect(deleteRequests[0].pathParams).toEqual({ userId: user.id });
+
+        expectTypeOf(deleteRequests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
+
+        expectTypeOf(deleteRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
+        expect(deleteRequests[0].searchParams.size).toBe(0);
+
+        expectTypeOf(deleteRequests[0].body).toEqualTypeOf<null>();
+        expect(deleteRequests[0].body).toBe(null);
+
+        expectTypeOf(deleteRequests[0].raw).toEqualTypeOf<HttpRequest<null>>();
+        expect(deleteRequests[0].raw).toBeInstanceOf(Request);
+        expectTypeOf(deleteRequests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
+        expect(await deleteRequests[0].raw.text()).toBe('');
+
+        expectTypeOf(deleteRequests[0].response.body).toEqualTypeOf<NotFoundError>();
+        expect(deleteRequests[0].response.body).toEqual(notFoundError);
+
+        expectTypeOf(deleteRequests[0].response.raw).toEqualTypeOf<HttpResponse<NotFoundError, 404>>();
+        expect(deleteRequests[0].response.raw).toBeInstanceOf(Response);
+        expectTypeOf(deleteRequests[0].response.raw.json).toEqualTypeOf<() => Promise<NotFoundError>>();
+        expect(await deleteRequests[0].response.raw.json()).toEqual(notFoundError);
+      });
+    });
+  });
+
+  describe('Notifications', () => {
+    const notification: Notification = {
+      id: crypto.randomUUID(),
+      userId: crypto.randomUUID(),
+      content: 'Notification content',
+    };
+
+    describe('Notification list', () => {
+      beforeEach(() => {
+        notificationInterceptor.get('/notifications/:userId').respond({
+          status: 200,
+          body: [],
+        });
+      });
+
+      async function listNotifications(userId: string) {
+        const request = new notificationFetch.Request(`/notifications/${encodeURIComponent(userId)}`, {
+          method: 'GET',
+        });
+
+        const response = await notificationFetch(request);
+
+        if (!response.ok) {
+          throw response.error;
+        }
+
+        return response;
+      }
+
+      it('should list notifications', async () => {
+        const listHandler = notificationInterceptor
+          .get('/notifications/:userId')
+          .respond({
+            status: 200,
+            body: [notification],
+          })
+          .times(0, 1);
+
+        let response = await listNotifications(notification.userId);
+        expectTypeOf(response.status).toEqualTypeOf<200>();
+        expect(response.status).toBe(200);
+
+        let returnedNotifications = await response.json();
+        expect(returnedNotifications).toEqual([notification]);
+
+        const listRequests = listHandler.requests();
+        expect(listRequests).toHaveLength(1);
+        expect(listRequests[0].url).toBe(`${notificationFetch.defaults.baseURL}/notifications/${notification.userId}`);
+
+        expectTypeOf(listRequests[0].pathParams).toEqualTypeOf<{ userId: string }>();
+        expect(listRequests[0].pathParams).toEqual({ userId: notification.userId });
+
+        expectTypeOf(listRequests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
+
+        expectTypeOf(listRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
+        expect(listRequests[0].searchParams.size).toBe(0);
+
+        expectTypeOf(listRequests[0].body).toEqualTypeOf<null>();
+        expect(listRequests[0].body).toBe(null);
+
+        expectTypeOf(listRequests[0].raw).toEqualTypeOf<HttpRequest<null>>();
+        expect(listRequests[0].raw).toBeInstanceOf(Request);
+        expectTypeOf(listRequests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
+        expect(await listRequests[0].raw.text()).toBe('');
+
+        expectTypeOf(listRequests[0].response.body).toEqualTypeOf<Notification[]>();
+        expect(listRequests[0].response.body).toEqual([notification]);
+
+        expectTypeOf(listRequests[0].response.raw).toEqualTypeOf<HttpResponse<Notification[], 200>>();
+        expect(listRequests[0].response.raw).toBeInstanceOf(Response);
+        expectTypeOf(listRequests[0].response.raw.json).toEqualTypeOf<() => Promise<Notification[]>>();
+        expect(await listRequests[0].response.raw.json()).toEqual([notification]);
+
+        listHandler.clear();
+
+        response = await listNotifications(notification.userId);
+        expectTypeOf(response.status).toEqualTypeOf<200>();
+        expect(response.status).toBe(200);
+
+        returnedNotifications = await response.json();
+        expect(returnedNotifications).toEqual([]);
+
+        expect(listRequests).toHaveLength(1);
+        expect(listHandler.requests()).toHaveLength(0);
+      });
+    });
+  });
+});

--- a/apps/zimic-test-client/tests/interceptor/thirdParty/shared/index.ts
+++ b/apps/zimic-test-client/tests/interceptor/thirdParty/shared/index.ts
@@ -1,7 +1,7 @@
 import { HttpInterceptorPlatform, HttpInterceptorType } from '@zimic/interceptor/http';
 import { describe } from 'vitest';
 
-import declareDefaultClientTests from './default';
+import declareHttpInterceptorTests from './httpInterceptor';
 
 export const ZIMIC_SERVER_PORT = 4000;
 
@@ -17,8 +17,8 @@ export interface ClientTestOptionsByWorkerType extends ClientTestOptions {
 function declareClientTests(options: ClientTestOptions) {
   const interceptorTypes: HttpInterceptorType[] = ['local', 'remote'];
 
-  describe.each(interceptorTypes)("Default (type '%s')", async (type) => {
-    await declareDefaultClientTests({ ...options, type });
+  describe.each(interceptorTypes)("HTTP interceptor (type '%s')", async (type) => {
+    await declareHttpInterceptorTests({ ...options, type });
   });
 }
 

--- a/packages/zimic-fetch/src/client/FetchClient.ts
+++ b/packages/zimic-fetch/src/client/FetchClient.ts
@@ -194,8 +194,8 @@ class FetchClient<Schema extends HttpSchema> {
 
   isRequest<Path extends HttpSchemaPath.Literal<Schema, Method>, Method extends HttpSchemaMethod<Schema>>(
     request: unknown,
-    path: Path,
     method: Method,
+    path: Path,
   ): request is FetchRequest<Schema, Method, Path> {
     return (
       request instanceof Request &&
@@ -208,21 +208,21 @@ class FetchClient<Schema extends HttpSchema> {
 
   isResponse<Path extends HttpSchemaPath.Literal<Schema, Method>, Method extends HttpSchemaMethod<Schema>>(
     response: unknown,
-    path: Path,
     method: Method,
+    path: Path,
   ): response is FetchResponse<Schema, Method, Path> {
     return (
       response instanceof Response &&
       'request' in response &&
       'error' in response &&
-      this.isRequest(response.request, path, method)
+      this.isRequest(response.request, method, path)
     );
   }
 
   isResponseError<Path extends HttpSchemaPath.Literal<Schema, Method>, Method extends HttpSchemaMethod<Schema>>(
     error: unknown,
-    path: Path,
     method: Method,
+    path: Path,
   ): error is FetchResponseError<Schema, Method, Path> {
     return (
       error instanceof FetchResponseError &&

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.blob.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.blob.test.ts
@@ -51,9 +51,7 @@ describe('FetchClient (node) > Bodies > Blob', () => {
       expect(receivedResponseBlob.size).toBe(responseBlob.size);
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'POST', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
@@ -71,9 +69,7 @@ describe('FetchClient (node) > Bodies > Blob', () => {
       expectTypeOf(response.error).toEqualTypeOf<null>();
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'POST', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -130,9 +126,7 @@ describe('FetchClient (node) > Bodies > Blob', () => {
       expect(await response.blob()).toEqual(new Blob([], { type: 'application/octet-stream' }));
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'POST', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
@@ -150,9 +144,7 @@ describe('FetchClient (node) > Bodies > Blob', () => {
       expectTypeOf(response.error).toEqualTypeOf<null>();
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'POST', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -218,9 +210,7 @@ describe('FetchClient (node) > Bodies > Blob', () => {
       expect(await response.arrayBuffer()).toEqual(responseBuffer);
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'POST', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
@@ -236,9 +226,7 @@ describe('FetchClient (node) > Bodies > Blob', () => {
       expectTypeOf(response.error).toEqualTypeOf<null>();
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'POST', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -295,9 +283,7 @@ describe('FetchClient (node) > Bodies > Blob', () => {
       expect(await response.arrayBuffer()).toEqual(new ArrayBuffer(0));
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'POST', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
@@ -313,9 +299,7 @@ describe('FetchClient (node) > Bodies > Blob', () => {
       expectTypeOf(response.error).toEqualTypeOf<null>();
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'POST', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
 

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.formData.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.formData.test.ts
@@ -64,9 +64,7 @@ describe('FetchClient (node) > Bodies > Form data', () => {
       expect(receivedResponseFormData.get('file')).toEqual(responseFormData.get('file'));
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'POST', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
@@ -82,9 +80,7 @@ describe('FetchClient (node) > Bodies > Form data', () => {
       expectTypeOf(response.error).toEqualTypeOf<null>();
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'POST', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -138,9 +134,7 @@ describe('FetchClient (node) > Bodies > Form data', () => {
       expect(await response.text()).toBe('');
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'POST', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
@@ -156,9 +150,7 @@ describe('FetchClient (node) > Bodies > Form data', () => {
       expectTypeOf(response.error).toEqualTypeOf<null>();
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'POST', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
 

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.json.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.json.test.ts
@@ -53,9 +53,7 @@ describe('FetchClient (node) > Bodies > JSON', () => {
       expect(await response.json()).toEqual(users[0]);
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'POST', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
@@ -71,9 +69,7 @@ describe('FetchClient (node) > Bodies > JSON', () => {
       expectTypeOf(response.error).toEqualTypeOf<null>();
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'POST', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -125,9 +121,7 @@ describe('FetchClient (node) > Bodies > JSON', () => {
       expect(await response.json()).toEqual(2);
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'POST', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
@@ -143,9 +137,7 @@ describe('FetchClient (node) > Bodies > JSON', () => {
       expectTypeOf(response.error).toEqualTypeOf<null>();
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'POST', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -197,9 +189,7 @@ describe('FetchClient (node) > Bodies > JSON', () => {
       expect(await response.json()).toEqual(true);
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'POST', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
@@ -215,9 +205,7 @@ describe('FetchClient (node) > Bodies > JSON', () => {
       expectTypeOf(response.error).toEqualTypeOf<null>();
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'POST', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -263,9 +251,7 @@ describe('FetchClient (node) > Bodies > JSON', () => {
       expect(await response.json()).toEqual(null);
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'POST', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
@@ -281,9 +267,7 @@ describe('FetchClient (node) > Bodies > JSON', () => {
       expectTypeOf(response.error).toEqualTypeOf<null>();
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'POST', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
 

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.plainText.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.plainText.test.ts
@@ -47,9 +47,7 @@ describe('FetchClient (node) > Bodies > Plain text', () => {
       expect(await response.text()).toBe('response');
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'POST', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
@@ -65,9 +63,7 @@ describe('FetchClient (node) > Bodies > Plain text', () => {
       expectTypeOf(response.error).toEqualTypeOf<null>();
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'POST', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -116,9 +112,7 @@ describe('FetchClient (node) > Bodies > Plain text', () => {
       expect(await response.text()).toBe('');
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'POST', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
@@ -135,9 +129,7 @@ describe('FetchClient (node) > Bodies > Plain text', () => {
       expectTypeOf(response.error).toEqualTypeOf<null>();
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'POST', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
 

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.searchParams.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.searchParams.test.ts
@@ -63,9 +63,7 @@ describe('FetchClient (node) > Bodies > Search params', () => {
       expect(receivedResponseSearchParams.getAll('descriptions')).toEqual(responseSearchParams.getAll('descriptions'));
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'POST', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
@@ -81,9 +79,7 @@ describe('FetchClient (node) > Bodies > Search params', () => {
       expectTypeOf(response.error).toEqualTypeOf<null>();
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'POST', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -133,9 +129,7 @@ describe('FetchClient (node) > Bodies > Search params', () => {
       expect(await response.text()).toBe('');
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'POST', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
@@ -151,9 +145,7 @@ describe('FetchClient (node) > Bodies > Search params', () => {
       expectTypeOf(response.error).toEqualTypeOf<null>();
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'POST', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
 

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.defaults.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.defaults.test.ts
@@ -47,16 +47,12 @@ describe('FetchClient (node) > Defaults', () => {
       expect(await response.json()).toEqual(users);
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'GET', Schema['/users']['GET']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'GET', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'GET', Schema['/users']['GET']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'GET', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
     });
@@ -114,16 +110,12 @@ describe('FetchClient (node) > Defaults', () => {
       expect(await response.json()).toEqual(users);
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'POST', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'POST', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -210,16 +202,12 @@ describe('FetchClient (node) > Defaults', () => {
       expect(await response.json()).toEqual(users);
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'POST', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'POST', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
 

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.errors.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.errors.test.ts
@@ -261,13 +261,13 @@ describe('FetchClient (node) > Errors', () => {
 
       const error = response.error as unknown;
 
-      expect(fetch.isResponseError(error, '/users', 'GET')).toBe(true);
-      expect(fetch.isResponseError(error, '/users', 'POST')).toBe(false);
-      expect(fetch.isResponseError(error, '/users/:id', 'GET')).toBe(false);
+      expect(fetch.isResponseError(error, 'GET', '/users')).toBe(true);
+      expect(fetch.isResponseError(error, 'POST', '/users')).toBe(false);
+      expect(fetch.isResponseError(error, 'GET', '/users/:id')).toBe(false);
 
       /* istanbul ignore else -- @preserve
        * This if is necessary to narrow the error type to a specific error. */
-      if (fetch.isResponseError(error, '/users', 'GET')) {
+      if (fetch.isResponseError(error, 'GET', '/users')) {
         expectTypeOf(error).toEqualTypeOf<FetchResponseError<Schema, 'GET', '/users'>>();
 
         expect(error.request).toBe(response.request);
@@ -341,13 +341,13 @@ describe('FetchClient (node) > Errors', () => {
 
       const error = response.error as unknown;
 
-      expect(fetch.isResponseError(error, '/users', 'GET')).toBe(false);
-      expect(fetch.isResponseError(error, '/users', 'POST')).toBe(false);
-      expect(fetch.isResponseError(error, '/users/:id', 'GET')).toBe(true);
+      expect(fetch.isResponseError(error, 'GET', '/users')).toBe(false);
+      expect(fetch.isResponseError(error, 'POST', '/users')).toBe(false);
+      expect(fetch.isResponseError(error, 'GET', '/users/:id')).toBe(true);
 
       /* istanbul ignore else -- @preserve
        * This if is necessary to narrow the error type to a specific error. */
-      if (fetch.isResponseError(error, '/users/:id', 'GET')) {
+      if (fetch.isResponseError(error, 'GET', '/users/:id')) {
         expectTypeOf(error).toEqualTypeOf<FetchResponseError<Schema, 'GET', '/users/:id'>>();
 
         expect(error.request).toBe(response.request);

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.errors.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.errors.test.ts
@@ -54,9 +54,7 @@ describe('FetchClient (node) > Errors', () => {
       expect(await response.json()).toEqual(users);
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'GET', Schema['/users']['GET']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'GET', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
@@ -68,13 +66,13 @@ describe('FetchClient (node) > Errors', () => {
       >();
       expectTypeOf(response.formData).toEqualTypeOf<() => Promise<FormData>>();
       expectTypeOf(response.clone).toEqualTypeOf<
-        | (() => FetchResponsePerStatusCode<'/users', 'GET', Schema['/users']['GET'], 200>)
-        | (() => FetchResponsePerStatusCode<'/users', 'GET', Schema['/users']['GET'], 401>)
-        | (() => FetchResponsePerStatusCode<'/users', 'GET', Schema['/users']['GET'], 403>)
-        | (() => FetchResponsePerStatusCode<'/users', 'GET', Schema['/users']['GET'], 500>)
+        | (() => FetchResponsePerStatusCode<Schema, 'GET', '/users', 200>)
+        | (() => FetchResponsePerStatusCode<Schema, 'GET', '/users', 401>)
+        | (() => FetchResponsePerStatusCode<Schema, 'GET', '/users', 403>)
+        | (() => FetchResponsePerStatusCode<Schema, 'GET', '/users', 500>)
       >();
 
-      expectTypeOf(response.error).toEqualTypeOf<FetchResponseError<'/users', 'GET', Schema['/users']['GET']> | null>();
+      expectTypeOf(response.error).toEqualTypeOf<FetchResponseError<Schema, 'GET', '/users'> | null>();
 
       expect(response.ok).toBe(true);
 
@@ -82,7 +80,7 @@ describe('FetchClient (node) > Errors', () => {
        * response.ok is true. This if is necessary to narrow the response to a successful type. */
       if (!response.ok) {
         expectTypeOf(response.status).toEqualTypeOf<401 | 403 | 500>();
-        expectTypeOf(response.error).toEqualTypeOf<FetchResponseError<'/users', 'GET', Schema['/users']['GET']>>();
+        expectTypeOf(response.error).toEqualTypeOf<FetchResponseError<Schema, 'GET', '/users'>>();
 
         throw response.error;
       }
@@ -91,14 +89,12 @@ describe('FetchClient (node) > Errors', () => {
 
       expect(response).toBeInstanceOf(Response);
       expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponsePerStatusCode<'/users', 'GET', Schema['/users']['GET'], 200>
+        FetchResponsePerStatusCode<Schema, 'GET', '/users', 200>
       >();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
-      expectTypeOf(response.clone).toEqualTypeOf<
-        () => FetchResponsePerStatusCode<'/users', 'GET', Schema['/users']['GET'], 200>
-      >();
+      expectTypeOf(response.clone).toEqualTypeOf<() => FetchResponsePerStatusCode<Schema, 'GET', '/users', 200>>();
 
       expectTypeOf(response.error).toEqualTypeOf<null>();
       expect(response.error).toBe(null);
@@ -137,9 +133,7 @@ describe('FetchClient (node) > Errors', () => {
       expect(await response.json()).toEqual({ code: 403, message: 'Forbidden' });
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'GET', Schema['/users']['GET']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'GET', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
@@ -151,13 +145,13 @@ describe('FetchClient (node) > Errors', () => {
       >();
       expectTypeOf(response.formData).toEqualTypeOf<() => Promise<FormData>>();
       expectTypeOf(response.clone).toEqualTypeOf<
-        | (() => FetchResponsePerStatusCode<'/users', 'GET', Schema['/users']['GET'], 200>)
-        | (() => FetchResponsePerStatusCode<'/users', 'GET', Schema['/users']['GET'], 401>)
-        | (() => FetchResponsePerStatusCode<'/users', 'GET', Schema['/users']['GET'], 403>)
-        | (() => FetchResponsePerStatusCode<'/users', 'GET', Schema['/users']['GET'], 500>)
+        | (() => FetchResponsePerStatusCode<Schema, 'GET', '/users', 200>)
+        | (() => FetchResponsePerStatusCode<Schema, 'GET', '/users', 401>)
+        | (() => FetchResponsePerStatusCode<Schema, 'GET', '/users', 403>)
+        | (() => FetchResponsePerStatusCode<Schema, 'GET', '/users', 500>)
       >();
 
-      expectTypeOf(response.error).toEqualTypeOf<FetchResponseError<'/users', 'GET', Schema['/users']['GET']> | null>();
+      expectTypeOf(response.error).toEqualTypeOf<FetchResponseError<Schema, 'GET', '/users'> | null>();
 
       expect(response.ok).toBe(false);
 
@@ -174,9 +168,9 @@ describe('FetchClient (node) > Errors', () => {
 
       expect(response).toBeInstanceOf(Response);
       expectTypeOf(response satisfies Response).toEqualTypeOf<
-        | FetchResponsePerStatusCode<'/users', 'GET', Schema['/users']['GET'], 401>
-        | FetchResponsePerStatusCode<'/users', 'GET', Schema['/users']['GET'], 403>
-        | FetchResponsePerStatusCode<'/users', 'GET', Schema['/users']['GET'], 500>
+        | FetchResponsePerStatusCode<Schema, 'GET', '/users', 401>
+        | FetchResponsePerStatusCode<Schema, 'GET', '/users', 403>
+        | FetchResponsePerStatusCode<Schema, 'GET', '/users', 500>
       >();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
@@ -188,15 +182,13 @@ describe('FetchClient (node) > Errors', () => {
       >();
       expectTypeOf(response.formData).toEqualTypeOf<() => Promise<FormData>>();
       expectTypeOf(response.clone).toEqualTypeOf<
-        | (() => FetchResponsePerStatusCode<'/users', 'GET', Schema['/users']['GET'], 401>)
-        | (() => FetchResponsePerStatusCode<'/users', 'GET', Schema['/users']['GET'], 403>)
-        | (() => FetchResponsePerStatusCode<'/users', 'GET', Schema['/users']['GET'], 500>)
+        | (() => FetchResponsePerStatusCode<Schema, 'GET', '/users', 401>)
+        | (() => FetchResponsePerStatusCode<Schema, 'GET', '/users', 403>)
+        | (() => FetchResponsePerStatusCode<Schema, 'GET', '/users', 500>)
       >();
 
-      expectTypeOf(response.error).toEqualTypeOf<FetchResponseError<'/users', 'GET', Schema['/users']['GET']>>();
-      expect(response.error).toEqual(
-        new FetchResponseError<'/users', 'GET', Schema['/users']['GET']>(response.request, response),
-      );
+      expectTypeOf(response.error).toEqualTypeOf<FetchResponseError<Schema, 'GET', '/users'>>();
+      expect(response.error).toEqual(new FetchResponseError<Schema, 'GET', '/users'>(response.request, response));
     });
   });
 
@@ -250,13 +242,11 @@ describe('FetchClient (node) > Errors', () => {
       expect(await response.json()).toEqual({ code: 403, message: 'Forbidden' });
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'GET', Schema['/users']['GET']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'GET', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
-      expectTypeOf(response.error).toEqualTypeOf<FetchResponseError<'/users', 'GET', Schema['/users']['GET']> | null>();
+      expectTypeOf(response.error).toEqualTypeOf<FetchResponseError<Schema, 'GET', '/users'> | null>();
 
       expect(response.ok).toBe(false);
 
@@ -278,7 +268,7 @@ describe('FetchClient (node) > Errors', () => {
       /* istanbul ignore else -- @preserve
        * This if is necessary to narrow the error type to a specific error. */
       if (fetch.isResponseError(error, '/users', 'GET')) {
-        expectTypeOf(error).toEqualTypeOf<FetchResponseError<'/users', 'GET', Schema['/users']['GET']>>();
+        expectTypeOf(error).toEqualTypeOf<FetchResponseError<Schema, 'GET', '/users'>>();
 
         expect(error.request).toBe(response.request);
         expect(error.response).toBe(response);
@@ -340,18 +330,12 @@ describe('FetchClient (node) > Errors', () => {
       expect(await response.json()).toEqual({ code: 404, message: 'Not Found' });
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users/:id', 'GET', Schema['/users/:id']['GET']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'GET', '/users/:id'>>();
 
       expect(response.url).toBe(joinURL(baseURL, `/users/${users[0].id}`));
       expect(response.request.path).toBe(`/users/${users[0].id}`);
 
-      expectTypeOf(response.error).toEqualTypeOf<FetchResponseError<
-        '/users/:id',
-        'GET',
-        Schema['/users/:id']['GET']
-      > | null>();
+      expectTypeOf(response.error).toEqualTypeOf<FetchResponseError<Schema, 'GET', '/users/:id'> | null>();
 
       expect(response.ok).toBe(false);
 
@@ -364,7 +348,7 @@ describe('FetchClient (node) > Errors', () => {
       /* istanbul ignore else -- @preserve
        * This if is necessary to narrow the error type to a specific error. */
       if (fetch.isResponseError(error, '/users/:id', 'GET')) {
-        expectTypeOf(error).toEqualTypeOf<FetchResponseError<'/users/:id', 'GET', Schema['/users/:id']['GET']>>();
+        expectTypeOf(error).toEqualTypeOf<FetchResponseError<Schema, 'GET', '/users/:id'>>();
 
         expect(error.request).toBe(response.request);
         expect(error.response).toBe(response);

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.headers.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.headers.test.ts
@@ -58,7 +58,7 @@ describe('FetchClient (node) > Headers', () => {
         headers,
       });
       expect(request).toBeInstanceOf(Request);
-      expectTypeOf(request satisfies Request).toEqualTypeOf<FetchRequest<'/users', 'GET', Schema['/users']['GET']>>();
+      expectTypeOf(request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'GET', '/users'>>();
 
       expect(request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -116,7 +116,7 @@ describe('FetchClient (node) > Headers', () => {
         headers,
       });
       expect(request).toBeInstanceOf(Request);
-      expectTypeOf(request satisfies Request).toEqualTypeOf<FetchRequest<'/users', 'GET', Schema['/users']['GET']>>();
+      expectTypeOf(request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'GET', '/users'>>();
 
       expect(request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -182,7 +182,7 @@ describe('FetchClient (node) > Headers', () => {
         headers,
       });
       expect(request).toBeInstanceOf(Request);
-      expectTypeOf(request satisfies Request).toEqualTypeOf<FetchRequest<'/users', 'GET', Schema['/users']['GET']>>();
+      expectTypeOf(request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'GET', '/users'>>();
 
       expect(request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -238,7 +238,7 @@ describe('FetchClient (node) > Headers', () => {
         new fetch.Request('/users', { method: 'GET', headers: new HttpHeaders() }),
       ]) {
         expect(request).toBeInstanceOf(Request);
-        expectTypeOf(request satisfies Request).toEqualTypeOf<FetchRequest<'/users', 'GET', Schema['/users']['GET']>>();
+        expectTypeOf(request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'GET', '/users'>>();
 
         expect(request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -294,9 +294,7 @@ describe('FetchClient (node) > Headers', () => {
       expect(await response.json()).toEqual(users);
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'GET', Schema['/users']['GET']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'GET', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
@@ -304,9 +302,7 @@ describe('FetchClient (node) > Headers', () => {
       expectTypeOf(response.headers).toEqualTypeOf<StrictHeaders<ResponseHeaders>>();
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'GET', Schema['/users']['GET']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'GET', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -350,9 +346,7 @@ describe('FetchClient (node) > Headers', () => {
       expect(await response.json()).toEqual(users);
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'GET', Schema['/users']['GET']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'GET', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
@@ -360,9 +354,7 @@ describe('FetchClient (node) > Headers', () => {
       expectTypeOf(response.headers).toEqualTypeOf<StrictHeaders<ResponseHeaders>>();
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'GET', Schema['/users']['GET']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'GET', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -414,9 +406,7 @@ describe('FetchClient (node) > Headers', () => {
       expect(await response.json()).toEqual(users);
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'GET', Schema['/users']['GET']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'GET', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
@@ -424,9 +414,7 @@ describe('FetchClient (node) > Headers', () => {
       expectTypeOf(response.headers).toEqualTypeOf<StrictHeaders<ResponseHeaders>>();
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'GET', Schema['/users']['GET']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'GET', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -471,9 +459,7 @@ describe('FetchClient (node) > Headers', () => {
         expect(await response.json()).toEqual(users);
 
         expect(response).toBeInstanceOf(Response);
-        expectTypeOf(response satisfies Response).toEqualTypeOf<
-          FetchResponse<'/users', 'GET', Schema['/users']['GET']>
-        >();
+        expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'GET', '/users'>>();
 
         expect(response.url).toBe(joinURL(baseURL, '/users'));
 
@@ -481,9 +467,7 @@ describe('FetchClient (node) > Headers', () => {
         expectTypeOf(response.headers).toEqualTypeOf<StrictHeaders<never>>();
 
         expect(response.request).toBeInstanceOf(Request);
-        expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-          FetchRequest<'/users', 'GET', Schema['/users']['GET']>
-        >();
+        expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'GET', '/users'>>();
 
         expect(response.request.url).toBe(joinURL(baseURL, '/users'));
 

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.listeners.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.listeners.test.ts
@@ -63,11 +63,11 @@ describe('FetchClient (node) > Listeners', () => {
         // eslint-disable-next-line @typescript-eslint/no-use-before-define
         expectTypeOf(fetchSelf).toEqualTypeOf(fetch);
 
-        expect(fetchSelf.isRequest(request, '/users', 'POST')).toBe(true);
+        expect(fetchSelf.isRequest(request, 'POST', '/users')).toBe(true);
 
         /* istanbul ignore else -- @preserve
          * This else is necessary to narrow the error type to a specific error. */
-        if (fetchSelf.isRequest(request, '/users', 'POST')) {
+        if (fetchSelf.isRequest(request, 'POST', '/users')) {
           expect(request).toBeInstanceOf(Request);
           expectTypeOf(request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'POST', '/users'>>();
 
@@ -159,11 +159,11 @@ describe('FetchClient (node) > Listeners', () => {
         // eslint-disable-next-line @typescript-eslint/no-use-before-define
         expectTypeOf(fetchSelf).toEqualTypeOf(fetch);
 
-        expect(fetchSelf.isRequest(request, '/users/:id', 'POST')).toBe(true);
+        expect(fetchSelf.isRequest(request, 'POST', '/users/:id')).toBe(true);
 
         /* istanbul ignore else -- @preserve
          * This else is necessary to narrow the error type to a specific error. */
-        if (fetchSelf.isRequest(request, '/users/:id', 'POST')) {
+        if (fetchSelf.isRequest(request, 'POST', '/users/:id')) {
           expect(request).toBeInstanceOf(Request);
           expectTypeOf(request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'POST', '/users/:id'>>();
 
@@ -310,7 +310,7 @@ describe('FetchClient (node) > Listeners', () => {
         .times(1);
 
       const onRequest = vi.fn<Default<Fetch<Schema>['onRequest']>>((request, { Request, isRequest }) => {
-        if (isRequest(request, '/users', 'POST')) {
+        if (isRequest(request, 'POST', '/users')) {
           const headers = new HttpHeaders<HeadersSchema>(request.headers);
           headers.set('accept-language', 'en');
 
@@ -538,11 +538,11 @@ describe('FetchClient (node) > Listeners', () => {
         // eslint-disable-next-line @typescript-eslint/no-use-before-define
         expectTypeOf(fetchSelf).toEqualTypeOf(fetch);
 
-        expect(fetchSelf.isResponse(response, '/users', 'POST')).toBe(true);
+        expect(fetchSelf.isResponse(response, 'POST', '/users')).toBe(true);
 
         /* istanbul ignore else -- @preserve
          * This else is necessary to narrow the error type to a specific error. */
-        if (fetchSelf.isResponse(response, '/users', 'POST')) {
+        if (fetchSelf.isResponse(response, 'POST', '/users')) {
           expect(response).toBeInstanceOf(Response);
           expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'POST', '/users'>>();
         } else {
@@ -626,11 +626,11 @@ describe('FetchClient (node) > Listeners', () => {
         // eslint-disable-next-line @typescript-eslint/no-use-before-define
         expectTypeOf(fetchSelf).toEqualTypeOf(fetch);
 
-        expect(fetchSelf.isResponse(response, '/users/:id', 'POST')).toBe(true);
+        expect(fetchSelf.isResponse(response, 'POST', '/users/:id')).toBe(true);
 
         /* istanbul ignore else -- @preserve
          * This else is necessary to narrow the error type to a specific error. */
-        if (fetchSelf.isResponse(response, '/users/:id', 'POST')) {
+        if (fetchSelf.isResponse(response, 'POST', '/users/:id')) {
           expect(response).toBeInstanceOf(Response);
           expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'POST', '/users/:id'>>();
         } else {

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.listeners.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.listeners.test.ts
@@ -69,9 +69,7 @@ describe('FetchClient (node) > Listeners', () => {
          * This else is necessary to narrow the error type to a specific error. */
         if (fetchSelf.isRequest(request, '/users', 'POST')) {
           expect(request).toBeInstanceOf(Request);
-          expectTypeOf(request satisfies Request).toEqualTypeOf<
-            FetchRequest<'/users', 'POST', Schema['/users']['POST']>
-          >();
+          expectTypeOf(request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'POST', '/users'>>();
 
           const requestClone = request.clone();
           expectTypeOf(requestClone).toEqualTypeOf(request);
@@ -108,16 +106,12 @@ describe('FetchClient (node) > Listeners', () => {
       expect(await response.json()).toEqual(users[0]);
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'POST', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'POST', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -171,9 +165,7 @@ describe('FetchClient (node) > Listeners', () => {
          * This else is necessary to narrow the error type to a specific error. */
         if (fetchSelf.isRequest(request, '/users/:id', 'POST')) {
           expect(request).toBeInstanceOf(Request);
-          expectTypeOf(request satisfies Request).toEqualTypeOf<
-            FetchRequest<'/users/:id', 'POST', Schema['/users/:id']['POST']>
-          >();
+          expectTypeOf(request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'POST', '/users/:id'>>();
 
           const requestClone = request.clone();
           expectTypeOf(requestClone).toEqualTypeOf(request);
@@ -210,16 +202,12 @@ describe('FetchClient (node) > Listeners', () => {
       expect(await response.json()).toEqual(users[0]);
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users/:id', 'POST', Schema['/users/:id']['POST']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'POST', '/users/:id'>>();
 
       expect(response.url).toBe(joinURL(baseURL, `/users/${users[0].id}`));
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users/:id', 'POST', Schema['/users/:id']['POST']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'POST', '/users/:id'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, `/users/${users[0].id}`));
 
@@ -269,16 +257,12 @@ describe('FetchClient (node) > Listeners', () => {
       expect(await response.json()).toEqual(users);
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'POST', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'POST', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -360,16 +344,12 @@ describe('FetchClient (node) > Listeners', () => {
       expect(await response.json()).toEqual(users);
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'POST', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users?page=1&limit=10'));
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'POST', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users?page=1&limit=10'));
 
@@ -431,16 +411,12 @@ describe('FetchClient (node) > Listeners', () => {
       expect(await response.json()).toEqual(users);
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'POST', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users?page=1&limit=10'));
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'POST', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users?page=1&limit=10'));
 
@@ -497,16 +473,12 @@ describe('FetchClient (node) > Listeners', () => {
       expect(await response.json()).toEqual(users);
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'POST', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'POST', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -572,9 +544,7 @@ describe('FetchClient (node) > Listeners', () => {
          * This else is necessary to narrow the error type to a specific error. */
         if (fetchSelf.isResponse(response, '/users', 'POST')) {
           expect(response).toBeInstanceOf(Response);
-          expectTypeOf(response satisfies Response).toEqualTypeOf<
-            FetchResponse<'/users', 'POST', Schema['/users']['POST']>
-          >();
+          expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'POST', '/users'>>();
         } else {
           expectTypeOf(response).toEqualTypeOf<FetchResponse.Loose>();
         }
@@ -595,16 +565,12 @@ describe('FetchClient (node) > Listeners', () => {
       expect(await response.json()).toEqual(users);
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'POST', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'POST', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -666,9 +632,7 @@ describe('FetchClient (node) > Listeners', () => {
          * This else is necessary to narrow the error type to a specific error. */
         if (fetchSelf.isResponse(response, '/users/:id', 'POST')) {
           expect(response).toBeInstanceOf(Response);
-          expectTypeOf(response satisfies Response).toEqualTypeOf<
-            FetchResponse<'/users/:id', 'POST', Schema['/users/:id']['POST']>
-          >();
+          expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'POST', '/users/:id'>>();
         } else {
           expectTypeOf(response).toEqualTypeOf<FetchResponse.Loose>();
         }
@@ -689,16 +653,12 @@ describe('FetchClient (node) > Listeners', () => {
       expect(await response.json()).toEqual(users[0]);
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users/:id', 'POST', Schema['/users/:id']['POST']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'POST', '/users/:id'>>();
 
       expect(response.url).toBe(joinURL(baseURL, `/users/${users[0].id}`));
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users/:id', 'POST', Schema['/users/:id']['POST']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'POST', '/users/:id'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, `/users/${users[0].id}`));
 
@@ -755,9 +715,7 @@ describe('FetchClient (node) > Listeners', () => {
       expect(await response.json()).toEqual(users);
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'POST', '/users'>>();
 
       expect(response.url).toBe('');
 
@@ -766,9 +724,7 @@ describe('FetchClient (node) > Listeners', () => {
       expect(response.headers.get('content-language')).toBe('en');
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'POST', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -827,9 +783,7 @@ describe('FetchClient (node) > Listeners', () => {
       expect(await response.json()).toEqual(users);
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'POST', '/users'>>();
 
       expect(response.url).toBe('');
 
@@ -838,9 +792,7 @@ describe('FetchClient (node) > Listeners', () => {
       expect(response.headers.get('content-language')).toBe('en');
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'POST', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
 

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.methods.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.methods.test.ts
@@ -44,16 +44,12 @@ describe('FetchClient (node) > Methods', () => {
       expect(await response.json()).toEqual(users);
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'GET', Schema['/users']['GET']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'GET', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'GET', Schema['/users']['GET']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'GET', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -94,16 +90,12 @@ describe('FetchClient (node) > Methods', () => {
       expect(await response.json()).toEqual(users);
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'GET', Schema['/users']['GET']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'GET', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'GET', Schema['/users']['GET']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'GET', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -137,7 +129,7 @@ describe('FetchClient (node) > Methods', () => {
 
       const request = new fetch.Request('/users', { method: 'GET' });
       expect(request).toBeInstanceOf(Request);
-      expectTypeOf(request satisfies Request).toEqualTypeOf<FetchRequest<'/users', 'GET', Schema['/users']['GET']>>();
+      expectTypeOf(request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'GET', '/users'>>();
 
       expect(request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -158,16 +150,12 @@ describe('FetchClient (node) > Methods', () => {
       expect(await response.json()).toEqual(users);
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'GET', Schema['/users']['GET']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'GET', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'GET', Schema['/users']['GET']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'GET', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -216,16 +204,12 @@ describe('FetchClient (node) > Methods', () => {
       expect(await response.json()).toEqual(user);
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'POST', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'POST', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -278,16 +262,12 @@ describe('FetchClient (node) > Methods', () => {
       expect(await response.json()).toEqual(user);
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'POST', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'POST', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -335,7 +315,7 @@ describe('FetchClient (node) > Methods', () => {
         body: JSON.stringify(user),
       });
       expect(request).toBeInstanceOf(Request);
-      expectTypeOf(request satisfies Request).toEqualTypeOf<FetchRequest<'/users', 'POST', Schema['/users']['POST']>>();
+      expectTypeOf(request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'POST', '/users'>>();
 
       expect(request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -354,16 +334,12 @@ describe('FetchClient (node) > Methods', () => {
       expect(await response.json()).toEqual(user);
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'POST', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'POST', Schema['/users']['POST']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'POST', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -416,16 +392,12 @@ describe('FetchClient (node) > Methods', () => {
       expect(await response.json()).toEqual(user);
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'PUT', Schema['/users']['PUT']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'PUT', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'PUT', Schema['/users']['PUT']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'PUT', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -479,16 +451,12 @@ describe('FetchClient (node) > Methods', () => {
       expect(await response.json()).toEqual(user);
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'PUT', Schema['/users']['PUT']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'PUT', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'PUT', Schema['/users']['PUT']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'PUT', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -536,7 +504,7 @@ describe('FetchClient (node) > Methods', () => {
         body: JSON.stringify(user),
       });
       expect(request).toBeInstanceOf(Request);
-      expectTypeOf(request satisfies Request).toEqualTypeOf<FetchRequest<'/users', 'PUT', Schema['/users']['PUT']>>();
+      expectTypeOf(request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'PUT', '/users'>>();
 
       expect(request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -556,16 +524,12 @@ describe('FetchClient (node) > Methods', () => {
       expect(await response.json()).toEqual(user);
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'PUT', Schema['/users']['PUT']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'PUT', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'PUT', Schema['/users']['PUT']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'PUT', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -618,16 +582,12 @@ describe('FetchClient (node) > Methods', () => {
       expect(await response.json()).toEqual(user);
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'PATCH', Schema['/users']['PATCH']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'PATCH', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'PATCH', Schema['/users']['PATCH']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'PATCH', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -681,16 +641,12 @@ describe('FetchClient (node) > Methods', () => {
       expect(await response.json()).toEqual(user);
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'PATCH', Schema['/users']['PATCH']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'PATCH', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'PATCH', Schema['/users']['PATCH']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'PATCH', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -738,9 +694,7 @@ describe('FetchClient (node) > Methods', () => {
         body: JSON.stringify(user),
       });
       expect(request).toBeInstanceOf(Request);
-      expectTypeOf(request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'PATCH', Schema['/users']['PATCH']>
-      >();
+      expectTypeOf(request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'PATCH', '/users'>>();
 
       expect(request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -764,16 +718,12 @@ describe('FetchClient (node) > Methods', () => {
       expect(await response.json()).toEqual(user);
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'PATCH', Schema['/users']['PATCH']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'PATCH', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'PATCH', Schema['/users']['PATCH']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'PATCH', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -808,16 +758,12 @@ describe('FetchClient (node) > Methods', () => {
       expect(await response.text()).toBe('');
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'DELETE', Schema['/users']['DELETE']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'DELETE', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'DELETE', Schema['/users']['DELETE']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'DELETE', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -850,16 +796,12 @@ describe('FetchClient (node) > Methods', () => {
       expect(await response.text()).toBe('');
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'DELETE', Schema['/users']['DELETE']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'DELETE', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'DELETE', Schema['/users']['DELETE']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'DELETE', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -887,9 +829,7 @@ describe('FetchClient (node) > Methods', () => {
 
       const request = new fetch.Request('/users', { method: 'DELETE' });
       expect(request).toBeInstanceOf(Request);
-      expectTypeOf(request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'DELETE', Schema['/users']['DELETE']>
-      >();
+      expectTypeOf(request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'DELETE', '/users'>>();
 
       expect(request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -908,16 +848,12 @@ describe('FetchClient (node) > Methods', () => {
       expect(await response.text()).toBe('');
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'DELETE', Schema['/users']['DELETE']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'DELETE', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'DELETE', Schema['/users']['DELETE']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'DELETE', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -950,16 +886,12 @@ describe('FetchClient (node) > Methods', () => {
       expect(await response.text()).toBe('');
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'HEAD', Schema['/users']['HEAD']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'HEAD', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'HEAD', Schema['/users']['HEAD']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'HEAD', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -993,16 +925,12 @@ describe('FetchClient (node) > Methods', () => {
       expect(await response.text()).toBe('');
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'HEAD', Schema['/users']['HEAD']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'HEAD', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'HEAD', Schema['/users']['HEAD']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'HEAD', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -1030,7 +958,7 @@ describe('FetchClient (node) > Methods', () => {
 
       const request = new fetch.Request('/users', { method: 'HEAD' });
       expect(request).toBeInstanceOf(Request);
-      expectTypeOf(request satisfies Request).toEqualTypeOf<FetchRequest<'/users', 'HEAD', Schema['/users']['HEAD']>>();
+      expectTypeOf(request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'HEAD', '/users'>>();
 
       expect(request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -1050,16 +978,12 @@ describe('FetchClient (node) > Methods', () => {
       expect(await response.text()).toBe('');
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'HEAD', Schema['/users']['HEAD']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'HEAD', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'HEAD', Schema['/users']['HEAD']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'HEAD', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -1092,16 +1016,12 @@ describe('FetchClient (node) > Methods', () => {
       expect(await response.text()).toBe('');
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'OPTIONS', Schema['/users']['OPTIONS']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'OPTIONS', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'OPTIONS', Schema['/users']['OPTIONS']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'OPTIONS', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -1135,16 +1055,12 @@ describe('FetchClient (node) > Methods', () => {
       expect(await response.text()).toBe('');
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'OPTIONS', Schema['/users']['OPTIONS']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'OPTIONS', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'OPTIONS', Schema['/users']['OPTIONS']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'OPTIONS', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -1172,9 +1088,7 @@ describe('FetchClient (node) > Methods', () => {
 
       const request = new fetch.Request('/users', { method: 'OPTIONS' });
       expect(request).toBeInstanceOf(Request);
-      expectTypeOf(request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'OPTIONS', Schema['/users']['OPTIONS']>
-      >();
+      expectTypeOf(request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'OPTIONS', '/users'>>();
 
       expect(request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -1194,16 +1108,12 @@ describe('FetchClient (node) > Methods', () => {
       expect(await response.text()).toBe('');
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'OPTIONS', Schema['/users']['OPTIONS']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'OPTIONS', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'OPTIONS', Schema['/users']['OPTIONS']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'OPTIONS', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -1249,9 +1159,7 @@ describe('FetchClient (node) > Methods', () => {
       expect(await getResponse.json()).toEqual([]);
 
       expect(getResponse).toBeInstanceOf(Response);
-      expectTypeOf(getResponse satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'GET', Schema['/users']['GET']>
-      >();
+      expectTypeOf(getResponse satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'GET', '/users'>>();
 
       expect(getResponse.url).toBe(joinURL(baseURL, '/users'));
 
@@ -1264,9 +1172,7 @@ describe('FetchClient (node) > Methods', () => {
       expectTypeOf(getResponse.error).toEqualTypeOf<null>();
 
       expect(getResponse.request).toBeInstanceOf(Request);
-      expectTypeOf(getResponse.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'GET', Schema['/users']['GET']>
-      >();
+      expectTypeOf(getResponse.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'GET', '/users'>>();
 
       expect(getResponse.request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -1299,9 +1205,7 @@ describe('FetchClient (node) > Methods', () => {
       expect(await patchResponse.json()).toEqual(users[0]);
 
       expect(patchResponse).toBeInstanceOf(Response);
-      expectTypeOf(patchResponse satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'PATCH', Schema['/users']['PATCH']>
-      >();
+      expectTypeOf(patchResponse satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'PATCH', '/users'>>();
 
       expect(patchResponse.url).toBe(joinURL(baseURL, '/users'));
 
@@ -1314,9 +1218,7 @@ describe('FetchClient (node) > Methods', () => {
       expectTypeOf(patchResponse.error).toEqualTypeOf<null>();
 
       expect(patchResponse.request).toBeInstanceOf(Request);
-      expectTypeOf(patchResponse.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'PATCH', Schema['/users']['PATCH']>
-      >();
+      expectTypeOf(patchResponse.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'PATCH', '/users'>>();
 
       expect(patchResponse.request.url).toBe(joinURL(baseURL, '/users'));
 
@@ -1393,6 +1295,13 @@ describe('FetchClient (node) > Methods', () => {
         body: JSON.stringify({ name: 'User 1' }),
       });
 
+      // @ts-expect-error Additional headers
+      await fetch('/users', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-custom': 'value' },
+        body: JSON.stringify({ name: 'User 1' }),
+      });
+
       // @ts-expect-error Headers and body are missing
       await fetch('/users', { method: 'POST' });
 
@@ -1433,6 +1342,13 @@ describe('FetchClient (node) > Methods', () => {
         method: 'PATCH',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({}),
+      });
+
+      // @ts-expect-error Invalid body
+      await fetch('/users/1', {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ name: 1 }),
       });
 
       // @ts-expect-error Headers and body are missing

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.pathParams.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.pathParams.test.ts
@@ -46,16 +46,12 @@ describe('FetchClient (node) > Path params', () => {
       expect(await response.json()).toEqual(users[0]);
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/:username', 'GET', Schema['/:username']['GET']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'GET', '/:username'>>();
 
       expect(response.url).toBe(joinURL(baseURL, `/${users[0].username}`));
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/:username', 'GET', Schema['/:username']['GET']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'GET', '/:username'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, `/${users[0].username}`));
 
@@ -97,15 +93,13 @@ describe('FetchClient (node) > Path params', () => {
       expect(await response.json()).toEqual(users[0]);
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users/:username/get', 'GET', Schema['/users/:username/get']['GET']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'GET', '/users/:username/get'>>();
 
       expect(response.url).toBe(joinURL(baseURL, `/users/${users[0].username}/get`));
 
       expect(response.request).toBeInstanceOf(Request);
       expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users/:username/get', 'GET', Schema['/users/:username/get']['GET']>
+        FetchRequest<Schema, 'GET', '/users/:username/get'>
       >();
 
       expect(response.request.url).toBe(joinURL(baseURL, `/users/${users[0].username}/get`));
@@ -148,16 +142,12 @@ describe('FetchClient (node) > Path params', () => {
       expect(await response.json()).toEqual(users[0]);
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users/:username', 'GET', Schema['/users/:username']['GET']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'GET', '/users/:username'>>();
 
       expect(response.url).toBe(joinURL(baseURL, `/users/${users[0].username}`));
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users/:username', 'GET', Schema['/users/:username']['GET']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'GET', '/users/:username'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, `/users/${users[0].username}`));
 
@@ -200,14 +190,14 @@ describe('FetchClient (node) > Path params', () => {
 
       expect(response).toBeInstanceOf(Response);
       expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users/:username/get/:other', 'GET', Schema['/users/:username/get/:other']['GET']>
+        FetchResponse<Schema, 'GET', '/users/:username/get/:other'>
       >();
 
       expect(response.url).toBe(joinURL(baseURL, `/users/${users[0].username}/get/${users[1].username}`));
 
       expect(response.request).toBeInstanceOf(Request);
       expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users/:username/get/:other', 'GET', Schema['/users/:username/get/:other']['GET']>
+        FetchRequest<Schema, 'GET', '/users/:username/get/:other'>
       >();
 
       expect(response.request.url).toBe(joinURL(baseURL, `/users/${users[0].username}/get/${users[1].username}`));
@@ -251,14 +241,14 @@ describe('FetchClient (node) > Path params', () => {
 
       expect(response).toBeInstanceOf(Response);
       expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users/:username/:other', 'GET', Schema['/users/:username/:other']['GET']>
+        FetchResponse<Schema, 'GET', '/users/:username/:other'>
       >();
 
       expect(response.url).toBe(joinURL(baseURL, `/users/${users[0].username}/${users[1].username}`));
 
       expect(response.request).toBeInstanceOf(Request);
       expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users/:username/:other', 'GET', Schema['/users/:username/:other']['GET']>
+        FetchRequest<Schema, 'GET', '/users/:username/:other'>
       >();
 
       expect(response.request.url).toBe(joinURL(baseURL, `/users/${users[0].username}/${users[1].username}`));
@@ -302,14 +292,14 @@ describe('FetchClient (node) > Path params', () => {
 
       expect(response).toBeInstanceOf(Response);
       expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users/:username/:other/get', 'GET', Schema['/users/:username/:other/get']['GET']>
+        FetchResponse<Schema, 'GET', '/users/:username/:other/get'>
       >();
 
       expect(response.url).toBe(joinURL(baseURL, `/users/${users[0].username}/${users[1].username}/get`));
 
       expect(response.request).toBeInstanceOf(Request);
       expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users/:username/:other/get', 'GET', Schema['/users/:username/:other/get']['GET']>
+        FetchRequest<Schema, 'GET', '/users/:username/:other/get'>
       >();
 
       expect(response.request.url).toBe(joinURL(baseURL, `/users/${users[0].username}/${users[1].username}/get`));
@@ -360,16 +350,12 @@ describe('FetchClient (node) > Path params', () => {
       expect(await response.json()).toEqual(users);
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'GET', Schema['/users']['GET']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'GET', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
       expect(response.request).toBeInstanceOf(Request);
-      expectTypeOf(response.request satisfies Request).toEqualTypeOf<
-        FetchRequest<'/users', 'GET', Schema['/users']['GET']>
-      >();
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'GET', '/users'>>();
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
     });

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.searchParams.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.searchParams.test.ts
@@ -56,7 +56,7 @@ describe('FetchClient (node) > Search params', () => {
         searchParams,
       });
       expect(request).toBeInstanceOf(Request);
-      expectTypeOf(request satisfies Request).toEqualTypeOf<FetchRequest<'/users', 'GET', Schema['/users']['GET']>>();
+      expectTypeOf(request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'GET', '/users'>>();
 
       expect(request.url).toBe(joinURL(baseURL, '/users?name=User'));
 
@@ -111,7 +111,7 @@ describe('FetchClient (node) > Search params', () => {
         searchParams,
       });
       expect(request).toBeInstanceOf(Request);
-      expectTypeOf(request satisfies Request).toEqualTypeOf<FetchRequest<'/users', 'GET', Schema['/users']['GET']>>();
+      expectTypeOf(request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'GET', '/users'>>();
 
       expect(request.url).toBe(joinURL(baseURL, '/users?name=User'));
 
@@ -180,7 +180,7 @@ describe('FetchClient (node) > Search params', () => {
         searchParams,
       });
       expect(request).toBeInstanceOf(Request);
-      expectTypeOf(request satisfies Request).toEqualTypeOf<FetchRequest<'/users', 'GET', Schema['/users']['GET']>>();
+      expectTypeOf(request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'GET', '/users'>>();
 
       expect(request.url).toBe(joinURL(baseURL, '/users?name=User&usernames=User+1&usernames=User+2&orderBy=name'));
 
@@ -233,7 +233,7 @@ describe('FetchClient (node) > Search params', () => {
         new fetch.Request('/users', { method: 'GET', searchParams: new HttpSearchParams() }),
       ]) {
         expect(request).toBeInstanceOf(Request);
-        expectTypeOf(request satisfies Request).toEqualTypeOf<FetchRequest<'/users', 'GET', Schema['/users']['GET']>>();
+        expectTypeOf(request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'GET', '/users'>>();
 
         expect(request.url).toBe(joinURL(baseURL, '/users'));
 

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.types.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.types.test.ts
@@ -61,9 +61,7 @@ describe('FetchClient (node) > Types', () => {
       expect(await response.json()).toEqual(users);
 
       expect(response).toBeInstanceOf(Response);
-      expectTypeOf(response satisfies Response).toEqualTypeOf<
-        FetchResponse<'/users', 'GET', Schema['/users']['GET']>
-      >();
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'GET', '/users'>>();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
@@ -72,14 +70,14 @@ describe('FetchClient (node) > Types', () => {
       >();
       expectTypeOf(response.formData).toEqualTypeOf<() => Promise<FormData>>();
       expectTypeOf(response.clone).toEqualTypeOf<
-        | (() => FetchResponsePerStatusCode<'/users', 'GET', Schema['/users']['GET'], 200>)
-        | (() => FetchResponsePerStatusCode<'/users', 'GET', Schema['/users']['GET'], 201>)
-        | (() => FetchResponsePerStatusCode<'/users', 'GET', Schema['/users']['GET'], 204>)
-        | (() => FetchResponsePerStatusCode<'/users', 'GET', Schema['/users']['GET'], 400>)
-        | (() => FetchResponsePerStatusCode<'/users', 'GET', Schema['/users']['GET'], 401>)
+        | (() => FetchResponsePerStatusCode<Schema, 'GET', '/users', 200>)
+        | (() => FetchResponsePerStatusCode<Schema, 'GET', '/users', 201>)
+        | (() => FetchResponsePerStatusCode<Schema, 'GET', '/users', 204>)
+        | (() => FetchResponsePerStatusCode<Schema, 'GET', '/users', 400>)
+        | (() => FetchResponsePerStatusCode<Schema, 'GET', '/users', 401>)
       >();
 
-      expectTypeOf(response.error).toEqualTypeOf<FetchResponseError<'/users', 'GET', Schema['/users']['GET']> | null>();
+      expectTypeOf(response.error).toEqualTypeOf<FetchResponseError<Schema, 'GET', '/users'> | null>();
 
       expect(response.ok).toBe(true);
 
@@ -87,7 +85,7 @@ describe('FetchClient (node) > Types', () => {
        * response.ok is true. This if is necessary to narrow the response to a successful type. */
       if (!response.ok) {
         expectTypeOf(response.status).toEqualTypeOf<400 | 401>();
-        expectTypeOf(response.error).toEqualTypeOf<FetchResponseError<'/users', 'GET', Schema['/users']['GET']>>();
+        expectTypeOf(response.error).toEqualTypeOf<FetchResponseError<Schema, 'GET', '/users'>>();
 
         throw response.error;
       }
@@ -96,17 +94,17 @@ describe('FetchClient (node) > Types', () => {
 
       expect(response).toBeInstanceOf(Response);
       expectTypeOf(response satisfies Response).toEqualTypeOf<
-        | FetchResponsePerStatusCode<'/users', 'GET', Schema['/users']['GET'], 200>
-        | FetchResponsePerStatusCode<'/users', 'GET', Schema['/users']['GET'], 201>
-        | FetchResponsePerStatusCode<'/users', 'GET', Schema['/users']['GET'], 204>
+        | FetchResponsePerStatusCode<Schema, 'GET', '/users', 200>
+        | FetchResponsePerStatusCode<Schema, 'GET', '/users', 201>
+        | FetchResponsePerStatusCode<Schema, 'GET', '/users', 204>
       >();
 
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
       expectTypeOf(response.clone).toEqualTypeOf<
-        | (() => FetchResponsePerStatusCode<'/users', 'GET', Schema['/users']['GET'], 200>)
-        | (() => FetchResponsePerStatusCode<'/users', 'GET', Schema['/users']['GET'], 201>)
-        | (() => FetchResponsePerStatusCode<'/users', 'GET', Schema['/users']['GET'], 204>)
+        | (() => FetchResponsePerStatusCode<Schema, 'GET', '/users', 200>)
+        | (() => FetchResponsePerStatusCode<Schema, 'GET', '/users', 201>)
+        | (() => FetchResponsePerStatusCode<Schema, 'GET', '/users', 204>)
       >();
 
       expectTypeOf(response.error).toEqualTypeOf<null>();

--- a/packages/zimic-fetch/src/client/errors/FetchResponseError.ts
+++ b/packages/zimic-fetch/src/client/errors/FetchResponseError.ts
@@ -1,15 +1,15 @@
-import { HttpMethod, HttpMethodSchema } from '@zimic/http';
+import { HttpSchema, HttpSchemaMethod, HttpSchemaPath } from '@zimic/http';
 
 import { FetchRequest, FetchResponse } from '../types/requests';
 
 class FetchResponseError<
-  Path extends string = string,
-  Method extends HttpMethod = HttpMethod,
-  MethodSchema extends HttpMethodSchema = HttpMethodSchema,
+  Schema extends HttpSchema,
+  Method extends HttpSchemaMethod<Schema>,
+  Path extends HttpSchemaPath.Literal<Schema, Method>,
 > extends Error {
   constructor(
-    public request: FetchRequest<Path, Method, MethodSchema>,
-    public response: FetchResponse<Path, Method, MethodSchema, true>,
+    public request: FetchRequest<Schema, Method, Path>,
+    public response: FetchResponse<Schema, Method, Path, true>,
   ) {
     super(`${request.method} ${request.url} failed with status ${response.status}: ${response.statusText}`);
     this.name = 'FetchResponseError';

--- a/packages/zimic-fetch/src/client/factory.ts
+++ b/packages/zimic-fetch/src/client/factory.ts
@@ -3,10 +3,8 @@ import { HttpSchema } from '@zimic/http';
 import FetchClient from './FetchClient';
 import { FetchOptions, Fetch as PublicFetch } from './types/public';
 
-function createFetch<Schema extends HttpSchema>(
-  options: FetchOptions<HttpSchema<Schema>>,
-): PublicFetch<HttpSchema<Schema>> {
-  const { fetch } = new FetchClient<HttpSchema<Schema>>(options);
+function createFetch<Schema extends HttpSchema>(options: FetchOptions<Schema>): PublicFetch<Schema> {
+  const { fetch } = new FetchClient<Schema>(options);
   return fetch;
 }
 

--- a/packages/zimic-fetch/src/client/types/public.ts
+++ b/packages/zimic-fetch/src/client/types/public.ts
@@ -1,48 +1,25 @@
 import { HttpSchemaPath, HttpSchemaMethod, LiteralHttpSchemaPathFromNonLiteral, HttpSchema } from '@zimic/http';
-import { Default, PossiblePromise } from '@zimic/utils/types';
+import { PossiblePromise } from '@zimic/utils/types';
 
 import FetchResponseError from '../errors/FetchResponseError';
 import { FetchRequest, FetchRequestConstructor, FetchRequestInit, FetchResponse } from './requests';
 
 export type FetchInput<
   Schema extends HttpSchema,
-  Path extends HttpSchemaPath.NonLiteral<Schema, Method>,
   Method extends HttpSchemaMethod<Schema>,
-> =
-  | Path
-  | URL
-  | FetchRequest<
-      LiteralHttpSchemaPathFromNonLiteral<Schema, Method, Path>,
-      Method,
-      Default<Schema[LiteralHttpSchemaPathFromNonLiteral<Schema, Method, Path>][Method]>
-    >;
+  Path extends HttpSchemaPath.NonLiteral<Schema, Method>,
+> = Path | URL | FetchRequest<Schema, Method, LiteralHttpSchemaPathFromNonLiteral<Schema, Method, Path>>;
 
 export interface FetchFunction<Schema extends HttpSchema> {
-  <Path extends HttpSchemaPath.NonLiteral<Schema, Method>, Method extends HttpSchemaMethod<Schema>>(
+  <Method extends HttpSchemaMethod<Schema>, Path extends HttpSchemaPath.NonLiteral<Schema, Method>>(
     input: Path | URL,
-    init: FetchRequestInit<Schema, LiteralHttpSchemaPathFromNonLiteral<Schema, Method, Path>, Method>,
-  ): Promise<
-    FetchResponse<
-      LiteralHttpSchemaPathFromNonLiteral<Schema, Method, Path>,
-      Method,
-      Default<Schema[LiteralHttpSchemaPathFromNonLiteral<Schema, Method, Path>][Method]>
-    >
-  >;
+    init: FetchRequestInit<Schema, Method, LiteralHttpSchemaPathFromNonLiteral<Schema, Method, Path>>,
+  ): Promise<FetchResponse<Schema, Method, LiteralHttpSchemaPathFromNonLiteral<Schema, Method, Path>>>;
 
-  <Path extends HttpSchemaPath.NonLiteral<Schema, Method>, Method extends HttpSchemaMethod<Schema>>(
-    input: FetchRequest<
-      LiteralHttpSchemaPathFromNonLiteral<Schema, Method, Path>,
-      Method,
-      Default<Schema[LiteralHttpSchemaPathFromNonLiteral<Schema, Method, Path>][Method]>
-    >,
-    init?: FetchRequestInit<Schema, LiteralHttpSchemaPathFromNonLiteral<Schema, Method, Path>, Method>,
-  ): Promise<
-    FetchResponse<
-      LiteralHttpSchemaPathFromNonLiteral<Schema, Method, Path>,
-      Method,
-      Default<Schema[LiteralHttpSchemaPathFromNonLiteral<Schema, Method, Path>][Method]>
-    >
-  >;
+  <Method extends HttpSchemaMethod<Schema>, Path extends HttpSchemaPath.NonLiteral<Schema, Method>>(
+    input: FetchRequest<Schema, Method, LiteralHttpSchemaPathFromNonLiteral<Schema, Method, Path>>,
+    init?: FetchRequestInit<Schema, Method, LiteralHttpSchemaPathFromNonLiteral<Schema, Method, Path>>,
+  ): Promise<FetchResponse<Schema, Method, LiteralHttpSchemaPathFromNonLiteral<Schema, Method, Path>>>;
 }
 
 export interface FetchOptions<Schema extends HttpSchema> extends Omit<FetchRequestInit.Defaults, 'method'> {
@@ -58,23 +35,23 @@ export interface FetchClient<Schema extends HttpSchema> {
   onRequest?: FetchOptions<Schema>['onRequest'];
   onResponse?: FetchOptions<Schema>['onResponse'];
 
-  isRequest: <Path extends HttpSchemaPath<Schema, Method>, Method extends HttpSchemaMethod<Schema>>(
+  isRequest: <Method extends HttpSchemaMethod<Schema>, Path extends HttpSchemaPath.Literal<Schema, Method>>(
     request: unknown,
     path: Path,
     method: Method,
-  ) => request is FetchRequest<Path, Method, Default<Schema[Path][Method]>>;
+  ) => request is FetchRequest<Schema, Method, Path>;
 
-  isResponse: <Path extends HttpSchemaPath<Schema, Method>, Method extends HttpSchemaMethod<Schema>>(
+  isResponse: <Method extends HttpSchemaMethod<Schema>, Path extends HttpSchemaPath.Literal<Schema, Method>>(
     response: unknown,
     path: Path,
     method: Method,
-  ) => response is FetchResponse<Path, Method, Default<Schema[Path][Method]>>;
+  ) => response is FetchResponse<Schema, Method, Path>;
 
-  isResponseError: <Path extends HttpSchemaPath<Schema, Method>, Method extends HttpSchemaMethod<Schema>>(
+  isResponseError: <Method extends HttpSchemaMethod<Schema>, Path extends HttpSchemaPath.Literal<Schema, Method>>(
     error: unknown,
     path: Path,
     method: Method,
-  ) => error is FetchResponseError<Path, Method, Default<Schema[Path][Method]>>;
+  ) => error is FetchResponseError<Schema, Method, Path>;
 }
 
 export type Fetch<Schema extends HttpSchema> = FetchFunction<Schema> & FetchClient<Schema>;

--- a/packages/zimic-fetch/src/client/types/public.ts
+++ b/packages/zimic-fetch/src/client/types/public.ts
@@ -37,20 +37,20 @@ export interface FetchClient<Schema extends HttpSchema> {
 
   isRequest: <Method extends HttpSchemaMethod<Schema>, Path extends HttpSchemaPath.Literal<Schema, Method>>(
     request: unknown,
-    path: Path,
     method: Method,
+    path: Path,
   ) => request is FetchRequest<Schema, Method, Path>;
 
   isResponse: <Method extends HttpSchemaMethod<Schema>, Path extends HttpSchemaPath.Literal<Schema, Method>>(
     response: unknown,
-    path: Path,
     method: Method,
+    path: Path,
   ) => response is FetchResponse<Schema, Method, Path>;
 
   isResponseError: <Method extends HttpSchemaMethod<Schema>, Path extends HttpSchemaPath.Literal<Schema, Method>>(
     error: unknown,
-    path: Path,
     method: Method,
+    path: Path,
   ) => error is FetchResponseError<Schema, Method, Path>;
 }
 

--- a/packages/zimic-fetch/tests/utils/interceptors.ts
+++ b/packages/zimic-fetch/tests/utils/interceptors.ts
@@ -13,7 +13,7 @@ type UsingInterceptorCallback<Schema extends HttpSchema> = (
 
 export async function usingHttpInterceptor<Schema extends HttpSchema>(
   interceptorOptions: HttpInterceptorOptions,
-  callback: UsingInterceptorCallback<HttpSchema<Schema>>,
+  callback: UsingInterceptorCallback<Schema>,
 ): Promise<void> {
   const interceptor = httpInterceptor.create<Schema>({
     ...interceptorOptions,

--- a/packages/zimic-interceptor/src/http/interceptor/factory.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/factory.ts
@@ -28,22 +28,22 @@ function isRemoteHttpInterceptorOptions(options: HttpInterceptorOptions) {
  */
 export function createHttpInterceptor<Schema extends HttpSchema>(
   options: LocalHttpInterceptorOptions,
-): PublicLocalHttpInterceptor<HttpSchema<Schema>>;
+): PublicLocalHttpInterceptor<Schema>;
 export function createHttpInterceptor<Schema extends HttpSchema>(
   options: RemoteHttpInterceptorOptions,
-): PublicRemoteHttpInterceptor<HttpSchema<Schema>>;
+): PublicRemoteHttpInterceptor<Schema>;
 export function createHttpInterceptor<Schema extends HttpSchema>(
   options: HttpInterceptorOptions,
-): PublicLocalHttpInterceptor<HttpSchema<Schema>> | PublicRemoteHttpInterceptor<HttpSchema<Schema>>;
+): PublicLocalHttpInterceptor<Schema> | PublicRemoteHttpInterceptor<Schema>;
 export function createHttpInterceptor<Schema extends HttpSchema>(
   options: HttpInterceptorOptions,
-): PublicLocalHttpInterceptor<HttpSchema<Schema>> | PublicRemoteHttpInterceptor<HttpSchema<Schema>> {
+): PublicLocalHttpInterceptor<Schema> | PublicRemoteHttpInterceptor<Schema> {
   const type = options.type;
 
   if (isLocalHttpInterceptorOptions(options)) {
-    return new LocalHttpInterceptor<HttpSchema<Schema>>(options);
+    return new LocalHttpInterceptor<Schema>(options);
   } else if (isRemoteHttpInterceptorOptions(options)) {
-    return new RemoteHttpInterceptor<HttpSchema<Schema>>(options);
+    return new RemoteHttpInterceptor<Schema>(options);
   }
 
   throw new UnknownHttpInterceptorTypeError(type);

--- a/packages/zimic-interceptor/src/http/requestHandler/HttpRequestHandlerClient.ts
+++ b/packages/zimic-interceptor/src/http/requestHandler/HttpRequestHandlerClient.ts
@@ -230,7 +230,7 @@ class HttpRequestHandlerClient<
 
   private matchesRequestHeadersRestrictions(
     request: HttpInterceptorRequest<Path, Default<Schema[Path][Method]>>,
-    restriction: HttpRequestHandlerStaticRestriction<Schema, Path, Method>,
+    restriction: HttpRequestHandlerStaticRestriction<Schema, Method, Path>,
   ): RestrictionMatchResult<RestrictionDiff<HttpHeaders<never>>> {
     if (restriction.headers === undefined) {
       return { value: true };
@@ -254,7 +254,7 @@ class HttpRequestHandlerClient<
 
   private matchesRequestSearchParamsRestrictions(
     request: HttpInterceptorRequest<Path, Default<Schema[Path][Method]>>,
-    restriction: HttpRequestHandlerStaticRestriction<Schema, Path, Method>,
+    restriction: HttpRequestHandlerStaticRestriction<Schema, Method, Path>,
   ): RestrictionMatchResult<RestrictionDiff<HttpSearchParams<never>>> {
     if (restriction.searchParams === undefined) {
       return { value: true };
@@ -278,7 +278,7 @@ class HttpRequestHandlerClient<
 
   private async matchesRequestBodyRestrictions(
     request: HttpInterceptorRequest<Path, Default<Schema[Path][Method]>>,
-    restriction: HttpRequestHandlerStaticRestriction<Schema, Path, Method>,
+    restriction: HttpRequestHandlerStaticRestriction<Schema, Method, Path>,
   ): Promise<RestrictionMatchResult<RestrictionDiff<unknown>>> {
     if (restriction.body === undefined) {
       return { value: true };

--- a/packages/zimic-interceptor/src/http/requestHandler/types/restrictions.ts
+++ b/packages/zimic-interceptor/src/http/requestHandler/types/restrictions.ts
@@ -29,8 +29,8 @@ type PartialHttpHeadersOrSchema<Schema extends HttpHeadersSchema> = IfNever<
  */
 export type HttpRequestHandlerHeadersStaticRestriction<
   Schema extends HttpSchema,
-  Path extends HttpSchemaPath<Schema, Method>,
   Method extends HttpSchemaMethod<Schema>,
+  Path extends HttpSchemaPath<Schema, Method>,
 > = PartialHttpHeadersOrSchema<HttpRequestHeadersSchema<Default<Schema[Path][Method]>>>;
 
 type PartialHttpSearchParamsOrSchema<Schema extends HttpSearchParamsSchema> = IfNever<
@@ -46,8 +46,8 @@ type PartialHttpSearchParamsOrSchema<Schema extends HttpSearchParamsSchema> = If
  */
 export type HttpRequestHandlerSearchParamsStaticRestriction<
   Schema extends HttpSchema,
-  Path extends HttpSchemaPath<Schema, Method>,
   Method extends HttpSchemaMethod<Schema>,
+  Path extends HttpSchemaPath<Schema, Method>,
 > = PartialHttpSearchParamsOrSchema<HttpRequestSearchParamsSchema<Default<Schema[Path][Method]>>>;
 
 type PartialBodyOrSchema<Body extends HttpBody> =
@@ -66,8 +66,8 @@ type PartialBodyOrSchema<Body extends HttpBody> =
  */
 export type HttpRequestHandlerBodyStaticRestriction<
   Schema extends HttpSchema,
-  Path extends HttpSchemaPath<Schema, Method>,
   Method extends HttpSchemaMethod<Schema>,
+  Path extends HttpSchemaPath<Schema, Method>,
 > = PartialBodyOrSchema<HttpRequestBodySchema<Default<Schema[Path][Method]>>>;
 
 /**
@@ -77,26 +77,26 @@ export type HttpRequestHandlerBodyStaticRestriction<
  */
 export interface HttpRequestHandlerStaticRestriction<
   Schema extends HttpSchema,
-  Path extends HttpSchemaPath<Schema, Method>,
   Method extends HttpSchemaMethod<Schema>,
+  Path extends HttpSchemaPath<Schema, Method>,
 > {
   /**
    * A set of headers that the intercepted request must contain to match the handler. If exact is `true`, the request
    * must contain exactly these headers and no others.
    */
-  headers?: HttpRequestHandlerHeadersStaticRestriction<Schema, Path, Method>;
+  headers?: HttpRequestHandlerHeadersStaticRestriction<Schema, Method, Path>;
 
   /**
    * A set of search params that the intercepted request must contain to match the handler. If exact is `true`, the
    * request must contain exactly these search params and no others.
    */
-  searchParams?: HttpRequestHandlerSearchParamsStaticRestriction<Schema, Path, Method>;
+  searchParams?: HttpRequestHandlerSearchParamsStaticRestriction<Schema, Method, Path>;
 
   /**
    * The body that the intercepted request must contain to match the handler. If exact is `true`, the request must
    * contain exactly this body and no other.
    */
-  body?: HttpRequestHandlerBodyStaticRestriction<Schema, Path, Method>;
+  body?: HttpRequestHandlerBodyStaticRestriction<Schema, Method, Path>;
 
   /**
    * If `true`, the request must contain **exactly** the headers, search params, and body declared in this restriction.
@@ -126,7 +126,7 @@ export type HttpRequestHandlerRestriction<
   Method extends HttpSchemaMethod<Schema>,
   Path extends HttpSchemaPath<Schema, Method>,
 > =
-  | HttpRequestHandlerStaticRestriction<Schema, Path, Method>
+  | HttpRequestHandlerStaticRestriction<Schema, Method, Path>
   | HttpRequestHandlerComputedRestriction<Schema, Method, Path>;
 
 export interface RestrictionDiff<Value> {

--- a/packages/zimic-interceptor/tests/utils/interceptors.ts
+++ b/packages/zimic-interceptor/tests/utils/interceptors.ts
@@ -66,9 +66,7 @@ export function createInternalHttpInterceptor<Schema extends HttpSchema>(options
   return httpInterceptor.create<Schema>({
     saveRequests: true,
     ...options,
-  }) satisfies HttpInterceptor<HttpSchema<Schema>> as
-    | LocalHttpInterceptor<HttpSchema<Schema>>
-    | RemoteHttpInterceptor<HttpSchema<Schema>>;
+  }) satisfies HttpInterceptor<Schema> as LocalHttpInterceptor<Schema> | RemoteHttpInterceptor<Schema>;
 }
 
 type UsingInterceptorCallback<Schema extends HttpSchema> = (

--- a/packages/zimic-utils/error/expectToThrow.d.ts
+++ b/packages/zimic-utils/error/expectToThrow.d.ts
@@ -1,0 +1,4 @@
+import expectToThrow from '../dist/error/expectToThrow';
+
+export * from '../dist/error/expectToThrow';
+export default expectToThrow;

--- a/packages/zimic-utils/package.json
+++ b/packages/zimic-utils/package.json
@@ -67,6 +67,12 @@
       "require": "./dist/data/fileEquals.js",
       "default": "./dist/data/fileEquals.js"
     },
+    "./error/expectToThrow": {
+      "types": "./error/expectToThrow.d.ts",
+      "import": "./dist/error/expectToThrow.mjs",
+      "require": "./dist/error/expectToThrow.js",
+      "default": "./dist/error/expectToThrow.js"
+    },
     "./fetch/expectFetchError": {
       "types": "./fetch/expectFetchError.d.ts",
       "import": "./dist/fetch/expectFetchError.mjs",

--- a/packages/zimic-utils/src/error/expectToThrow.ts
+++ b/packages/zimic-utils/src/error/expectToThrow.ts
@@ -1,0 +1,35 @@
+import { PossiblePromise } from '@/types';
+
+export class ExpectedToThrowError extends Error {
+  constructor() {
+    super('Expected an error to be thrown, but succeeded instead.');
+  }
+}
+
+async function expectToThrow<ExpectedError extends Error = Error>(
+  promiseOrCallback: Promise<unknown> | (() => PossiblePromise<unknown>),
+  options: { is: (error: unknown) => error is ExpectedError },
+): Promise<ExpectedError> {
+  const { is: isExpectedError } = options;
+
+  try {
+    if (promiseOrCallback instanceof Promise) {
+      await promiseOrCallback;
+    } else {
+      await promiseOrCallback();
+    }
+    throw new ExpectedToThrowError();
+  } catch (error) {
+    if (error instanceof ExpectedToThrowError) {
+      throw error;
+    }
+
+    if (!isExpectedError(error)) {
+      throw error;
+    }
+
+    return error;
+  }
+}
+
+export default expectToThrow;

--- a/packages/zimic-utils/tsup.config.ts
+++ b/packages/zimic-utils/tsup.config.ts
@@ -23,6 +23,7 @@ const neutralConfig = (['cjs', 'esm'] as const).map<Options>((format) => ({
     'data/blobEquals': 'src/data/blobEquals.ts',
     'data/blobContains': 'src/data/blobContains.ts',
     'data/fileEquals': 'src/data/fileEquals.ts',
+    'error/expectToThrow': 'src/error/expectToThrow.ts',
     'fetch/expectFetchError': 'src/fetch/expectFetchError.ts',
     'import/createCachedDynamicImport': 'src/import/createCachedDynamicImport.ts',
     'time/waitFor': 'src/time/waitFor.ts',


### PR DESCRIPTION
- feat(#zimic-fetch): improve types
- feat(#zimic-interceptor): improve types
- perf(#zimic-interceptor): remove double http schema normalization
- perf(#zimic-fetch): remove double http schema normalization
- feat(#zimic-utils): create `expectToThrow` utility
- test(zimic-test-client): verify fetch client implementation
- fix(ci): test npm release using canary code

Part of #565.
