### PR TITLE
refactor(#zimic-fetch)!: improve type exports

### DIFF
--- a/apps/zimic-test-client/tests/exports/exports.test.ts
+++ b/apps/zimic-test-client/tests/exports/exports.test.ts
@@ -1,14 +1,14 @@
 import {
   createFetch,
   type Fetch,
-  type FetchClient,
-  type FetchClientOptions,
-  type FetchFunction,
+  type FetchOptions,
+  type InferFetchSchema,
   type FetchInput,
   type FetchRequest,
   type FetchRequestConstructor,
   type FetchRequestInit,
   type FetchResponse,
+  type JSONStringified,
   FetchResponseError,
 } from '@zimic/fetch';
 import {
@@ -172,15 +172,15 @@ describe('Exports', () => {
 
     expect(typeof createFetch).toBe('function');
     expectTypeOf<Fetch<never>>().not.toBeAny();
-    expectTypeOf<FetchClient<never>>().not.toBeAny();
-    expectTypeOf<FetchClientOptions<never>>().not.toBeAny();
-    expectTypeOf<FetchFunction<never>>().not.toBeAny();
+    expectTypeOf<FetchOptions<never>>().not.toBeAny();
+    expectTypeOf<InferFetchSchema<never>>().not.toBeAny();
     expectTypeOf<FetchInput<never, never, never>>().not.toBeAny();
     expectTypeOf<FetchRequest<never, never, never>>().not.toBeAny();
     expectTypeOf<FetchRequestConstructor<never>>().not.toBeAny();
     expectTypeOf<FetchRequestInit<never, never, never>>().not.toBeAny();
     expectTypeOf<FetchResponse<never, never, never>>().not.toBeAny();
     expectTypeOf<FetchResponseError<never, never, never>>().not.toBeAny();
+    expectTypeOf<JSONStringified<never>>().not.toBeAny();
     expect(typeof FetchResponseError).toBe('function');
 
     expectTypeOf<HttpInterceptorNamespace>().not.toBeAny();

--- a/packages/zimic-fetch/src/client/FetchClient.ts
+++ b/packages/zimic-fetch/src/client/FetchClient.ts
@@ -26,8 +26,8 @@ class FetchClient<Schema extends HttpSchema> {
 
   private createFetchFunction() {
     const fetch = async <
-      Path extends HttpSchemaPath.NonLiteral<Schema, Method>,
       Method extends HttpSchemaMethod<Schema>,
+      Path extends HttpSchemaPath.NonLiteral<Schema, Method>,
     >(
       input: FetchInput<Schema, Method, Path>,
       init: FetchRequestInit<Schema, Method, LiteralHttpSchemaPathFromNonLiteral<Schema, Method, Path>>,

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.defaults.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.defaults.test.ts
@@ -4,8 +4,8 @@ import { describe, expect, expectTypeOf, it } from 'vitest';
 
 import { usingHttpInterceptor } from '@tests/utils/interceptors';
 
-import { FetchClientOptions } from '../..';
 import createFetch from '../factory';
+import { FetchOptions } from '../types/public';
 import { FetchResponse, FetchRequest, FetchRequestInit } from '../types/requests';
 
 describe('FetchClient (node) > Defaults', () => {
@@ -96,7 +96,7 @@ describe('FetchClient (node) > Defaults', () => {
         referrer: 'about:client',
         referrerPolicy: 'origin',
         signal: new AbortController().signal,
-      } satisfies FetchClientOptions<Schema>;
+      } satisfies FetchOptions<Schema>;
 
       const fetch = createFetch<Schema>(defaults);
 
@@ -177,7 +177,7 @@ describe('FetchClient (node) > Defaults', () => {
         referrer: 'about:client',
         referrerPolicy: 'origin',
         signal: new AbortController().signal,
-      } satisfies FetchClientOptions<Schema>;
+      } satisfies FetchOptions<Schema>;
 
       fetch.defaults.baseURL = defaults.baseURL;
       fetch.defaults.cache = defaults.cache;

--- a/packages/zimic-fetch/src/client/types/public.ts
+++ b/packages/zimic-fetch/src/client/types/public.ts
@@ -10,7 +10,7 @@ export type FetchInput<
   Path extends HttpSchemaPath.NonLiteral<Schema, Method>,
 > = Path | URL | FetchRequest<Schema, Method, LiteralHttpSchemaPathFromNonLiteral<Schema, Method, Path>>;
 
-export interface FetchFunction<Schema extends HttpSchema> {
+interface FetchFunction<Schema extends HttpSchema> {
   <Method extends HttpSchemaMethod<Schema>, Path extends HttpSchemaPath.NonLiteral<Schema, Method>>(
     input: Path | URL,
     init: FetchRequestInit<Schema, Method, LiteralHttpSchemaPathFromNonLiteral<Schema, Method, Path>>,
@@ -27,7 +27,7 @@ export interface FetchOptions<Schema extends HttpSchema> extends Omit<FetchReque
   onResponse?: (response: FetchResponse.Loose, fetch: Fetch<Schema>) => PossiblePromise<Response>;
 }
 
-export interface FetchClient<Schema extends HttpSchema> {
+interface FetchClient<Schema extends HttpSchema> {
   defaults: FetchRequestInit.Defaults;
 
   Request: FetchRequestConstructor<Schema>;

--- a/packages/zimic-fetch/src/client/types/requests.ts
+++ b/packages/zimic-fetch/src/client/types/requests.ts
@@ -24,25 +24,33 @@ import FetchResponseError, { AnyFetchRequestError } from '../errors/FetchRespons
 import { JSONStringified } from './json';
 import { FetchInput } from './public';
 
+type FetchRequestInitHeaders<RequestSchema extends HttpRequestSchema> =
+  | RequestSchema['headers']
+  | HttpHeaders<Default<RequestSchema['headers']>>;
+
 type FetchRequestInitWithHeaders<RequestSchema extends HttpRequestSchema> = [RequestSchema['headers']] extends [never]
   ? { headers?: undefined }
   : undefined extends RequestSchema['headers']
-    ? { headers?: RequestSchema['headers'] | HttpHeaders<Default<RequestSchema['headers']>> }
-    : { headers: RequestSchema['headers'] | HttpHeaders<Default<RequestSchema['headers']>> };
+    ? { headers?: FetchRequestInitHeaders<RequestSchema> }
+    : { headers: FetchRequestInitHeaders<RequestSchema> };
+
+type FetchRequestInitSearchParams<RequestSchema extends HttpRequestSchema> =
+  | RequestSchema['searchParams']
+  | HttpSearchParams<Default<RequestSchema['searchParams']>>;
 
 type FetchRequestInitWithSearchParams<RequestSchema extends HttpRequestSchema> = [
   RequestSchema['searchParams'],
 ] extends [never]
   ? { searchParams?: undefined }
   : undefined extends RequestSchema['searchParams']
-    ? { searchParams?: RequestSchema['searchParams'] | HttpSearchParams<Default<RequestSchema['searchParams']>> }
-    : { searchParams: RequestSchema['searchParams'] | HttpSearchParams<Default<RequestSchema['searchParams']>> };
+    ? { searchParams?: FetchRequestInitSearchParams<RequestSchema> }
+    : { searchParams: FetchRequestInitSearchParams<RequestSchema> };
 
 type FetchRequestInitWithBody<RequestSchema extends HttpRequestSchema> = [RequestSchema['body']] extends [never]
   ? { body?: null }
   : RequestSchema['body'] extends string
     ? undefined extends RequestSchema['body']
-      ? { body?: RequestSchema['body'] }
+      ? { body?: ReplaceBy<RequestSchema['body'], undefined, null> }
       : { body: RequestSchema['body'] }
     : RequestSchema['body'] extends JSONValue
       ? undefined extends RequestSchema['body']
@@ -80,7 +88,7 @@ type FetchResponseStatusCode<MethodSchema extends HttpMethodSchema, ErrorOnly ex
   ? AllFetchResponseStatusCode<MethodSchema> & (HttpStatusCode.ClientError | HttpStatusCode.ServerError)
   : AllFetchResponseStatusCode<MethodSchema>;
 
-export type HttpRequestBodySchema<MethodSchema extends HttpMethodSchema> = ReplaceBy<
+type HttpRequestBodySchema<MethodSchema extends HttpMethodSchema> = ReplaceBy<
   ReplaceBy<IfNever<DefaultNoExclude<Default<MethodSchema['request']>['body']>, null>, undefined, null>,
   ArrayBuffer,
   Blob

--- a/packages/zimic-fetch/src/index.ts
+++ b/packages/zimic-fetch/src/index.ts
@@ -1,10 +1,6 @@
-export type {
-  Fetch,
-  FetchFunction,
-  FetchClient,
-  FetchOptions as FetchClientOptions,
-  FetchInput,
-} from './client/types/public';
+export type { JSONStringified } from './client/types/json';
+
+export type { Fetch, InferFetchSchema, FetchOptions, FetchInput } from './client/types/public';
 
 export type { FetchRequestInit, FetchRequest, FetchRequestConstructor, FetchResponse } from './client/types/requests';
 


### PR DESCRIPTION
### Refactoring
- [#zimic-fetch] Improved the types exported by `@zimic/fetch`:
  - Added `JSONStringified`
  - Renamed `FetchClientOptions` to `FetchOptions`
  - Removed `FetchFunction` and `FetchClient` from the exports, as these are internal types.
