### PR TITLE
fix(root): bundle `@zimic/utils` types

### DIFF
--- a/packages/zimic-fetch/tsup.config.ts
+++ b/packages/zimic-fetch/tsup.config.ts
@@ -16,11 +16,10 @@ const neutralConfig = (['cjs', 'esm'] as const).map<Options>((format) => ({
   name: `neutral-${format}`,
   platform: 'neutral',
   format: [format],
-  dts: format === 'cjs',
+  dts: format === 'cjs' ? { resolve: true } : false,
   entry: {
     index: 'src/index.ts',
   },
-  external: ['buffer'],
 }));
 
 export default defineConfig([...neutralConfig]);

--- a/packages/zimic-http/tsup.config.ts
+++ b/packages/zimic-http/tsup.config.ts
@@ -21,7 +21,7 @@ const neutralConfig = (['cjs', 'esm'] as const).map<Options>((format) => ({
   name: `neutral-${format}`,
   platform: 'neutral',
   format: [format],
-  dts: format === 'cjs',
+  dts: format === 'cjs' ? { resolve: true } : false,
   entry: {
     index: 'src/index.ts',
   },
@@ -43,7 +43,7 @@ const nodeConfig = (['cjs', 'esm'] as const).map<Options>((format) => {
     name: `node-${format}`,
     platform: 'node',
     format: [format],
-    dts: format === 'cjs' ? { entry: dtsEntry } : false,
+    dts: format === 'cjs' ? { entry: dtsEntry, resolve: true } : false,
     entry,
   };
 });

--- a/packages/zimic-interceptor/tsup.config.ts
+++ b/packages/zimic-interceptor/tsup.config.ts
@@ -19,7 +19,7 @@ const neutralConfig = (['cjs', 'esm'] as const).map<Options>((format) => ({
   name: `neutral-${format}`,
   platform: 'neutral',
   format: [format],
-  dts: format === 'cjs',
+  dts: format === 'cjs' ? { resolve: true } : false,
   entry: {
     index: 'src/index.ts',
     http: 'src/http/index.ts',
@@ -43,7 +43,7 @@ const nodeConfig = (['cjs', 'esm'] as const).map<Options>((format) => {
     name: `node-${format}`,
     platform: 'node',
     format: [format],
-    dts: format === 'cjs' ? { entry: dtsEntry } : false,
+    dts: format === 'cjs' ? { entry: dtsEntry, resolve: true } : false,
     entry,
   };
 });


### PR DESCRIPTION
### Fixes
- [#zimic-interceptor, #zimic-fetch, #zimic-http] Added `resolve: true` to the type declaration config on `tsup.config.ts`, so that the type referenced from `@zimic/utils` are bundled inline in the `.d.ts` files, instead of imported.