### PR TITLE
fix(fetch): correctly check request and response paths with slashes

### DIFF
--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.blob.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.blob.test.ts
@@ -7,7 +7,7 @@ import { usingHttpInterceptor } from '@tests/utils/interceptors';
 import createFetch from '../factory';
 import { FetchRequest, FetchResponse } from '../types/requests';
 
-describe('FetchClient (node) > Bodies > Blob', () => {
+describe('FetchClient > Bodies > Blob', () => {
   const baseURL = 'http://localhost:3000';
 
   it('should support requests and responses with a blob body', async () => {

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.formData.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.formData.test.ts
@@ -8,7 +8,7 @@ import { usingHttpInterceptor } from '@tests/utils/interceptors';
 import createFetch from '../factory';
 import { FetchRequest, FetchResponse } from '../types/requests';
 
-describe('FetchClient (node) > Bodies > Form data', () => {
+describe('FetchClient > Bodies > Form data', () => {
   const baseURL = 'http://localhost:3000';
 
   it('should support requests and responses with a form data body', async () => {

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.json.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.json.test.ts
@@ -7,7 +7,7 @@ import { usingHttpInterceptor } from '@tests/utils/interceptors';
 import createFetch from '../factory';
 import { FetchRequest, FetchResponse } from '../types/requests';
 
-describe('FetchClient (node) > Bodies > JSON', () => {
+describe('FetchClient > Bodies > JSON', () => {
   const baseURL = 'http://localhost:3000';
 
   interface User {

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.plainText.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.plainText.test.ts
@@ -7,7 +7,7 @@ import { usingHttpInterceptor } from '@tests/utils/interceptors';
 import createFetch from '../factory';
 import { FetchRequest, FetchResponse } from '../types/requests';
 
-describe('FetchClient (node) > Bodies > Plain text', () => {
+describe('FetchClient > Bodies > Plain text', () => {
   const baseURL = 'http://localhost:3000';
 
   it('should support requests and responses with a plain text body', async () => {

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.searchParams.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.searchParams.test.ts
@@ -7,7 +7,7 @@ import { usingHttpInterceptor } from '@tests/utils/interceptors';
 import createFetch from '../factory';
 import { FetchRequest, FetchResponse } from '../types/requests';
 
-describe('FetchClient (node) > Bodies > Search params', () => {
+describe('FetchClient > Bodies > Search params', () => {
   const baseURL = 'http://localhost:3000';
 
   it('should support requests and responses with search params', async () => {

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.test.ts
@@ -5,7 +5,7 @@ import { usingHttpInterceptor } from '@tests/utils/interceptors';
 
 import createFetch from '../factory';
 
-describe('FetchClient (node) > Bodies', () => {
+describe('FetchClient > Bodies', () => {
   const baseURL = 'http://localhost:3000';
 
   interface User {

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.defaults.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.defaults.test.ts
@@ -8,7 +8,7 @@ import createFetch from '../factory';
 import { FetchDefaults, FetchOptions } from '../types/public';
 import { FetchResponse, FetchRequest } from '../types/requests';
 
-describe('FetchClient (node) > Defaults', () => {
+describe('FetchClient > Defaults', () => {
   const baseURL = 'http://localhost:3000';
 
   interface User {

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.errors.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.errors.test.ts
@@ -8,7 +8,7 @@ import FetchResponseError from '../errors/FetchResponseError';
 import createFetch from '../factory';
 import { FetchResponse, FetchResponsePerStatusCode } from '../types/requests';
 
-describe('FetchClient (node) > Errors', () => {
+describe('FetchClient > Errors', () => {
   const baseURL = 'http://localhost:3000';
 
   interface User {

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.headers.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.headers.test.ts
@@ -7,7 +7,7 @@ import { usingHttpInterceptor } from '@tests/utils/interceptors';
 import createFetch from '../factory';
 import { FetchRequest, FetchResponse } from '../types/requests';
 
-describe('FetchClient (node) > Headers', () => {
+describe('FetchClient > Headers', () => {
   const baseURL = 'http://localhost:3000';
 
   interface User {

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.isRequest.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.isRequest.test.ts
@@ -1,0 +1,363 @@
+import { HttpSchema } from '@zimic/http';
+import joinURL from '@zimic/utils/url/joinURL';
+import { describe, expect, expectTypeOf, it } from 'vitest';
+
+import createFetch from '../factory';
+
+describe('FetchClient > isRequest', () => {
+  const baseURL = 'http://localhost:3000';
+
+  interface User {
+    id: string;
+    name: string;
+  }
+
+  const users: User[] = [
+    { id: '1', name: 'User 1' },
+    { id: '2', name: 'User 2' },
+  ];
+
+  it('should correctly check a fetch request without path params', () => {
+    type Schema = HttpSchema<{
+      '/users': {
+        POST: {
+          request: {
+            body: User;
+          };
+          response: {
+            201: { body: User };
+          };
+        };
+        GET: {
+          response: {
+            200: { body: User[] };
+          };
+        };
+      };
+
+      '/users/:userId': {
+        GET: {
+          response: {
+            200: { body: User };
+            404: {};
+          };
+        };
+      };
+    }>;
+
+    const fetch = createFetch<Schema>({
+      baseURL,
+    });
+
+    const request = new fetch.Request('/users', {
+      method: 'GET',
+    });
+
+    expect(request.url).toBe(joinURL(baseURL, '/users'));
+
+    expectTypeOf(request.method).toEqualTypeOf<'GET'>();
+    expect(request.method).toBe('GET');
+
+    expectTypeOf(request.path).toEqualTypeOf<'/users'>();
+    expect(request.path).toBe('/users');
+
+    expect(fetch.isRequest(request, 'GET', '/users')).toBe(true);
+    expect(fetch.isRequest(request, 'POST', '/users')).toBe(false);
+    expect(fetch.isRequest(request, 'GET', '/users/:userId')).toBe(false);
+  });
+
+  it('should correctly check a fetch request with path params', () => {
+    type Schema = HttpSchema<{
+      '/users': {
+        POST: {
+          request: {
+            body: User;
+          };
+          response: {
+            201: { body: User };
+          };
+        };
+        GET: {
+          response: {
+            200: { body: User[] };
+          };
+        };
+      };
+
+      '/users/:userId': {
+        GET: {
+          response: {
+            200: { body: User };
+            404: {};
+          };
+        };
+      };
+    }>;
+
+    const fetch = createFetch<Schema>({
+      baseURL,
+    });
+
+    const request = new fetch.Request(`/users/${users[0].id}`, {
+      method: 'GET',
+    });
+
+    expectTypeOf(request.method).toEqualTypeOf<'GET'>();
+    expect(request.method).toBe('GET');
+
+    expectTypeOf(request.path).toEqualTypeOf<`/users/${string}`>();
+    expect(request.path).toBe(`/users/${users[0].id}`);
+
+    expect(fetch.isRequest(request, 'GET', '/users')).toBe(false);
+    expect(fetch.isRequest(request, 'POST', '/users')).toBe(false);
+    expect(fetch.isRequest(request, 'GET', '/users/:userId')).toBe(true);
+  });
+
+  it('should correctly check a fetch request without a leading slash in the path', () => {
+    type Schema = HttpSchema<{
+      users: {
+        POST: {
+          request: {
+            body: User;
+          };
+          response: {
+            201: { body: User };
+          };
+        };
+        GET: {
+          response: {
+            200: { body: User[] };
+          };
+        };
+      };
+
+      'users/:userId': {
+        GET: {
+          response: {
+            200: { body: User };
+            404: {};
+          };
+        };
+      };
+    }>;
+
+    const fetch = createFetch<Schema>({
+      baseURL,
+    });
+
+    const request = new fetch.Request('users', {
+      method: 'GET',
+    });
+
+    expect(request.url).toBe(joinURL(baseURL, '/users'));
+
+    expectTypeOf(request.method).toEqualTypeOf<'GET'>();
+    expect(request.method).toBe('GET');
+
+    expectTypeOf(request.path).toEqualTypeOf<'users'>();
+    expect(request.path).toBe('/users');
+
+    expect(fetch.isRequest(request, 'GET', 'users')).toBe(true);
+
+    // @ts-expect-error Forcing a leading slash in the path
+    expect(fetch.isRequest(request, 'GET', '/users')).toBe(true);
+    // @ts-expect-error Forcing a trailing slash in the path
+    expect(fetch.isRequest(request, 'GET', 'users/')).toBe(true);
+    // @ts-expect-error Forcing a leading and trailing slash in the path
+    expect(fetch.isRequest(request, 'GET', '/users/')).toBe(true);
+
+    expect(fetch.isRequest(request, 'POST', 'users')).toBe(false);
+
+    // @ts-expect-error Forcing a leading slash in the path
+    expect(fetch.isRequest(request, 'POST', '/users')).toBe(false);
+    // @ts-expect-error Forcing a trailing slash in the path
+    expect(fetch.isRequest(request, 'POST', 'users/')).toBe(false);
+    // @ts-expect-error Forcing a leading and trailing slash in the path
+    expect(fetch.isRequest(request, 'POST', '/users/')).toBe(false);
+
+    expect(fetch.isRequest(request, 'GET', 'users/:userId')).toBe(false);
+
+    // @ts-expect-error Forcing a leading slash in the path
+    expect(fetch.isRequest(request, 'GET', '/users/:userId')).toBe(false);
+    // @ts-expect-error Forcing a trailing slash in the path
+    expect(fetch.isRequest(request, 'GET', 'users/:userId/')).toBe(false);
+    // @ts-expect-error Forcing a leading and trailing slash in the path
+    expect(fetch.isRequest(request, 'GET', '/users/:userId/')).toBe(false);
+  });
+
+  it('should correctly check a fetch request with a trailing slash in the path', () => {
+    type Schema = HttpSchema<{
+      'users/': {
+        POST: {
+          request: {
+            body: User;
+          };
+          response: {
+            201: { body: User };
+          };
+        };
+        GET: {
+          response: {
+            200: { body: User[] };
+          };
+        };
+      };
+
+      'users/:userId/': {
+        GET: {
+          response: {
+            200: { body: User };
+            404: {};
+          };
+        };
+      };
+    }>;
+
+    const fetch = createFetch<Schema>({
+      baseURL,
+    });
+
+    const request = new fetch.Request('users/', {
+      method: 'GET',
+    });
+
+    expect(request.url).toBe(joinURL(baseURL, '/users/'));
+
+    expectTypeOf(request.method).toEqualTypeOf<'GET'>();
+    expect(request.method).toBe('GET');
+
+    expectTypeOf(request.path).toEqualTypeOf<'users/'>();
+    expect(request.path).toBe('/users/');
+
+    expect(fetch.isRequest(request, 'GET', 'users/')).toBe(true);
+
+    // @ts-expect-error Forcing a no leading or training slashes in the path
+    expect(fetch.isRequest(request, 'GET', 'users')).toBe(true);
+    // @ts-expect-error Forcing a leading slash in the path
+    expect(fetch.isRequest(request, 'GET', '/users')).toBe(true);
+    // @ts-expect-error Forcing a leading and trailing slash in the path
+    expect(fetch.isRequest(request, 'GET', '/users/')).toBe(true);
+
+    expect(fetch.isRequest(request, 'POST', 'users/')).toBe(false);
+
+    // @ts-expect-error Forcing a trailing slash in the path
+    expect(fetch.isRequest(request, 'POST', 'users')).toBe(false);
+    // @ts-expect-error Forcing a leading slash in the path
+    expect(fetch.isRequest(request, 'POST', '/users')).toBe(false);
+    // @ts-expect-error Forcing a leading and trailing slash in the path
+    expect(fetch.isRequest(request, 'POST', '/users/')).toBe(false);
+
+    expect(fetch.isRequest(request, 'GET', 'users/:userId/')).toBe(false);
+
+    // @ts-expect-error Forcing a trailing slash in the path
+    expect(fetch.isRequest(request, 'GET', 'users/:userId')).toBe(false);
+    // @ts-expect-error Forcing a leading and trailing slash in the path
+    expect(fetch.isRequest(request, 'GET', '/users/:userId')).toBe(false);
+    // @ts-expect-error Forcing a leading slash in the path
+    expect(fetch.isRequest(request, 'GET', '/users/:userId/')).toBe(false);
+  });
+
+  it('should correctly check a fetch request with a leading and trailing slash in the path', () => {
+    type Schema = HttpSchema<{
+      '/users/': {
+        POST: {
+          request: {
+            body: User;
+          };
+          response: {
+            201: { body: User };
+          };
+        };
+        GET: {
+          response: {
+            200: { body: User[] };
+          };
+        };
+      };
+
+      '/users/:userId/': {
+        GET: {
+          response: {
+            200: { body: User };
+            404: {};
+          };
+        };
+      };
+    }>;
+
+    const fetch = createFetch<Schema>({
+      baseURL,
+    });
+
+    const request = new fetch.Request('/users/', {
+      method: 'GET',
+    });
+
+    expect(request.url).toBe(joinURL(baseURL, '/users/'));
+
+    expectTypeOf(request.method).toEqualTypeOf<'GET'>();
+    expect(request.method).toBe('GET');
+
+    expectTypeOf(request.path).toEqualTypeOf<'/users/'>();
+    expect(request.path).toBe('/users/');
+
+    expect(fetch.isRequest(request, 'GET', '/users/')).toBe(true);
+
+    // @ts-expect-error Forcing a trailing slash in the path
+    expect(fetch.isRequest(request, 'GET', 'users')).toBe(true);
+    // @ts-expect-error Forcing a trailing slash in the path
+    expect(fetch.isRequest(request, 'GET', 'users/')).toBe(true);
+    // @ts-expect-error Forcing a leading and trailing slash in the path
+    expect(fetch.isRequest(request, 'GET', '/users')).toBe(true);
+
+    expect(fetch.isRequest(request, 'POST', '/users/')).toBe(false);
+
+    // @ts-expect-error Forcing a trailing slash in the path
+    expect(fetch.isRequest(request, 'POST', 'users')).toBe(false);
+    // @ts-expect-error Forcing a leading and trailing slash in the path
+    expect(fetch.isRequest(request, 'POST', '/users')).toBe(false);
+    // @ts-expect-error Forcing a trailing slash in the path
+    expect(fetch.isRequest(request, 'POST', 'users/')).toBe(false);
+
+    expect(fetch.isRequest(request, 'GET', '/users/:userId/')).toBe(false);
+
+    // @ts-expect-error Forcing a trailing slash in the path
+    expect(fetch.isRequest(request, 'GET', 'users/:userId')).toBe(false);
+    // @ts-expect-error Forcing a leading and trailing slash in the path
+    expect(fetch.isRequest(request, 'GET', '/users/:userId')).toBe(false);
+    // @ts-expect-error Forcing a trailing slash in the path
+    expect(fetch.isRequest(request, 'GET', 'users/:userId/')).toBe(false);
+  });
+
+  it('should correctly check non-fetch requests', () => {
+    type Schema = HttpSchema<{
+      '/users': {
+        GET: {
+          response: {
+            200: { body: User[] };
+          };
+        };
+      };
+    }>;
+
+    const fetch = createFetch<Schema>({
+      baseURL,
+    });
+
+    const request = new Request(`${fetch.defaults.baseURL}/users`, {
+      method: 'GET',
+    });
+
+    expect(request.url).toBe(joinURL(baseURL, '/users'));
+
+    expectTypeOf(request.method).toEqualTypeOf<string>();
+    expect(request.method).toBe('GET');
+
+    expect(fetch.isRequest(request, 'GET', '/users')).toBe(false);
+
+    expect(fetch.isRequest(new Error(), 'GET', '/users')).toBe(false);
+    expect(fetch.isRequest('string', 'GET', '/users')).toBe(false);
+    expect(fetch.isRequest(null, 'GET', '/users')).toBe(false);
+    expect(fetch.isRequest(undefined, 'GET', '/users')).toBe(false);
+  });
+});

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.isResponse.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.isResponse.test.ts
@@ -1,0 +1,434 @@
+import { HttpSchema } from '@zimic/http';
+import joinURL from '@zimic/utils/url/joinURL';
+import { describe, expect, expectTypeOf, it } from 'vitest';
+
+import { usingHttpInterceptor } from '@tests/utils/interceptors';
+
+import createFetch from '../factory';
+
+describe('FetchClient > isResponse', () => {
+  const baseURL = 'http://localhost:3000';
+
+  interface User {
+    id: string;
+    name: string;
+  }
+
+  const users: User[] = [
+    { id: '1', name: 'User 1' },
+    { id: '2', name: 'User 2' },
+  ];
+
+  it('should correctly check a fetch response without path params', async () => {
+    type Schema = HttpSchema<{
+      '/users': {
+        POST: {
+          request: {
+            body: User;
+          };
+          response: {
+            201: { body: User };
+          };
+        };
+        GET: {
+          response: {
+            200: { body: User[] };
+          };
+        };
+      };
+
+      '/users/:userId': {
+        GET: {
+          response: {
+            200: { body: User };
+            404: {};
+          };
+        };
+      };
+    }>;
+
+    await usingHttpInterceptor<Schema>({ type: 'local', baseURL }, async (interceptor) => {
+      await interceptor
+        .get('/users')
+        .respond({
+          status: 200,
+          body: users,
+        })
+        .times(1);
+
+      const fetch = createFetch<Schema>({
+        baseURL,
+      });
+
+      const response = await fetch('/users', {
+        method: 'GET',
+      });
+
+      expect(response.url).toBe(joinURL(baseURL, '/users'));
+
+      expectTypeOf(response.status).toEqualTypeOf<200>();
+      expect(response.status).toBe(200);
+
+      expectTypeOf(response.request.method).toEqualTypeOf<'GET'>();
+      expect(response.request.method).toBe('GET');
+
+      expectTypeOf(response.request.path).toEqualTypeOf<'/users'>();
+      expect(response.request.path).toBe('/users');
+
+      expect(fetch.isResponse(response, 'GET', '/users')).toBe(true);
+      expect(fetch.isResponse(response, 'POST', '/users')).toBe(false);
+      expect(fetch.isResponse(response, 'GET', '/users/:userId')).toBe(false);
+    });
+  });
+
+  it('should correctly check a fetch response with path params', async () => {
+    type Schema = HttpSchema<{
+      '/users': {
+        POST: {
+          request: {
+            body: User;
+          };
+          response: {
+            201: { body: User };
+          };
+        };
+        GET: {
+          response: {
+            200: { body: User[] };
+          };
+        };
+      };
+
+      '/users/:userId': {
+        GET: {
+          response: {
+            200: { body: User };
+            404: {};
+          };
+        };
+      };
+    }>;
+
+    await usingHttpInterceptor<Schema>({ type: 'local', baseURL }, async (interceptor) => {
+      await interceptor
+        .get(`/users/${users[0].id}`)
+        .respond({
+          status: 200,
+          body: users[0],
+        })
+        .times(1);
+
+      const fetch = createFetch<Schema>({
+        baseURL,
+      });
+
+      const response = await fetch(`/users/${users[0].id}`, {
+        method: 'GET',
+      });
+
+      expectTypeOf(response.status).toEqualTypeOf<200 | 404>();
+      expect(response.status).toBe(200);
+
+      expectTypeOf(response.request.method).toEqualTypeOf<'GET'>();
+      expect(response.request.method).toBe('GET');
+
+      expectTypeOf(response.request.path).toEqualTypeOf<`/users/${string}`>();
+      expect(response.request.path).toBe(`/users/${users[0].id}`);
+
+      expect(fetch.isResponse(response, 'GET', '/users')).toBe(false);
+      expect(fetch.isResponse(response, 'POST', '/users')).toBe(false);
+      expect(fetch.isResponse(response, 'GET', '/users/:userId')).toBe(true);
+    });
+  });
+
+  it('should correctly check a fetch response without a leading slash in the path', async () => {
+    type Schema = HttpSchema<{
+      users: {
+        POST: {
+          request: {
+            body: User;
+          };
+          response: {
+            201: { body: User };
+          };
+        };
+        GET: {
+          response: {
+            200: { body: User[] };
+          };
+        };
+      };
+
+      'users/:userId': {
+        GET: {
+          response: {
+            200: { body: User };
+            404: {};
+          };
+        };
+      };
+    }>;
+
+    await usingHttpInterceptor<Schema>({ type: 'local', baseURL }, async (interceptor) => {
+      await interceptor
+        .get('users')
+        .respond({
+          status: 200,
+          body: users,
+        })
+        .times(1);
+
+      const fetch = createFetch<Schema>({
+        baseURL,
+      });
+
+      const response = await fetch('users', {
+        method: 'GET',
+      });
+
+      expect(response.url).toBe(joinURL(baseURL, '/users'));
+
+      expectTypeOf(response.status).toEqualTypeOf<200>();
+      expect(response.status).toBe(200);
+
+      expectTypeOf(response.request.method).toEqualTypeOf<'GET'>();
+      expect(response.request.method).toBe('GET');
+
+      expectTypeOf(response.request.path).toEqualTypeOf<'users'>();
+      expect(response.request.path).toBe('/users');
+
+      expect(fetch.isResponse(response, 'GET', 'users')).toBe(true);
+
+      // @ts-expect-error Forcing a leading slash in the path
+      expect(fetch.isResponse(response, 'GET', '/users')).toBe(true);
+      // @ts-expect-error Forcing a trailing slash in the path
+      expect(fetch.isResponse(response, 'GET', 'users/')).toBe(true);
+      // @ts-expect-error Forcing a leading and trailing slash in the path
+      expect(fetch.isResponse(response, 'GET', '/users/')).toBe(true);
+
+      expect(fetch.isResponse(response, 'POST', 'users')).toBe(false);
+
+      // @ts-expect-error Forcing a leading slash in the path
+      expect(fetch.isResponse(response, 'POST', '/users')).toBe(false);
+      // @ts-expect-error Forcing a trailing slash in the path
+      expect(fetch.isResponse(response, 'POST', 'users/')).toBe(false);
+      // @ts-expect-error Forcing a leading and trailing slash in the path
+      expect(fetch.isResponse(response, 'POST', '/users/')).toBe(false);
+
+      expect(fetch.isResponse(response, 'GET', 'users/:userId')).toBe(false);
+
+      // @ts-expect-error Forcing a leading slash in the path
+      expect(fetch.isResponse(response, 'GET', '/users/:userId')).toBe(false);
+      // @ts-expect-error Forcing a trailing slash in the path
+      expect(fetch.isResponse(response, 'GET', 'users/:userId/')).toBe(false);
+      // @ts-expect-error Forcing a leading and trailing slash in the path
+      expect(fetch.isResponse(response, 'GET', '/users/:userId/')).toBe(false);
+    });
+  });
+
+  it('should correctly check a fetch response with a trailing slash in the path', async () => {
+    type Schema = HttpSchema<{
+      'users/': {
+        POST: {
+          request: {
+            body: User;
+          };
+          response: {
+            201: { body: User };
+          };
+        };
+        GET: {
+          response: {
+            200: { body: User[] };
+          };
+        };
+      };
+
+      'users/:userId/': {
+        GET: {
+          response: {
+            200: { body: User };
+            404: {};
+          };
+        };
+      };
+    }>;
+
+    await usingHttpInterceptor<Schema>({ type: 'local', baseURL }, async (interceptor) => {
+      await interceptor
+        .get('users/')
+        .respond({
+          status: 200,
+          body: users,
+        })
+        .times(1);
+      const fetch = createFetch<Schema>({
+        baseURL,
+      });
+
+      const response = await fetch('users/', {
+        method: 'GET',
+      });
+
+      expect(response.url).toBe(joinURL(baseURL, '/users/'));
+
+      expectTypeOf(response.status).toEqualTypeOf<200>();
+      expect(response.status).toBe(200);
+
+      expectTypeOf(response.request.method).toEqualTypeOf<'GET'>();
+      expect(response.request.method).toBe('GET');
+
+      expectTypeOf(response.request.path).toEqualTypeOf<'users/'>();
+      expect(response.request.path).toBe('/users/');
+
+      expect(fetch.isResponse(response, 'GET', 'users/')).toBe(true);
+
+      // @ts-expect-error Forcing a no leading or training slashes in the path
+      expect(fetch.isResponse(response, 'GET', 'users')).toBe(true);
+      // @ts-expect-error Forcing a leading slash in the path
+      expect(fetch.isResponse(response, 'GET', '/users')).toBe(true);
+      // @ts-expect-error Forcing a leading and trailing slash in the path
+      expect(fetch.isResponse(response, 'GET', '/users/')).toBe(true);
+
+      expect(fetch.isResponse(response, 'POST', 'users/')).toBe(false);
+
+      // @ts-expect-error Forcing a trailing slash in the path
+      expect(fetch.isResponse(response, 'POST', 'users')).toBe(false);
+      // @ts-expect-error Forcing a leading slash in the path
+      expect(fetch.isResponse(response, 'POST', '/users')).toBe(false);
+      // @ts-expect-error Forcing a leading and trailing slash in the path
+      expect(fetch.isResponse(response, 'POST', '/users/')).toBe(false);
+
+      expect(fetch.isResponse(response, 'GET', 'users/:userId/')).toBe(false);
+
+      // @ts-expect-error Forcing a trailing slash in the path
+      expect(fetch.isResponse(response, 'GET', 'users/:userId')).toBe(false);
+      // @ts-expect-error Forcing a leading and trailing slash in the path
+      expect(fetch.isResponse(response, 'GET', '/users/:userId')).toBe(false);
+      // @ts-expect-error Forcing a leading slash in the path
+      expect(fetch.isResponse(response, 'GET', '/users/:userId/')).toBe(false);
+    });
+  });
+
+  it('should correctly check a fetch response with a leading and trailing slash in the path', async () => {
+    type Schema = HttpSchema<{
+      '/users/': {
+        POST: {
+          request: {
+            body: User;
+          };
+          response: {
+            201: { body: User };
+          };
+        };
+        GET: {
+          response: {
+            200: { body: User[] };
+          };
+        };
+      };
+
+      '/users/:userId/': {
+        GET: {
+          response: {
+            200: { body: User };
+            404: {};
+          };
+        };
+      };
+    }>;
+
+    await usingHttpInterceptor<Schema>({ type: 'local', baseURL }, async (interceptor) => {
+      await interceptor
+        .get('/users/')
+        .respond({
+          status: 200,
+          body: users,
+        })
+        .times(1);
+      const fetch = createFetch<Schema>({
+        baseURL,
+      });
+
+      const response = await fetch('/users/', {
+        method: 'GET',
+      });
+
+      expect(response.url).toBe(joinURL(baseURL, '/users/'));
+
+      expectTypeOf(response.status).toEqualTypeOf<200>();
+      expect(response.status).toBe(200);
+
+      expectTypeOf(response.request.method).toEqualTypeOf<'GET'>();
+      expect(response.request.method).toBe('GET');
+
+      expectTypeOf(response.request.path).toEqualTypeOf<'/users/'>();
+      expect(response.request.path).toBe('/users/');
+
+      expect(fetch.isResponse(response, 'GET', '/users/')).toBe(true);
+
+      // @ts-expect-error Forcing a trailing slash in the path
+      expect(fetch.isResponse(response, 'GET', 'users')).toBe(true);
+      // @ts-expect-error Forcing a trailing slash in the path
+      expect(fetch.isResponse(response, 'GET', 'users/')).toBe(true);
+      // @ts-expect-error Forcing a leading and trailing slash in the path
+      expect(fetch.isResponse(response, 'GET', '/users')).toBe(true);
+
+      expect(fetch.isResponse(response, 'POST', '/users/')).toBe(false);
+
+      // @ts-expect-error Forcing a trailing slash in the path
+      expect(fetch.isResponse(response, 'POST', 'users')).toBe(false);
+      // @ts-expect-error Forcing a leading and trailing slash in the path
+      expect(fetch.isResponse(response, 'POST', '/users')).toBe(false);
+      // @ts-expect-error Forcing a trailing slash in the path
+      expect(fetch.isResponse(response, 'POST', 'users/')).toBe(false);
+
+      expect(fetch.isResponse(response, 'GET', '/users/:userId/')).toBe(false);
+
+      // @ts-expect-error Forcing a trailing slash in the path
+      expect(fetch.isResponse(response, 'GET', 'users/:userId')).toBe(false);
+      // @ts-expect-error Forcing a leading and trailing slash in the path
+      expect(fetch.isResponse(response, 'GET', '/users/:userId')).toBe(false);
+      // @ts-expect-error Forcing a trailing slash in the path
+      expect(fetch.isResponse(response, 'GET', 'users/:userId/')).toBe(false);
+    });
+  });
+
+  it('should correctly check non-fetch responses', async () => {
+    type Schema = HttpSchema<{
+      '/users': {
+        GET: {
+          response: {
+            200: { body: User[] };
+          };
+        };
+      };
+    }>;
+
+    await usingHttpInterceptor<Schema>({ type: 'local', baseURL }, async (interceptor) => {
+      await interceptor
+        .get('/users')
+        .respond({
+          status: 200,
+          body: users,
+        })
+        .times(1);
+      const fetch = createFetch<Schema>({
+        baseURL,
+      });
+
+      const response = await globalThis.fetch(`${fetch.defaults.baseURL}/users`, {
+        method: 'GET',
+      });
+
+      expect(response.url).toBe(joinURL(baseURL, '/users'));
+
+      expect(fetch.isResponse(response, 'GET', '/users')).toBe(false);
+
+      expect(fetch.isRequest(new Error(), 'GET', '/users')).toBe(false);
+      expect(fetch.isRequest('string', 'GET', '/users')).toBe(false);
+      expect(fetch.isRequest(null, 'GET', '/users')).toBe(false);
+      expect(fetch.isRequest(undefined, 'GET', '/users')).toBe(false);
+    });
+  });
+});

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.isResponseError.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.isResponseError.test.ts
@@ -1,0 +1,435 @@
+import { HttpSchema } from '@zimic/http';
+import joinURL from '@zimic/utils/url/joinURL';
+import { describe, expect, expectTypeOf, it } from 'vitest';
+
+import { usingHttpInterceptor } from '@tests/utils/interceptors';
+
+import createFetch from '../factory';
+
+describe('FetchClient > isResponseError', () => {
+  const baseURL = 'http://localhost:3000';
+
+  interface User {
+    id: string;
+    name: string;
+  }
+
+  const users: User[] = [
+    { id: '1', name: 'User 1' },
+    { id: '2', name: 'User 2' },
+  ];
+
+  it('should correctly check a fetch response error without path params', async () => {
+    type Schema = HttpSchema<{
+      '/users': {
+        POST: {
+          request: {
+            body: User;
+          };
+          response: {
+            201: { body: User };
+          };
+        };
+        GET: {
+          response: {
+            200: { body: User[] };
+            500: { body: { message: string } };
+          };
+        };
+      };
+
+      '/users/:userId': {
+        GET: {
+          response: {
+            200: { body: User };
+            404: {};
+          };
+        };
+      };
+    }>;
+
+    await usingHttpInterceptor<Schema>({ type: 'local', baseURL }, async (interceptor) => {
+      await interceptor
+        .get('/users')
+        .respond({
+          status: 500,
+          body: { message: 'Internal server error' },
+        })
+        .times(1);
+
+      const fetch = createFetch<Schema>({
+        baseURL,
+      });
+
+      const response = await fetch('/users', {
+        method: 'GET',
+      });
+
+      expect(response.url).toBe(joinURL(baseURL, '/users'));
+
+      expectTypeOf(response.status).toEqualTypeOf<200 | 500>();
+      expect(response.status).toBe(500);
+
+      expectTypeOf(response.request.method).toEqualTypeOf<'GET'>();
+      expect(response.request.method).toBe('GET');
+
+      expectTypeOf(response.request.path).toEqualTypeOf<'/users'>();
+      expect(response.request.path).toBe('/users');
+
+      expect(fetch.isResponseError(response.error, 'GET', '/users')).toBe(true);
+      expect(fetch.isResponseError(response.error, 'POST', '/users')).toBe(false);
+      expect(fetch.isResponseError(response.error, 'GET', '/users/:userId')).toBe(false);
+    });
+  });
+
+  it('should correctly check a fetch response error with path params', async () => {
+    type Schema = HttpSchema<{
+      '/users': {
+        POST: {
+          request: {
+            body: User;
+          };
+          response: {
+            201: { body: User };
+          };
+        };
+        GET: {
+          response: {
+            200: { body: User[] };
+          };
+        };
+      };
+
+      '/users/:userId': {
+        GET: {
+          response: {
+            200: { body: User };
+            404: {};
+          };
+        };
+      };
+    }>;
+
+    await usingHttpInterceptor<Schema>({ type: 'local', baseURL }, async (interceptor) => {
+      await interceptor
+        .get(`/users/${users[0].id}`)
+        .respond({
+          status: 404,
+        })
+        .times(1);
+
+      const fetch = createFetch<Schema>({
+        baseURL,
+      });
+
+      const response = await fetch(`/users/${users[0].id}`, {
+        method: 'GET',
+      });
+
+      expectTypeOf(response.status).toEqualTypeOf<200 | 404>();
+      expect(response.status).toBe(404);
+
+      expectTypeOf(response.request.method).toEqualTypeOf<'GET'>();
+      expect(response.request.method).toBe('GET');
+
+      expectTypeOf(response.request.path).toEqualTypeOf<`/users/${string}`>();
+      expect(response.request.path).toBe(`/users/${users[0].id}`);
+
+      expect(fetch.isResponseError(response.error, 'GET', '/users')).toBe(false);
+      expect(fetch.isResponseError(response.error, 'POST', '/users')).toBe(false);
+      expect(fetch.isResponseError(response.error, 'GET', '/users/:userId')).toBe(true);
+    });
+  });
+
+  it('should correctly check a fetch response error without a leading slash in the path', async () => {
+    type Schema = HttpSchema<{
+      users: {
+        POST: {
+          request: {
+            body: User;
+          };
+          response: {
+            201: { body: User };
+          };
+        };
+        GET: {
+          response: {
+            200: { body: User[] };
+            500: { body: { message: string } };
+          };
+        };
+      };
+
+      'users/:userId': {
+        GET: {
+          response: {
+            200: { body: User };
+            404: {};
+          };
+        };
+      };
+    }>;
+
+    await usingHttpInterceptor<Schema>({ type: 'local', baseURL }, async (interceptor) => {
+      await interceptor
+        .get('users')
+        .respond({
+          status: 500,
+          body: { message: 'Internal server error' },
+        })
+        .times(1);
+
+      const fetch = createFetch<Schema>({
+        baseURL,
+      });
+
+      const response = await fetch('users', {
+        method: 'GET',
+      });
+
+      expect(response.url).toBe(joinURL(baseURL, '/users'));
+
+      expectTypeOf(response.status).toEqualTypeOf<200 | 500>();
+      expect(response.status).toBe(500);
+
+      expectTypeOf(response.request.method).toEqualTypeOf<'GET'>();
+      expect(response.request.method).toBe('GET');
+
+      expectTypeOf(response.request.path).toEqualTypeOf<'users'>();
+      expect(response.request.path).toBe('/users');
+
+      expect(fetch.isResponseError(response.error, 'GET', 'users')).toBe(true);
+
+      // @ts-expect-error Forcing a leading slash in the path
+      expect(fetch.isResponseError(response.error, 'GET', '/users')).toBe(true);
+      // @ts-expect-error Forcing a trailing slash in the path
+      expect(fetch.isResponseError(response.error, 'GET', 'users/')).toBe(true);
+      // @ts-expect-error Forcing a leading and trailing slash in the path
+      expect(fetch.isResponseError(response.error, 'GET', '/users/')).toBe(true);
+
+      expect(fetch.isResponseError(response.error, 'POST', 'users')).toBe(false);
+
+      // @ts-expect-error Forcing a leading slash in the path
+      expect(fetch.isResponseError(response.error, 'POST', '/users')).toBe(false);
+      // @ts-expect-error Forcing a trailing slash in the path
+      expect(fetch.isResponseError(response.error, 'POST', 'users/')).toBe(false);
+      // @ts-expect-error Forcing a leading and trailing slash in the path
+      expect(fetch.isResponseError(response.error, 'POST', '/users/')).toBe(false);
+
+      expect(fetch.isResponseError(response.error, 'GET', 'users/:userId')).toBe(false);
+
+      // @ts-expect-error Forcing a leading slash in the path
+      expect(fetch.isResponseError(response.error, 'GET', '/users/:userId')).toBe(false);
+      // @ts-expect-error Forcing a trailing slash in the path
+      expect(fetch.isResponseError(response.error, 'GET', 'users/:userId/')).toBe(false);
+      // @ts-expect-error Forcing a leading and trailing slash in the path
+      expect(fetch.isResponseError(response.error, 'GET', '/users/:userId/')).toBe(false);
+    });
+  });
+
+  it('should correctly check a fetch response error with a trailing slash in the path', async () => {
+    type Schema = HttpSchema<{
+      'users/': {
+        POST: {
+          request: {
+            body: User;
+          };
+          response: {
+            201: { body: User };
+          };
+        };
+        GET: {
+          response: {
+            200: { body: User[] };
+            500: { body: { message: string } };
+          };
+        };
+      };
+
+      'users/:userId/': {
+        GET: {
+          response: {
+            200: { body: User };
+            404: {};
+          };
+        };
+      };
+    }>;
+
+    await usingHttpInterceptor<Schema>({ type: 'local', baseURL }, async (interceptor) => {
+      await interceptor
+        .get('users/')
+        .respond({
+          status: 500,
+          body: { message: 'Internal server error' },
+        })
+        .times(1);
+      const fetch = createFetch<Schema>({
+        baseURL,
+      });
+
+      const response = await fetch('users/', {
+        method: 'GET',
+      });
+
+      expect(response.url).toBe(joinURL(baseURL, '/users/'));
+
+      expectTypeOf(response.status).toEqualTypeOf<200 | 500>();
+      expect(response.status).toBe(500);
+
+      expectTypeOf(response.request.method).toEqualTypeOf<'GET'>();
+      expect(response.request.method).toBe('GET');
+
+      expectTypeOf(response.request.path).toEqualTypeOf<'users/'>();
+      expect(response.request.path).toBe('/users/');
+
+      expect(fetch.isResponseError(response.error, 'GET', 'users/')).toBe(true);
+
+      // @ts-expect-error Forcing a no leading or training slashes in the path
+      expect(fetch.isResponseError(response.error, 'GET', 'users')).toBe(true);
+      // @ts-expect-error Forcing a leading slash in the path
+      expect(fetch.isResponseError(response.error, 'GET', '/users')).toBe(true);
+      // @ts-expect-error Forcing a leading and trailing slash in the path
+      expect(fetch.isResponseError(response.error, 'GET', '/users/')).toBe(true);
+
+      expect(fetch.isResponseError(response.error, 'POST', 'users/')).toBe(false);
+
+      // @ts-expect-error Forcing a trailing slash in the path
+      expect(fetch.isResponseError(response.error, 'POST', 'users')).toBe(false);
+      // @ts-expect-error Forcing a leading slash in the path
+      expect(fetch.isResponseError(response.error, 'POST', '/users')).toBe(false);
+      // @ts-expect-error Forcing a leading and trailing slash in the path
+      expect(fetch.isResponseError(response.error, 'POST', '/users/')).toBe(false);
+
+      expect(fetch.isResponseError(response.error, 'GET', 'users/:userId/')).toBe(false);
+
+      // @ts-expect-error Forcing a trailing slash in the path
+      expect(fetch.isResponseError(response.error, 'GET', 'users/:userId')).toBe(false);
+      // @ts-expect-error Forcing a leading and trailing slash in the path
+      expect(fetch.isResponseError(response.error, 'GET', '/users/:userId')).toBe(false);
+      // @ts-expect-error Forcing a leading slash in the path
+      expect(fetch.isResponseError(response.error, 'GET', '/users/:userId/')).toBe(false);
+    });
+  });
+
+  it('should correctly check a fetch response error with a leading and trailing slash in the path', async () => {
+    type Schema = HttpSchema<{
+      '/users/': {
+        POST: {
+          request: {
+            body: User;
+          };
+          response: {
+            201: { body: User };
+          };
+        };
+        GET: {
+          response: {
+            200: { body: User[] };
+            500: { body: { message: string } };
+          };
+        };
+      };
+
+      '/users/:userId/': {
+        GET: {
+          response: {
+            200: { body: User };
+            404: {};
+          };
+        };
+      };
+    }>;
+
+    await usingHttpInterceptor<Schema>({ type: 'local', baseURL }, async (interceptor) => {
+      await interceptor
+        .get('/users/')
+        .respond({
+          status: 500,
+          body: { message: 'Internal server error' },
+        })
+        .times(1);
+      const fetch = createFetch<Schema>({
+        baseURL,
+      });
+
+      const response = await fetch('/users/', {
+        method: 'GET',
+      });
+
+      expect(response.url).toBe(joinURL(baseURL, '/users/'));
+
+      expectTypeOf(response.status).toEqualTypeOf<200 | 500>();
+      expect(response.status).toBe(500);
+
+      expectTypeOf(response.request.method).toEqualTypeOf<'GET'>();
+      expect(response.request.method).toBe('GET');
+
+      expectTypeOf(response.request.path).toEqualTypeOf<'/users/'>();
+      expect(response.request.path).toBe('/users/');
+
+      expect(fetch.isResponseError(response.error, 'GET', '/users/')).toBe(true);
+
+      // @ts-expect-error Forcing a trailing slash in the path
+      expect(fetch.isResponseError(response.error, 'GET', 'users')).toBe(true);
+      // @ts-expect-error Forcing a trailing slash in the path
+      expect(fetch.isResponseError(response.error, 'GET', 'users/')).toBe(true);
+      // @ts-expect-error Forcing a leading and trailing slash in the path
+      expect(fetch.isResponseError(response.error, 'GET', '/users')).toBe(true);
+
+      expect(fetch.isResponseError(response.error, 'POST', '/users/')).toBe(false);
+
+      // @ts-expect-error Forcing a trailing slash in the path
+      expect(fetch.isResponseError(response.error, 'POST', 'users')).toBe(false);
+      // @ts-expect-error Forcing a leading and trailing slash in the path
+      expect(fetch.isResponseError(response.error, 'POST', '/users')).toBe(false);
+      // @ts-expect-error Forcing a trailing slash in the path
+      expect(fetch.isResponseError(response.error, 'POST', 'users/')).toBe(false);
+
+      expect(fetch.isResponseError(response.error, 'GET', '/users/:userId/')).toBe(false);
+
+      // @ts-expect-error Forcing a trailing slash in the path
+      expect(fetch.isResponseError(response.error, 'GET', 'users/:userId')).toBe(false);
+      // @ts-expect-error Forcing a leading and trailing slash in the path
+      expect(fetch.isResponseError(response.error, 'GET', '/users/:userId')).toBe(false);
+      // @ts-expect-error Forcing a trailing slash in the path
+      expect(fetch.isResponseError(response.error, 'GET', 'users/:userId/')).toBe(false);
+    });
+  });
+
+  it('should correctly check non-fetch response errors', async () => {
+    type Schema = HttpSchema<{
+      '/users': {
+        GET: {
+          response: {
+            200: { body: User[] };
+          };
+        };
+      };
+    }>;
+
+    await usingHttpInterceptor<Schema>({ type: 'local', baseURL }, async (interceptor) => {
+      await interceptor
+        .get('/users')
+        .respond({
+          status: 200,
+          body: users,
+        })
+        .times(1);
+      const fetch = createFetch<Schema>({
+        baseURL,
+      });
+
+      const response = await globalThis.fetch(`${fetch.defaults.baseURL}/users`, {
+        method: 'GET',
+      });
+
+      expect(response.url).toBe(joinURL(baseURL, '/users'));
+
+      expect(fetch.isRequest(new Error(), 'GET', '/users')).toBe(false);
+      expect(fetch.isRequest('string', 'GET', '/users')).toBe(false);
+      expect(fetch.isRequest(null, 'GET', '/users')).toBe(false);
+      expect(fetch.isRequest(undefined, 'GET', '/users')).toBe(false);
+    });
+  });
+});

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.listeners.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.listeners.test.ts
@@ -10,7 +10,7 @@ import createFetch from '../factory';
 import { Fetch } from '../types/public';
 import { FetchRequest, FetchResponse } from '../types/requests';
 
-describe('FetchClient (node) > Listeners', () => {
+describe('FetchClient > Listeners', () => {
   const baseURL = 'http://localhost:3000';
 
   interface User {

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.methods.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.methods.test.ts
@@ -7,7 +7,7 @@ import { usingHttpInterceptor } from '@tests/utils/interceptors';
 import createFetch from '../factory';
 import { FetchResponse, FetchRequest } from '../types/requests';
 
-describe('FetchClient (node) > Methods', () => {
+describe('FetchClient > Methods', () => {
   const baseURL = 'http://localhost:3000';
 
   interface User {

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.pathParams.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.pathParams.test.ts
@@ -7,7 +7,7 @@ import { usingHttpInterceptor } from '@tests/utils/interceptors';
 import createFetch from '../factory';
 import { FetchResponse, FetchRequest } from '../types/requests';
 
-describe('FetchClient (node) > Path params', () => {
+describe('FetchClient > Path params', () => {
   const baseURL = 'http://localhost:3000';
 
   interface User {

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.searchParams.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.searchParams.test.ts
@@ -7,7 +7,7 @@ import { usingHttpInterceptor } from '@tests/utils/interceptors';
 import createFetch from '../factory';
 import { FetchRequest } from '../types/requests';
 
-describe('FetchClient (node) > Search params', () => {
+describe('FetchClient > Search params', () => {
   const baseURL = 'http://localhost:3000';
 
   interface User {

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.types.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.types.test.ts
@@ -9,7 +9,7 @@ import createFetch from '../factory';
 import { Fetch, InferFetchSchema } from '../types/public';
 import { FetchResponse, FetchResponsePerStatusCode } from '../types/requests';
 
-describe('FetchClient (node) > Types', () => {
+describe('FetchClient > Types', () => {
   const baseURL = 'http://localhost:3000';
 
   interface User {

--- a/packages/zimic-fetch/src/client/types/public.ts
+++ b/packages/zimic-fetch/src/client/types/public.ts
@@ -29,7 +29,7 @@ export interface FetchOptions<Schema extends HttpSchema> extends Omit<FetchReque
 
 export type FetchDefaults = RequiredByKey<FetchRequestInit.Defaults, 'headers' | 'searchParams'>;
 
-interface FetchClient<Schema extends HttpSchema> extends Pick<FetchOptions<Schema>, 'onRequest' | 'onResponse'> {
+export interface FetchClient<Schema extends HttpSchema> extends Pick<FetchOptions<Schema>, 'onRequest' | 'onResponse'> {
   defaults: FetchDefaults;
 
   Request: FetchRequestConstructor<Schema>;

--- a/packages/zimic-utils/src/url/createRegExpFromURL.ts
+++ b/packages/zimic-utils/src/url/createRegExpFromURL.ts
@@ -6,9 +6,9 @@ function createRegExpFromURL(url: string) {
   const urlWithReplacedPathParams = encodeURI(url)
     .replace(/([.()*?+$\\])/g, '\\$1')
     .replace(URL_PATH_PARAM_REGEX, '/(?<$1>[^/]+)')
-    .replace(/(\/+)$/, '(?:/+)?');
+    .replace(/^(\/)|(\/)$/g, '');
 
-  return new RegExp(`^${urlWithReplacedPathParams}$`);
+  return new RegExp(`^(?:/)?${urlWithReplacedPathParams}(?:/)?$`);
 }
 
 export default createRegExpFromURL;


### PR DESCRIPTION
### Fixes
- [fetch] Improved how slashes are handled in `fetch.isRequest`, `fetch.isResponse`, and `fetch.isResponseError`, now ignoring leading and trailing slashes in the path when necessary.