### PR TITLE
fix(#zimic-fetch): merge headers and search params with defaults

### DIFF
--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.defaults.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.defaults.test.ts
@@ -5,8 +5,8 @@ import { describe, expect, expectTypeOf, it } from 'vitest';
 import { usingHttpInterceptor } from '@tests/utils/interceptors';
 
 import createFetch from '../factory';
-import { FetchOptions } from '../types/public';
-import { FetchResponse, FetchRequest, FetchRequestInit } from '../types/requests';
+import { FetchDefaults, FetchOptions } from '../types/public';
+import { FetchResponse, FetchRequest } from '../types/requests';
 
 describe('FetchClient (node) > Defaults', () => {
   const baseURL = 'http://localhost:3000';
@@ -17,7 +17,7 @@ describe('FetchClient (node) > Defaults', () => {
 
   const users: User[] = [{ name: 'User 1' }, { name: 'User 2' }];
 
-  it('should support creating fetch clients without defaults', async () => {
+  it('should support creating a fetch client without defaults', async () => {
     type Schema = HttpSchema<{
       '/users': {
         GET: {
@@ -27,17 +27,15 @@ describe('FetchClient (node) > Defaults', () => {
     }>;
 
     await usingHttpInterceptor<Schema>({ type: 'local', baseURL }, async (interceptor) => {
-      await interceptor
-        .get('/users')
-        .respond({
-          status: 200,
-          body: users,
-        })
-        .times(1);
+      await interceptor.get('/users').respond({ status: 200, body: users }).times(1);
 
       const fetch = createFetch<Schema>({ baseURL });
 
-      expect(fetch.defaults).toEqual<FetchRequestInit.Defaults>({ baseURL });
+      expect(fetch.defaults).toEqual<FetchDefaults>({
+        baseURL,
+        headers: {},
+        searchParams: {},
+      });
 
       const response = await fetch('/users', { method: 'GET' });
 
@@ -58,12 +56,13 @@ describe('FetchClient (node) > Defaults', () => {
     });
   });
 
-  it('should support creating fetch clients with defaults', async () => {
+  it('should support creating a fetch client with defaults', async () => {
     type Schema = HttpSchema<{
       '/users': {
         POST: {
           request: {
             headers?: { 'content-type': 'application/json' };
+            searchParams?: { limit: number };
             body?: { name: string };
           };
           response: {
@@ -76,11 +75,11 @@ describe('FetchClient (node) > Defaults', () => {
     await usingHttpInterceptor<Schema>({ type: 'local', baseURL }, async (interceptor) => {
       await interceptor
         .post('/users')
-        .with({ headers: { 'content-type': 'application/json' } })
-        .respond({
-          status: 200,
-          body: users,
+        .with({
+          headers: { 'content-type': 'application/json' },
+          searchParams: { limit: '10' },
         })
+        .respond({ status: 200, body: users })
         .times(1);
 
       const defaults = {
@@ -88,6 +87,7 @@ describe('FetchClient (node) > Defaults', () => {
         cache: 'no-cache',
         credentials: 'same-origin',
         headers: { 'content-type': 'application/json' },
+        searchParams: { limit: '10' },
         body: JSON.stringify({ name: 'User 1' }),
         keepalive: true,
         mode: 'cors',
@@ -100,7 +100,7 @@ describe('FetchClient (node) > Defaults', () => {
 
       const fetch = createFetch<Schema>(defaults);
 
-      expect(fetch.defaults).toEqual<FetchRequestInit.Defaults>(defaults);
+      expect(fetch.defaults).toEqual<FetchDefaults>(defaults);
 
       const response = await fetch('/users', { method: 'POST' });
 
@@ -112,12 +112,12 @@ describe('FetchClient (node) > Defaults', () => {
       expect(response).toBeInstanceOf(Response);
       expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'POST', '/users'>>();
 
-      expect(response.url).toBe(joinURL(baseURL, '/users'));
+      expect(response.url).toBe(joinURL(baseURL, '/users?limit=10'));
 
       expect(response.request).toBeInstanceOf(Request);
       expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'POST', '/users'>>();
 
-      expect(response.request.url).toBe(joinURL(baseURL, '/users'));
+      expect(response.request.url).toBe(joinURL(baseURL, '/users?limit=10'));
 
       expect(response.request.cache).toBe(defaults.cache);
       expect(response.request.headers.get('content-type')).toBe(defaults.headers['content-type']);
@@ -138,6 +138,7 @@ describe('FetchClient (node) > Defaults', () => {
         POST: {
           request: {
             headers?: { 'content-type': 'application/json' };
+            searchParams?: { limit: number };
             body?: { name: string };
           };
           response: {
@@ -150,11 +151,11 @@ describe('FetchClient (node) > Defaults', () => {
     await usingHttpInterceptor<Schema>({ type: 'local', baseURL }, async (interceptor) => {
       await interceptor
         .post('/users')
-        // .with({ headers: { 'content-type': 'application/json' } })
-        .respond({
-          status: 200,
-          body: users,
+        .with({
+          headers: { 'content-type': 'application/json' },
+          searchParams: { limit: '10' },
         })
+        .respond({ status: 200, body: users })
         .times(1);
 
       const otherBaseURL = 'http://localhost:3001';
@@ -162,13 +163,18 @@ describe('FetchClient (node) > Defaults', () => {
 
       const fetch = createFetch<Schema>({ baseURL: otherBaseURL });
 
-      expect(fetch.defaults).toEqual<FetchRequestInit.Defaults>({ baseURL: otherBaseURL });
+      expect(fetch.defaults).toEqual<FetchDefaults>({
+        baseURL: otherBaseURL,
+        headers: {},
+        searchParams: {},
+      });
 
       const defaults = {
         baseURL,
         cache: 'no-cache',
         credentials: 'same-origin',
         headers: { 'content-type': 'application/json' },
+        searchParams: { limit: '10' },
         body: JSON.stringify({ name: 'User 1' }),
         keepalive: true,
         mode: 'cors',
@@ -182,7 +188,8 @@ describe('FetchClient (node) > Defaults', () => {
       fetch.defaults.baseURL = defaults.baseURL;
       fetch.defaults.cache = defaults.cache;
       fetch.defaults.credentials = defaults.credentials;
-      fetch.defaults.headers = defaults.headers;
+      fetch.defaults.headers['content-type'] = defaults.headers['content-type'];
+      fetch.defaults.searchParams.limit = defaults.searchParams.limit;
       fetch.defaults.body = defaults.body;
       fetch.defaults.keepalive = defaults.keepalive;
       fetch.defaults.mode = defaults.mode;
@@ -192,9 +199,84 @@ describe('FetchClient (node) > Defaults', () => {
       fetch.defaults.referrerPolicy = defaults.referrerPolicy;
       fetch.defaults.signal = defaults.signal;
 
-      expect(fetch.defaults).toEqual<FetchRequestInit.Defaults>(defaults);
+      expect(fetch.defaults).toEqual<FetchDefaults>(defaults);
 
       const response = await fetch('/users', { method: 'POST' });
+
+      expectTypeOf(response.status).toEqualTypeOf<200>();
+      expect(response.status).toBe(200);
+
+      expect(await response.json()).toEqual(users);
+
+      expect(response).toBeInstanceOf(Response);
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'POST', '/users'>>();
+
+      expect(response.url).toBe(joinURL(baseURL, '/users?limit=10'));
+
+      expect(response.request).toBeInstanceOf(Request);
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'POST', '/users'>>();
+
+      expect(response.request.url).toBe(joinURL(baseURL, '/users?limit=10'));
+
+      expect(response.request.cache).toBe(defaults.cache);
+      expect(response.request.headers.get('content-type')).toBe(defaults.headers['content-type']);
+      expect(response.request.credentials).toBe(defaults.credentials);
+      expect(await response.request.text()).toBe(defaults.body);
+      expect(response.request.keepalive).toBe(defaults.keepalive);
+      expect(response.request.mode).toBe(defaults.mode);
+      expect(response.request.redirect).toBe(defaults.redirect);
+      expect(response.request.referrer).toBe(defaults.referrer);
+      expect(response.request.referrerPolicy).toBe(defaults.referrerPolicy);
+      expect(response.request.signal).toBeInstanceOf(AbortSignal);
+    });
+  });
+
+  it('should merge request headers with defaults', async () => {
+    type Schema = HttpSchema<{
+      '/users': {
+        POST: {
+          request: {
+            headers?: {
+              'content-type'?: 'application/json';
+              'accept-language'?: string;
+            };
+            searchParams?: { limit: number };
+            body?: { name: string };
+          };
+          response: {
+            200: { body: User[] };
+          };
+        };
+      };
+    }>;
+
+    await usingHttpInterceptor<Schema>({ type: 'local', baseURL }, async (interceptor) => {
+      await interceptor
+        .post('/users')
+        .with({
+          headers: {
+            'content-type': 'application/json',
+            'accept-language': 'en',
+          },
+        })
+        .respond({ status: 200, body: users })
+        .times(1);
+
+      const fetch = createFetch<Schema>({
+        baseURL,
+        headers: { 'accept-language': 'en' },
+      });
+
+      expect(fetch.defaults).toEqual<FetchDefaults>({
+        baseURL,
+        headers: { 'accept-language': 'en' },
+        searchParams: {},
+      });
+
+      const response = await fetch('/users', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+      });
 
       expectTypeOf(response.status).toEqualTypeOf<200>();
       expect(response.status).toBe(200);
@@ -211,16 +293,183 @@ describe('FetchClient (node) > Defaults', () => {
 
       expect(response.request.url).toBe(joinURL(baseURL, '/users'));
 
-      expect(response.request.cache).toBe(defaults.cache);
-      expect(response.request.headers.get('content-type')).toBe(defaults.headers['content-type']);
-      expect(response.request.credentials).toBe(defaults.credentials);
-      expect(await response.request.text()).toBe(defaults.body);
-      expect(response.request.keepalive).toBe(defaults.keepalive);
-      expect(response.request.mode).toBe(defaults.mode);
-      expect(response.request.redirect).toBe(defaults.redirect);
-      expect(response.request.referrer).toBe(defaults.referrer);
-      expect(response.request.referrerPolicy).toBe(defaults.referrerPolicy);
-      expect(response.request.signal).toBeInstanceOf(AbortSignal);
+      expect(response.request.headers.get('content-type')).toBe('application/json');
+      expect(response.request.headers.get('accept-language')).toBe('en');
+    });
+  });
+
+  it('should prefer request headers over defaults, if overlapping', async () => {
+    type Schema = HttpSchema<{
+      '/users': {
+        POST: {
+          request: {
+            headers?: {
+              'content-type'?: 'application/json';
+              'accept-language'?: string;
+            };
+            searchParams?: { limit: number };
+            body?: { name: string };
+          };
+          response: {
+            200: { body: User[] };
+          };
+        };
+      };
+    }>;
+
+    await usingHttpInterceptor<Schema>({ type: 'local', baseURL }, async (interceptor) => {
+      await interceptor
+        .post('/users')
+        .with({
+          headers: {
+            'content-type': 'application/json',
+            'accept-language': 'fr',
+          },
+        })
+        .respond({ status: 200, body: users })
+        .times(1);
+
+      const fetch = createFetch<Schema>({
+        baseURL,
+        headers: { 'accept-language': 'en' },
+      });
+
+      expect(fetch.defaults).toEqual<FetchDefaults>({
+        baseURL,
+        headers: { 'accept-language': 'en' },
+        searchParams: {},
+      });
+
+      const response = await fetch('/users', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'accept-language': 'fr' },
+      });
+
+      expectTypeOf(response.status).toEqualTypeOf<200>();
+      expect(response.status).toBe(200);
+
+      expect(await response.json()).toEqual(users);
+
+      expect(response).toBeInstanceOf(Response);
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'POST', '/users'>>();
+
+      expect(response.url).toBe(joinURL(baseURL, '/users'));
+
+      expect(response.request).toBeInstanceOf(Request);
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'POST', '/users'>>();
+
+      expect(response.request.url).toBe(joinURL(baseURL, '/users'));
+
+      expect(response.request.headers.get('content-type')).toBe('application/json');
+      expect(response.request.headers.get('accept-language')).toBe('fr');
+    });
+  });
+
+  it('should merge search params with defaults', async () => {
+    type Schema = HttpSchema<{
+      '/users': {
+        GET: {
+          request: {
+            searchParams: { page?: number; limit?: number; username: string[] };
+          };
+          response: {
+            200: { body: User[] };
+          };
+        };
+      };
+    }>;
+
+    await usingHttpInterceptor<Schema>({ type: 'local', baseURL }, async (interceptor) => {
+      await interceptor
+        .get('/users')
+        .with({ searchParams: { page: '1', limit: '10', username: ['my', 'other'] } })
+        .respond({ status: 200, body: users })
+        .times(1);
+
+      const fetch = createFetch<Schema>({
+        baseURL,
+        searchParams: { limit: '10' },
+      });
+
+      expect(fetch.defaults).toEqual<FetchDefaults>({
+        baseURL,
+        headers: {},
+        searchParams: { limit: '10' },
+      });
+
+      const response = await fetch('/users', {
+        method: 'GET',
+        searchParams: { page: '1', username: ['my', 'other'] },
+      });
+
+      expectTypeOf(response.status).toEqualTypeOf<200>();
+      expect(response.status).toBe(200);
+
+      expect(await response.json()).toEqual(users);
+
+      expect(response).toBeInstanceOf(Response);
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'GET', '/users'>>();
+
+      expect(response.url).toBe(joinURL(baseURL, '/users?limit=10&page=1&username=my&username=other'));
+
+      expect(response.request).toBeInstanceOf(Request);
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'GET', '/users'>>();
+
+      expect(response.request.url).toBe(joinURL(baseURL, '/users?limit=10&page=1&username=my&username=other'));
+    });
+  });
+
+  it('should prefer search params over defaults, if overlapping', async () => {
+    type Schema = HttpSchema<{
+      '/users': {
+        GET: {
+          request: {
+            searchParams: { page?: number; limit?: number; username: string[] };
+          };
+          response: {
+            200: { body: User[] };
+          };
+        };
+      };
+    }>;
+
+    await usingHttpInterceptor<Schema>({ type: 'local', baseURL }, async (interceptor) => {
+      await interceptor
+        .get('/users')
+        .with({ searchParams: { page: '1', limit: '20', username: ['any', 'other'] } })
+        .respond({ status: 200, body: users })
+        .times(1);
+
+      const fetch = createFetch<Schema>({
+        baseURL,
+        searchParams: { limit: '10', username: ['my', 'other'] },
+      });
+
+      expect(fetch.defaults).toEqual<FetchDefaults>({
+        baseURL,
+        headers: {},
+        searchParams: { limit: '10', username: ['my', 'other'] },
+      });
+
+      const response = await fetch('/users', {
+        method: 'GET',
+        searchParams: { page: '1', limit: '20', username: ['any', 'other'] },
+      });
+
+      expectTypeOf(response.status).toEqualTypeOf<200>();
+      expect(response.status).toBe(200);
+
+      expect(await response.json()).toEqual(users);
+
+      expect(response).toBeInstanceOf(Response);
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'GET', '/users'>>();
+
+      expect(response.url).toBe(joinURL(baseURL, '/users?limit=20&page=1&username=any&username=other'));
+
+      expect(response.request).toBeInstanceOf(Request);
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'GET', '/users'>>();
+
+      expect(response.request.url).toBe(joinURL(baseURL, '/users?limit=20&page=1&username=any&username=other'));
     });
   });
 });

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.searchParams.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.searchParams.test.ts
@@ -182,7 +182,7 @@ describe('FetchClient (node) > Search params', () => {
       expect(request).toBeInstanceOf(Request);
       expectTypeOf(request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'GET', '/users'>>();
 
-      expect(request.url).toBe(joinURL(baseURL, '/users?name=User&usernames=User+1&usernames=User+2&orderBy=name'));
+      expect(request.url).toBe(joinURL(baseURL, '/users?name=User&orderBy=name&usernames=User+1&usernames=User+2'));
 
       responses.push(await fetch(request));
 

--- a/packages/zimic-fetch/src/client/factory.ts
+++ b/packages/zimic-fetch/src/client/factory.ts
@@ -1,9 +1,9 @@
 import { HttpSchema } from '@zimic/http';
 
 import FetchClient from './FetchClient';
-import { FetchOptions, Fetch as PublicFetch } from './types/public';
+import { FetchOptions, Fetch } from './types/public';
 
-function createFetch<Schema extends HttpSchema>(options: FetchOptions<Schema>): PublicFetch<Schema> {
+function createFetch<Schema extends HttpSchema>(options: FetchOptions<Schema>): Fetch<Schema> {
   const { fetch } = new FetchClient<Schema>(options);
   return fetch;
 }

--- a/packages/zimic-fetch/src/client/types/public.ts
+++ b/packages/zimic-fetch/src/client/types/public.ts
@@ -1,5 +1,5 @@
 import { HttpSchemaPath, HttpSchemaMethod, LiteralHttpSchemaPathFromNonLiteral, HttpSchema } from '@zimic/http';
-import { PossiblePromise } from '@zimic/utils/types';
+import { PossiblePromise, RequiredByKey } from '@zimic/utils/types';
 
 import FetchResponseError from '../errors/FetchResponseError';
 import { FetchRequest, FetchRequestConstructor, FetchRequestInit, FetchResponse } from './requests';
@@ -27,13 +27,12 @@ export interface FetchOptions<Schema extends HttpSchema> extends Omit<FetchReque
   onResponse?: (this: Fetch<Schema>, response: FetchResponse.Loose) => PossiblePromise<Response>;
 }
 
-interface FetchClient<Schema extends HttpSchema> {
-  defaults: FetchRequestInit.Defaults;
+export type FetchDefaults = RequiredByKey<FetchRequestInit.Defaults, 'headers' | 'searchParams'>;
+
+interface FetchClient<Schema extends HttpSchema> extends Pick<FetchOptions<Schema>, 'onRequest' | 'onResponse'> {
+  defaults: FetchDefaults;
 
   Request: FetchRequestConstructor<Schema>;
-
-  onRequest?: FetchOptions<Schema>['onRequest'];
-  onResponse?: FetchOptions<Schema>['onResponse'];
 
   isRequest: <Method extends HttpSchemaMethod<Schema>, Path extends HttpSchemaPath.Literal<Schema, Method>>(
     request: unknown,

--- a/packages/zimic-fetch/src/client/types/requests.ts
+++ b/packages/zimic-fetch/src/client/types/requests.ts
@@ -17,6 +17,8 @@ import {
   HttpResponseBodySchema,
   HttpResponseHeadersSchema,
   HttpRequestHeadersSchema,
+  HttpHeadersSchema,
+  HttpSearchParamsSchema,
 } from '@zimic/http';
 import { Default, DefaultNoExclude, IfNever, ReplaceBy } from '@zimic/utils/types';
 
@@ -73,10 +75,12 @@ export type FetchRequestInit<
     : never);
 
 export namespace FetchRequestInit {
-  export interface Defaults extends RequestInit {
+  /** The default options for each request sent by a fetch instance. */
+  export interface Defaults extends Omit<RequestInit, 'headers'> {
     baseURL: string;
     method?: HttpMethod;
-    searchParams?: HttpSearchParams;
+    headers?: HttpHeadersSchema;
+    searchParams?: HttpSearchParamsSchema;
   }
 }
 

--- a/packages/zimic-fetch/src/index.ts
+++ b/packages/zimic-fetch/src/index.ts
@@ -1,8 +1,8 @@
 export type { JSONStringified } from './client/types/json';
 
-export type { Fetch, InferFetchSchema, FetchOptions, FetchInput } from './client/types/public';
+export type { Fetch, InferFetchSchema, FetchOptions, FetchDefaults, FetchInput } from './client/types/public';
 
-export type { FetchRequestInit, FetchRequest, FetchRequestConstructor, FetchResponse } from './client/types/requests';
+export type { FetchRequest, FetchRequestInit, FetchResponse, FetchRequestConstructor } from './client/types/requests';
 
 export { default as FetchResponseError } from './client/errors/FetchResponseError';
 

--- a/packages/zimic-utils/src/types/index.ts
+++ b/packages/zimic-utils/src/types/index.ts
@@ -41,6 +41,8 @@ export type Collection<Type> = Type[] | Set<Type>;
 
 export type PartialByKey<Type, Key extends keyof Type> = Omit<Type, Key> & Partial<Pick<Type, Key>>;
 
+export type RequiredByKey<Type, Key extends keyof Type> = Omit<Type, Key> & Required<Pick<Type, Key>>;
+
 export type DeepPartial<Type> = Type extends (...parameters: never[]) => unknown
   ? Type
   : Type extends (infer ArrayItem)[]


### PR DESCRIPTION
### Fixes
- [fetch] When using default headers and/or search params in a fetch client, headers or search params declared in a request would not merge with the defaults, but complete override them in the request. This was not expected, because headers and search params should be merged with the defaults in a request, preferring the data of the request. This PR fixes this issue.

```ts
const fetch = createFetch<MySchema>({
  baseURL: 'http://localhost:3000',
  headers: { 'accept-language': 'en' },
});

const response = await fetch('/users', {
  method: 'GET',
  headers: { 'user-agent': 'client' }
})
// The request will have { 'accept-language': 'en', 'user-agent': 'client' } as headers.