### PR TITLE
feat(#zimic-interceptor): infer optional `content-type` when possible

### DIFF
--- a/examples/with-openapi-typegen/tests/example.test.ts
+++ b/examples/with-openapi-typegen/tests/example.test.ts
@@ -28,7 +28,6 @@ describe('Example tests', () => {
       .get(`/repos/${ownerName}/${repositoryName}`)
       .respond({
         status: 200,
-        headers: { 'content-type': 'application/json' },
         body: repository,
       })
       .times(1);
@@ -47,7 +46,6 @@ describe('Example tests', () => {
       .get('/repos/:owner/:name')
       .respond({
         status: 404,
-        headers: { 'content-type': 'application/json' },
         body: { message: 'Not Found' },
       })
       .times(1);

--- a/packages/zimic-interceptor/src/http/requestHandler/types/requests.ts
+++ b/packages/zimic-interceptor/src/http/requestHandler/types/requests.ts
@@ -14,7 +14,7 @@ import {
   HttpStatusCode,
   InferPathParams,
 } from '@zimic/http';
-import { Default, PossiblePromise, ReplaceBy } from '@zimic/utils/types';
+import { Default, PartialByKey, PossiblePromise, ReplaceBy } from '@zimic/utils/types';
 
 export type HttpRequestHandlerResponseWithBody<ResponseSchema extends HttpResponseSchema> =
   unknown extends ResponseSchema['body']
@@ -23,10 +23,16 @@ export type HttpRequestHandlerResponseWithBody<ResponseSchema extends HttpRespon
       ? { body?: ReplaceBy<ReplaceBy<ResponseSchema['body'], undefined, null>, ArrayBuffer, Blob> }
       : { body: ReplaceBy<ResponseSchema['body'], ArrayBuffer, Blob> };
 
+type HttpRequestHandlerResponseHeaders<ResponseSchema extends HttpResponseSchema> = HttpHeadersInit<
+  PartialByKey<Default<ResponseSchema['headers']>, 'content-type'>
+>;
+
 export type HttpRequestHandlerResponseWithHeaders<ResponseSchema extends HttpResponseSchema> =
   undefined extends ResponseSchema['headers']
-    ? { headers?: undefined }
-    : { headers: HttpHeadersInit<Default<ResponseSchema['headers']>> };
+    ? { headers?: HttpRequestHandlerResponseHeaders<ResponseSchema> }
+    : keyof ResponseSchema['headers'] extends 'content-type'
+      ? { headers?: HttpRequestHandlerResponseHeaders<ResponseSchema> }
+      : { headers: HttpRequestHandlerResponseHeaders<ResponseSchema> };
 
 /** A declaration of an HTTP response for an intercepted request. */
 export type HttpRequestHandlerResponseDeclaration<

--- a/packages/zimic-utils/src/types/index.ts
+++ b/packages/zimic-utils/src/types/index.ts
@@ -39,6 +39,8 @@ export type ReplaceBy<Type, Source, Target> = Type extends Source ? Target : Typ
 
 export type Collection<Type> = Type[] | Set<Type>;
 
+export type PartialByKey<Type, Key extends keyof Type> = Omit<Type, Key> & Partial<Pick<Type, Key>>;
+
 export type DeepPartial<Type> = Type extends (...parameters: never[]) => unknown
   ? Type
   : Type extends (infer ArrayItem)[]


### PR DESCRIPTION
### Features
- [#zimic-interceptor] When `content-type` is the only declared header in a response schema, Zimic interceptors now treat it as optional. This is possible because the interceptors automatically populate the expected content-type based on the response body. Keeping any `content-type` as required in all response declarations would introduce unnecessary verbosity. This issue is specially evident in `zimic-http typegen`, because all requests and responses include at least a `content-type` header after https://github.com/zimicjs/zimic/pull/599.

The following code is now valid:

```ts
const interceptor = httpInterceptor.create<{
  '/users': {
    GET: {
      response: {
        200: {
          headers: { 'content-type': 'application/json' };
          body: User;
        };
      };
    };
}>({
  type: 'local',
  baseURL: 'http://localhost:3000',
})

interceptor.get('/users').respond({
  status: 200,
  body: users[0],
});
```
