### PR TITLE
feat(fetch): type response status based on `request.redirect`

### DIFF
--- a/examples/with-openapi-typegen/src/clients/github/client.ts
+++ b/examples/with-openapi-typegen/src/clients/github/client.ts
@@ -11,7 +11,7 @@ export const githubFetch = createFetch<GitHubSchema>({
 export async function fetchGitHubRepository(ownerName: string, repositoryName: string) {
   const response = await githubFetch(`/repos/${ownerName}/${repositoryName}`, { method: 'GET' });
 
-  if (response.status === 404 || response.status === 301) {
+  if (response.status === 404) {
     return null;
   }
 

--- a/packages/zimic-fetch/src/client/FetchClient.ts
+++ b/packages/zimic-fetch/src/client/FetchClient.ts
@@ -129,7 +129,12 @@ class FetchClient<Schema extends HttpSchema> implements Omit<PublicFetchClient<S
     Object.defineProperty(fetchResponse, 'error', {
       get() {
         if (responseError === undefined) {
-          responseError = fetchResponse.ok ? null : new FetchResponseError(fetchRequest, fetchResponse);
+          responseError = fetchResponse.ok
+            ? null
+            : new FetchResponseError(
+                fetchRequest,
+                fetchResponse as FetchResponse<Schema, Method, Path, true, 'manual'>,
+              );
         }
         return responseError;
       },

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.blob.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.blob.test.ts
@@ -3,6 +3,7 @@ import joinURL from '@zimic/utils/url/joinURL';
 import { describe, expect, expectTypeOf, it } from 'vitest';
 
 import { usingHttpInterceptor } from '@tests/utils/interceptors';
+import { expectResponseStatus } from '@tests/utils/requests';
 
 import createFetch from '../factory';
 import { FetchRequest, FetchResponse } from '../types/requests';
@@ -46,7 +47,7 @@ describe('FetchClient > Bodies > Blob', () => {
         body: requestBlob,
       });
 
-      expect(response.status).toBe(201);
+      expectResponseStatus(response, 201);
       const receivedResponseBlob = await response.blob();
       expect(receivedResponseBlob.size).toBe(responseBlob.size);
 
@@ -122,7 +123,7 @@ describe('FetchClient > Bodies > Blob', () => {
         headers: { 'content-type': 'application/octet-stream' },
       });
 
-      expect(response.status).toBe(201);
+      expectResponseStatus(response, 201);
       expect(await response.blob()).toEqual(new Blob([], { type: 'application/octet-stream' }));
 
       expect(response).toBeInstanceOf(Response);
@@ -206,7 +207,7 @@ describe('FetchClient > Bodies > Blob', () => {
         body: requestArrayBuffer,
       });
 
-      expect(response.status).toBe(201);
+      expectResponseStatus(response, 201);
       expect(await response.arrayBuffer()).toEqual(responseBuffer);
 
       expect(response).toBeInstanceOf(Response);
@@ -279,7 +280,7 @@ describe('FetchClient > Bodies > Blob', () => {
         headers: { 'content-type': 'application/octet-stream' },
       });
 
-      expect(response.status).toBe(201);
+      expectResponseStatus(response, 201);
       expect(await response.arrayBuffer()).toEqual(new ArrayBuffer(0));
 
       expect(response).toBeInstanceOf(Response);

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.formData.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.formData.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, expectTypeOf, it } from 'vitest';
 
 import { importFile } from '@/utils/files';
 import { usingHttpInterceptor } from '@tests/utils/interceptors';
+import { expectResponseStatus } from '@tests/utils/requests';
 
 import createFetch from '../factory';
 import { FetchRequest, FetchResponse } from '../types/requests';
@@ -56,7 +57,7 @@ describe('FetchClient > Bodies > Form data', () => {
         body: requestFormData,
       });
 
-      expect(response.status).toBe(201);
+      expectResponseStatus(response, 201);
       const receivedResponseFormData = await response.formData();
       expect(Array.from(receivedResponseFormData.entries())).toHaveLength(2);
 
@@ -130,7 +131,7 @@ describe('FetchClient > Bodies > Form data', () => {
         headers: { 'content-type': 'multipart/form-data' },
       });
 
-      expect(response.status).toBe(201);
+      expectResponseStatus(response, 201);
       expect(await response.text()).toBe('');
 
       expect(response).toBeInstanceOf(Response);

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.json.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.json.test.ts
@@ -3,6 +3,7 @@ import joinURL from '@zimic/utils/url/joinURL';
 import { describe, expect, expectTypeOf, it } from 'vitest';
 
 import { usingHttpInterceptor } from '@tests/utils/interceptors';
+import { expectResponseStatus } from '@tests/utils/requests';
 
 import createFetch from '../factory';
 import { FetchRequest, FetchResponse } from '../types/requests';
@@ -11,10 +12,14 @@ describe('FetchClient > Bodies > JSON', () => {
   const baseURL = 'http://localhost:3000';
 
   interface User {
+    id: string;
     name: string;
   }
 
-  const users: User[] = [{ name: 'User 1' }, { name: 'User 2' }];
+  const users: User[] = [
+    { id: '1', name: 'User 1' },
+    { id: '2', name: 'User 2' },
+  ];
 
   it('should support requests and responses with a JSON body', async () => {
     type Schema = HttpSchema<{
@@ -49,7 +54,7 @@ describe('FetchClient > Bodies > JSON', () => {
         body: JSON.stringify(users[0]),
       });
 
-      expect(response.status).toBe(201);
+      expectResponseStatus(response, 201);
       expect(await response.json()).toEqual(users[0]);
 
       expect(response).toBeInstanceOf(Response);
@@ -117,7 +122,7 @@ describe('FetchClient > Bodies > JSON', () => {
         body: JSON.stringify(1),
       });
 
-      expect(response.status).toBe(201);
+      expectResponseStatus(response, 201);
       expect(await response.json()).toEqual(2);
 
       expect(response).toBeInstanceOf(Response);
@@ -185,7 +190,7 @@ describe('FetchClient > Bodies > JSON', () => {
         body: JSON.stringify(false),
       });
 
-      expect(response.status).toBe(201);
+      expectResponseStatus(response, 201);
       expect(await response.json()).toEqual(true);
 
       expect(response).toBeInstanceOf(Response);
@@ -247,7 +252,7 @@ describe('FetchClient > Bodies > JSON', () => {
         body: null,
       });
 
-      expect(response.status).toBe(201);
+      expectResponseStatus(response, 201);
       expect(await response.json()).toEqual(null);
 
       expect(response).toBeInstanceOf(Response);

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.plainText.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.plainText.test.ts
@@ -3,6 +3,7 @@ import joinURL from '@zimic/utils/url/joinURL';
 import { describe, expect, expectTypeOf, it } from 'vitest';
 
 import { usingHttpInterceptor } from '@tests/utils/interceptors';
+import { expectResponseStatus } from '@tests/utils/requests';
 
 import createFetch from '../factory';
 import { FetchRequest, FetchResponse } from '../types/requests';
@@ -43,7 +44,7 @@ describe('FetchClient > Bodies > Plain text', () => {
         body: 'request',
       });
 
-      expect(response.status).toBe(201);
+      expectResponseStatus(response, 201);
       expect(await response.text()).toBe('response');
 
       expect(response).toBeInstanceOf(Response);
@@ -108,7 +109,7 @@ describe('FetchClient > Bodies > Plain text', () => {
         headers: { 'content-type': 'text/plain' },
       });
 
-      expect(response.status).toBe(201);
+      expectResponseStatus(response, 201);
       expect(await response.text()).toBe('');
 
       expect(response).toBeInstanceOf(Response);

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.searchParams.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.searchParams.test.ts
@@ -3,6 +3,7 @@ import joinURL from '@zimic/utils/url/joinURL';
 import { describe, expect, expectTypeOf, it } from 'vitest';
 
 import { usingHttpInterceptor } from '@tests/utils/interceptors';
+import { expectResponseStatus } from '@tests/utils/requests';
 
 import createFetch from '../factory';
 import { FetchRequest, FetchResponse } from '../types/requests';
@@ -55,7 +56,7 @@ describe('FetchClient > Bodies > Search params', () => {
         body: requestSearchParams,
       });
 
-      expect(response.status).toBe(201);
+      expectResponseStatus(response, 201);
       const receivedResponseSearchParams = await response.formData();
       expect(Array.from(receivedResponseSearchParams.entries())).toHaveLength(responseSearchParams.size);
 
@@ -125,7 +126,7 @@ describe('FetchClient > Bodies > Search params', () => {
         method: 'POST',
       });
 
-      expect(response.status).toBe(201);
+      expectResponseStatus(response, 201);
       expect(await response.text()).toBe('');
 
       expect(response).toBeInstanceOf(Response);

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.defaults.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.defaults.test.ts
@@ -3,6 +3,7 @@ import joinURL from '@zimic/utils/url/joinURL';
 import { describe, expect, expectTypeOf, it } from 'vitest';
 
 import { usingHttpInterceptor } from '@tests/utils/interceptors';
+import { expectResponseStatus } from '@tests/utils/requests';
 
 import createFetch from '../factory';
 import { FetchDefaults, FetchOptions } from '../types/public';
@@ -12,10 +13,14 @@ describe('FetchClient > Defaults', () => {
   const baseURL = 'http://localhost:3000';
 
   interface User {
+    id: string;
     name: string;
   }
 
-  const users: User[] = [{ name: 'User 1' }, { name: 'User 2' }];
+  const users: User[] = [
+    { id: '1', name: 'User 1' },
+    { id: '2', name: 'User 2' },
+  ];
 
   it('should support creating a fetch client without defaults', async () => {
     type Schema = HttpSchema<{
@@ -40,7 +45,7 @@ describe('FetchClient > Defaults', () => {
       const response = await fetch('/users', { method: 'GET' });
 
       expectTypeOf(response.status).toEqualTypeOf<200>();
-      expect(response.status).toBe(200);
+      expectResponseStatus(response, 200);
 
       expect(await response.json()).toEqual(users);
 
@@ -105,7 +110,7 @@ describe('FetchClient > Defaults', () => {
       const response = await fetch('/users', { method: 'POST' });
 
       expectTypeOf(response.status).toEqualTypeOf<200>();
-      expect(response.status).toBe(200);
+      expectResponseStatus(response, 200);
 
       expect(await response.json()).toEqual(users);
 
@@ -204,7 +209,7 @@ describe('FetchClient > Defaults', () => {
       const response = await fetch('/users', { method: 'POST' });
 
       expectTypeOf(response.status).toEqualTypeOf<200>();
-      expect(response.status).toBe(200);
+      expectResponseStatus(response, 200);
 
       expect(await response.json()).toEqual(users);
 
@@ -279,7 +284,7 @@ describe('FetchClient > Defaults', () => {
       });
 
       expectTypeOf(response.status).toEqualTypeOf<200>();
-      expect(response.status).toBe(200);
+      expectResponseStatus(response, 200);
 
       expect(await response.json()).toEqual(users);
 
@@ -346,7 +351,7 @@ describe('FetchClient > Defaults', () => {
       });
 
       expectTypeOf(response.status).toEqualTypeOf<200>();
-      expect(response.status).toBe(200);
+      expectResponseStatus(response, 200);
 
       expect(await response.json()).toEqual(users);
 
@@ -403,7 +408,7 @@ describe('FetchClient > Defaults', () => {
       });
 
       expectTypeOf(response.status).toEqualTypeOf<200>();
-      expect(response.status).toBe(200);
+      expectResponseStatus(response, 200);
 
       expect(await response.json()).toEqual(users);
 
@@ -457,7 +462,7 @@ describe('FetchClient > Defaults', () => {
       });
 
       expectTypeOf(response.status).toEqualTypeOf<200>();
-      expect(response.status).toBe(200);
+      expectResponseStatus(response, 200);
 
       expect(await response.json()).toEqual(users);
 

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.headers.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.headers.test.ts
@@ -3,6 +3,7 @@ import joinURL from '@zimic/utils/url/joinURL';
 import { describe, expect, expectTypeOf, it } from 'vitest';
 
 import { usingHttpInterceptor } from '@tests/utils/interceptors';
+import { expectResponseStatus } from '@tests/utils/requests';
 
 import createFetch from '../factory';
 import { FetchRequest, FetchResponse } from '../types/requests';
@@ -11,10 +12,14 @@ describe('FetchClient > Headers', () => {
   const baseURL = 'http://localhost:3000';
 
   interface User {
+    id: string;
     name: string;
   }
 
-  const users: User[] = [{ name: 'User 1' }, { name: 'User 2' }];
+  const users: User[] = [
+    { id: '1', name: 'User 1' },
+    { id: '2', name: 'User 2' },
+  ];
 
   it('should support requests with headers as object', async () => {
     type RequestHeaders = HttpSchema.Headers<{
@@ -69,7 +74,7 @@ describe('FetchClient > Headers', () => {
 
       for (const response of responses) {
         expectTypeOf(response.status).toEqualTypeOf<200>();
-        expect(response.status).toBe(200);
+        expectResponseStatus(response, 200);
 
         expect(await response.json()).toEqual(users);
       }
@@ -127,7 +132,7 @@ describe('FetchClient > Headers', () => {
 
       for (const response of responses) {
         expectTypeOf(response.status).toEqualTypeOf<200>();
-        expect(response.status).toBe(200);
+        expectResponseStatus(response, 200);
 
         expect(await response.json()).toEqual(users);
       }
@@ -193,7 +198,7 @@ describe('FetchClient > Headers', () => {
 
       for (const response of responses) {
         expectTypeOf(response.status).toEqualTypeOf<200>();
-        expect(response.status).toBe(200);
+        expectResponseStatus(response, 200);
 
         expect(await response.json()).toEqual(users);
       }
@@ -250,7 +255,7 @@ describe('FetchClient > Headers', () => {
 
       for (const response of responses) {
         expectTypeOf(response.status).toEqualTypeOf<200>();
-        expect(response.status).toBe(200);
+        expectResponseStatus(response, 200);
 
         expect(await response.json()).toEqual(users);
       }
@@ -289,7 +294,7 @@ describe('FetchClient > Headers', () => {
       const response = await fetch('/users', { method: 'GET' });
 
       expectTypeOf(response.status).toEqualTypeOf<200>();
-      expect(response.status).toBe(200);
+      expectResponseStatus(response, 200);
 
       expect(await response.json()).toEqual(users);
 
@@ -341,7 +346,7 @@ describe('FetchClient > Headers', () => {
       const response = await fetch('/users', { method: 'GET' });
 
       expectTypeOf(response.status).toEqualTypeOf<200>();
-      expect(response.status).toBe(200);
+      expectResponseStatus(response, 200);
 
       expect(await response.json()).toEqual(users);
 
@@ -401,7 +406,7 @@ describe('FetchClient > Headers', () => {
       const response = await fetch('/users', { method: 'GET' });
 
       expectTypeOf(response.status).toEqualTypeOf<200>();
-      expect(response.status).toBe(200);
+      expectResponseStatus(response, 200);
 
       expect(await response.json()).toEqual(users);
 
@@ -454,7 +459,7 @@ describe('FetchClient > Headers', () => {
 
       for (const response of responses) {
         expectTypeOf(response.status).toEqualTypeOf<200>();
-        expect(response.status).toBe(200);
+        expectResponseStatus(response, 200);
 
         expect(await response.json()).toEqual(users);
 

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.isResponse.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.isResponse.test.ts
@@ -3,6 +3,7 @@ import joinURL from '@zimic/utils/url/joinURL';
 import { describe, expect, expectTypeOf, it } from 'vitest';
 
 import { usingHttpInterceptor } from '@tests/utils/interceptors';
+import { expectResponseStatus } from '@tests/utils/requests';
 
 import createFetch from '../factory';
 
@@ -67,7 +68,7 @@ describe('FetchClient > isResponse', () => {
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
       expectTypeOf(response.status).toEqualTypeOf<200>();
-      expect(response.status).toBe(200);
+      expectResponseStatus(response, 200);
 
       expectTypeOf(response.request.method).toEqualTypeOf<'GET'>();
       expect(response.request.method).toBe('GET');
@@ -127,7 +128,7 @@ describe('FetchClient > isResponse', () => {
       });
 
       expectTypeOf(response.status).toEqualTypeOf<200 | 404>();
-      expect(response.status).toBe(200);
+      expectResponseStatus(response, 200);
 
       expectTypeOf(response.request.method).toEqualTypeOf<'GET'>();
       expect(response.request.method).toBe('GET');
@@ -189,7 +190,7 @@ describe('FetchClient > isResponse', () => {
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
       expectTypeOf(response.status).toEqualTypeOf<200>();
-      expect(response.status).toBe(200);
+      expectResponseStatus(response, 200);
 
       expectTypeOf(response.request.method).toEqualTypeOf<'GET'>();
       expect(response.request.method).toBe('GET');
@@ -273,7 +274,7 @@ describe('FetchClient > isResponse', () => {
       expect(response.url).toBe(joinURL(baseURL, '/users/'));
 
       expectTypeOf(response.status).toEqualTypeOf<200>();
-      expect(response.status).toBe(200);
+      expectResponseStatus(response, 200);
 
       expectTypeOf(response.request.method).toEqualTypeOf<'GET'>();
       expect(response.request.method).toBe('GET');
@@ -357,7 +358,7 @@ describe('FetchClient > isResponse', () => {
       expect(response.url).toBe(joinURL(baseURL, '/users/'));
 
       expectTypeOf(response.status).toEqualTypeOf<200>();
-      expect(response.status).toBe(200);
+      expectResponseStatus(response, 200);
 
       expectTypeOf(response.request.method).toEqualTypeOf<'GET'>();
       expect(response.request.method).toBe('GET');

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.isResponseError.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.isResponseError.test.ts
@@ -3,6 +3,7 @@ import joinURL from '@zimic/utils/url/joinURL';
 import { describe, expect, expectTypeOf, it } from 'vitest';
 
 import { usingHttpInterceptor } from '@tests/utils/interceptors';
+import { expectResponseStatus } from '@tests/utils/requests';
 
 import createFetch from '../factory';
 
@@ -68,7 +69,7 @@ describe('FetchClient > isResponseError', () => {
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
       expectTypeOf(response.status).toEqualTypeOf<200 | 500>();
-      expect(response.status).toBe(500);
+      expectResponseStatus(response, 500);
 
       expectTypeOf(response.request.method).toEqualTypeOf<'GET'>();
       expect(response.request.method).toBe('GET');
@@ -127,7 +128,7 @@ describe('FetchClient > isResponseError', () => {
       });
 
       expectTypeOf(response.status).toEqualTypeOf<200 | 404>();
-      expect(response.status).toBe(404);
+      expectResponseStatus(response, 404);
 
       expectTypeOf(response.request.method).toEqualTypeOf<'GET'>();
       expect(response.request.method).toBe('GET');
@@ -190,7 +191,7 @@ describe('FetchClient > isResponseError', () => {
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
       expectTypeOf(response.status).toEqualTypeOf<200 | 500>();
-      expect(response.status).toBe(500);
+      expectResponseStatus(response, 500);
 
       expectTypeOf(response.request.method).toEqualTypeOf<'GET'>();
       expect(response.request.method).toBe('GET');
@@ -275,7 +276,7 @@ describe('FetchClient > isResponseError', () => {
       expect(response.url).toBe(joinURL(baseURL, '/users/'));
 
       expectTypeOf(response.status).toEqualTypeOf<200 | 500>();
-      expect(response.status).toBe(500);
+      expectResponseStatus(response, 500);
 
       expectTypeOf(response.request.method).toEqualTypeOf<'GET'>();
       expect(response.request.method).toBe('GET');
@@ -360,7 +361,7 @@ describe('FetchClient > isResponseError', () => {
       expect(response.url).toBe(joinURL(baseURL, '/users/'));
 
       expectTypeOf(response.status).toEqualTypeOf<200 | 500>();
-      expect(response.status).toBe(500);
+      expectResponseStatus(response, 500);
 
       expectTypeOf(response.request.method).toEqualTypeOf<'GET'>();
       expect(response.request.method).toBe('GET');

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.listeners.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.listeners.test.ts
@@ -5,6 +5,7 @@ import joinURL from '@zimic/utils/url/joinURL';
 import { describe, expect, expectTypeOf, it, vi } from 'vitest';
 
 import { usingHttpInterceptor } from '@tests/utils/interceptors';
+import { expectResponseStatus } from '@tests/utils/requests';
 
 import createFetch from '../factory';
 import { Fetch } from '../types/public';
@@ -104,7 +105,7 @@ describe('FetchClient > Listeners', () => {
       });
 
       expectTypeOf(response.status).toEqualTypeOf<200>();
-      expect(response.status).toBe(200);
+      expectResponseStatus(response, 200);
 
       expect(await response.json()).toEqual(users[0]);
 
@@ -204,7 +205,7 @@ describe('FetchClient > Listeners', () => {
       });
 
       expectTypeOf(response.status).toEqualTypeOf<200>();
-      expect(response.status).toBe(200);
+      expectResponseStatus(response, 200);
 
       expect(await response.json()).toEqual(users[0]);
 
@@ -259,7 +260,7 @@ describe('FetchClient > Listeners', () => {
       const response = await fetch('/users', { method: 'POST' });
 
       expectTypeOf(response.status).toEqualTypeOf<200>();
-      expect(response.status).toBe(200);
+      expectResponseStatus(response, 200);
 
       expect(await response.json()).toEqual(users);
 
@@ -349,7 +350,7 @@ describe('FetchClient > Listeners', () => {
       const response = await fetch('/users', { method: 'POST' });
 
       expectTypeOf(response.status).toEqualTypeOf<200>();
-      expect(response.status).toBe(200);
+      expectResponseStatus(response, 200);
 
       expect(await response.json()).toEqual(users);
 
@@ -416,7 +417,7 @@ describe('FetchClient > Listeners', () => {
       const response = await fetch('/users', { method: 'POST' });
 
       expectTypeOf(response.status).toEqualTypeOf<200>();
-      expect(response.status).toBe(200);
+      expectResponseStatus(response, 200);
 
       expect(await response.json()).toEqual(users);
 
@@ -478,7 +479,7 @@ describe('FetchClient > Listeners', () => {
       const response = await fetch('/users', { method: 'POST' });
 
       expectTypeOf(response.status).toEqualTypeOf<200>();
-      expect(response.status).toBe(200);
+      expectResponseStatus(response, 200);
 
       expect(await response.json()).toEqual(users);
 
@@ -575,7 +576,7 @@ describe('FetchClient > Listeners', () => {
       const response = await fetch('/users', { method: 'POST' });
 
       expectTypeOf(response.status).toEqualTypeOf<200>();
-      expect(response.status).toBe(200);
+      expectResponseStatus(response, 200);
 
       expect(await response.json()).toEqual(users);
 
@@ -668,7 +669,7 @@ describe('FetchClient > Listeners', () => {
       const response = await fetch(`/users/${users[0].id}`, { method: 'POST' });
 
       expectTypeOf(response.status).toEqualTypeOf<200>();
-      expect(response.status).toBe(200);
+      expectResponseStatus(response, 200);
 
       expect(await response.json()).toEqual(users[0]);
 
@@ -730,7 +731,7 @@ describe('FetchClient > Listeners', () => {
       const response = await fetch('/users', { method: 'POST' });
 
       expectTypeOf(response.status).toEqualTypeOf<200>();
-      expect(response.status).toBe(200);
+      expectResponseStatus(response, 200);
 
       expect(await response.json()).toEqual(users);
 
@@ -798,7 +799,7 @@ describe('FetchClient > Listeners', () => {
       const response = await fetch('/users', { method: 'POST' });
 
       expectTypeOf(response.status).toEqualTypeOf<200>();
-      expect(response.status).toBe(200);
+      expectResponseStatus(response, 200);
 
       expect(await response.json()).toEqual(users);
 

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.methods.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.methods.test.ts
@@ -3,6 +3,7 @@ import joinURL from '@zimic/utils/url/joinURL';
 import { describe, expect, expectTypeOf, it } from 'vitest';
 
 import { usingHttpInterceptor } from '@tests/utils/interceptors';
+import { expectResponseStatus } from '@tests/utils/requests';
 
 import createFetch from '../factory';
 import { FetchResponse, FetchRequest } from '../types/requests';
@@ -11,10 +12,14 @@ describe('FetchClient > Methods', () => {
   const baseURL = 'http://localhost:3000';
 
   interface User {
+    id: string;
     name: string;
   }
 
-  const users: User[] = [{ name: 'User 1' }, { name: 'User 2' }];
+  const users: User[] = [
+    { id: '1', name: 'User 1' },
+    { id: '2', name: 'User 2' },
+  ];
 
   it('should support making GET requests', async () => {
     type Schema = HttpSchema<{
@@ -39,7 +44,7 @@ describe('FetchClient > Methods', () => {
       const response = await fetch('/users', { method: 'GET' });
 
       expectTypeOf(response.status).toEqualTypeOf<200>();
-      expect(response.status).toBe(200);
+      expectResponseStatus(response, 200);
 
       expect(await response.json()).toEqual(users);
 
@@ -85,7 +90,7 @@ describe('FetchClient > Methods', () => {
       const response = await fetch(url, { method: 'GET' });
 
       expectTypeOf(response.status).toEqualTypeOf<200>();
-      expect(response.status).toBe(200);
+      expectResponseStatus(response, 200);
 
       expect(await response.json()).toEqual(users);
 
@@ -145,7 +150,7 @@ describe('FetchClient > Methods', () => {
       const response = await fetch(request);
 
       expectTypeOf(response.status).toEqualTypeOf<200>();
-      expect(response.status).toBe(200);
+      expectResponseStatus(response, 200);
 
       expect(await response.json()).toEqual(users);
 
@@ -181,7 +186,7 @@ describe('FetchClient > Methods', () => {
     }>;
 
     await usingHttpInterceptor<Schema>({ type: 'local', baseURL }, async (interceptor) => {
-      const user: User = { name: 'User 1' };
+      const user = users[0];
 
       await interceptor
         .post('/users')
@@ -200,7 +205,7 @@ describe('FetchClient > Methods', () => {
         body: JSON.stringify(user),
       });
 
-      expect(response.status).toBe(201);
+      expectResponseStatus(response, 201);
       expect(await response.json()).toEqual(user);
 
       expect(response).toBeInstanceOf(Response);
@@ -238,7 +243,7 @@ describe('FetchClient > Methods', () => {
     }>;
 
     await usingHttpInterceptor<Schema>({ type: 'local', baseURL }, async (interceptor) => {
-      const user: User = { name: 'User 1' };
+      const user = users[0];
 
       await interceptor
         .post('/users')
@@ -258,7 +263,7 @@ describe('FetchClient > Methods', () => {
         body: JSON.stringify(user),
       });
 
-      expect(response.status).toBe(201);
+      expectResponseStatus(response, 201);
       expect(await response.json()).toEqual(user);
 
       expect(response).toBeInstanceOf(Response);
@@ -296,7 +301,7 @@ describe('FetchClient > Methods', () => {
     }>;
 
     await usingHttpInterceptor<Schema>({ type: 'local', baseURL }, async (interceptor) => {
-      const user: User = { name: 'User 1' };
+      const user = users[0];
 
       await interceptor
         .post('/users')
@@ -330,7 +335,7 @@ describe('FetchClient > Methods', () => {
 
       const response = await fetch(request);
 
-      expect(response.status).toBe(201);
+      expectResponseStatus(response, 201);
       expect(await response.json()).toEqual(user);
 
       expect(response).toBeInstanceOf(Response);
@@ -368,7 +373,7 @@ describe('FetchClient > Methods', () => {
     }>;
 
     await usingHttpInterceptor<Schema>({ type: 'local', baseURL }, async (interceptor) => {
-      const user: User = { name: 'User 1' };
+      const user = users[0];
 
       await interceptor
         .put('/users')
@@ -388,7 +393,7 @@ describe('FetchClient > Methods', () => {
       });
 
       expectTypeOf(response.status).toEqualTypeOf<200>();
-      expect(response.status).toBe(200);
+      expectResponseStatus(response, 200);
       expect(await response.json()).toEqual(user);
 
       expect(response).toBeInstanceOf(Response);
@@ -426,7 +431,7 @@ describe('FetchClient > Methods', () => {
     }>;
 
     await usingHttpInterceptor<Schema>({ type: 'local', baseURL }, async (interceptor) => {
-      const user: User = { name: 'User 1' };
+      const user = users[0];
 
       await interceptor
         .put('/users')
@@ -447,7 +452,7 @@ describe('FetchClient > Methods', () => {
       });
 
       expectTypeOf(response.status).toEqualTypeOf<200>();
-      expect(response.status).toBe(200);
+      expectResponseStatus(response, 200);
       expect(await response.json()).toEqual(user);
 
       expect(response).toBeInstanceOf(Response);
@@ -485,7 +490,7 @@ describe('FetchClient > Methods', () => {
     }>;
 
     await usingHttpInterceptor<Schema>({ type: 'local', baseURL }, async (interceptor) => {
-      const user: User = { name: 'User 1' };
+      const user = users[0];
 
       await interceptor
         .put('/users')
@@ -520,7 +525,7 @@ describe('FetchClient > Methods', () => {
       const response = await fetch(request);
 
       expectTypeOf(response.status).toEqualTypeOf<200>();
-      expect(response.status).toBe(200);
+      expectResponseStatus(response, 200);
       expect(await response.json()).toEqual(user);
 
       expect(response).toBeInstanceOf(Response);
@@ -558,7 +563,7 @@ describe('FetchClient > Methods', () => {
     }>;
 
     await usingHttpInterceptor<Schema>({ type: 'local', baseURL }, async (interceptor) => {
-      const user: User = { name: 'User 1' };
+      const user = users[0];
 
       await interceptor
         .patch('/users')
@@ -578,7 +583,7 @@ describe('FetchClient > Methods', () => {
       });
 
       expectTypeOf(response.status).toEqualTypeOf<200>();
-      expect(response.status).toBe(200);
+      expectResponseStatus(response, 200);
       expect(await response.json()).toEqual(user);
 
       expect(response).toBeInstanceOf(Response);
@@ -616,7 +621,7 @@ describe('FetchClient > Methods', () => {
     }>;
 
     await usingHttpInterceptor<Schema>({ type: 'local', baseURL }, async (interceptor) => {
-      const user: User = { name: 'User 1' };
+      const user = users[0];
 
       await interceptor
         .patch('/users')
@@ -637,7 +642,7 @@ describe('FetchClient > Methods', () => {
       });
 
       expectTypeOf(response.status).toEqualTypeOf<200>();
-      expect(response.status).toBe(200);
+      expectResponseStatus(response, 200);
       expect(await response.json()).toEqual(user);
 
       expect(response).toBeInstanceOf(Response);
@@ -675,7 +680,7 @@ describe('FetchClient > Methods', () => {
     }>;
 
     await usingHttpInterceptor<Schema>({ type: 'local', baseURL }, async (interceptor) => {
-      const user: User = { name: 'User 1' };
+      const user = users[0];
 
       await interceptor
         .patch('/users')
@@ -714,7 +719,7 @@ describe('FetchClient > Methods', () => {
       const response = await fetch(request);
 
       expectTypeOf(response.status).toEqualTypeOf<200>();
-      expect(response.status).toBe(200);
+      expectResponseStatus(response, 200);
       expect(await response.json()).toEqual(user);
 
       expect(response).toBeInstanceOf(Response);
@@ -754,7 +759,7 @@ describe('FetchClient > Methods', () => {
 
       const response = await fetch('/users', { method: 'DELETE' });
 
-      expect(response.status).toBe(204);
+      expectResponseStatus(response, 204);
       expect(await response.text()).toBe('');
 
       expect(response).toBeInstanceOf(Response);
@@ -792,7 +797,7 @@ describe('FetchClient > Methods', () => {
       const url = new URL('/users', baseURL);
       const response = await fetch(url, { method: 'DELETE' });
 
-      expect(response.status).toBe(204);
+      expectResponseStatus(response, 204);
       expect(await response.text()).toBe('');
 
       expect(response).toBeInstanceOf(Response);
@@ -844,7 +849,7 @@ describe('FetchClient > Methods', () => {
 
       const response = await fetch(request);
 
-      expect(response.status).toBe(204);
+      expectResponseStatus(response, 204);
       expect(await response.text()).toBe('');
 
       expect(response).toBeInstanceOf(Response);
@@ -882,7 +887,7 @@ describe('FetchClient > Methods', () => {
       const response = await fetch('/users', { method: 'HEAD' });
 
       expectTypeOf(response.status).toEqualTypeOf<200>();
-      expect(response.status).toBe(200);
+      expectResponseStatus(response, 200);
       expect(await response.text()).toBe('');
 
       expect(response).toBeInstanceOf(Response);
@@ -921,7 +926,7 @@ describe('FetchClient > Methods', () => {
       const response = await fetch(url, { method: 'HEAD' });
 
       expectTypeOf(response.status).toEqualTypeOf<200>();
-      expect(response.status).toBe(200);
+      expectResponseStatus(response, 200);
       expect(await response.text()).toBe('');
 
       expect(response).toBeInstanceOf(Response);
@@ -974,7 +979,7 @@ describe('FetchClient > Methods', () => {
       const response = await fetch(request);
 
       expectTypeOf(response.status).toEqualTypeOf<200>();
-      expect(response.status).toBe(200);
+      expectResponseStatus(response, 200);
       expect(await response.text()).toBe('');
 
       expect(response).toBeInstanceOf(Response);
@@ -1012,7 +1017,7 @@ describe('FetchClient > Methods', () => {
       const response = await fetch('/users', { method: 'OPTIONS' });
 
       expectTypeOf(response.status).toEqualTypeOf<200>();
-      expect(response.status).toBe(200);
+      expectResponseStatus(response, 200);
       expect(await response.text()).toBe('');
 
       expect(response).toBeInstanceOf(Response);
@@ -1051,7 +1056,7 @@ describe('FetchClient > Methods', () => {
       const response = await fetch(url, { method: 'OPTIONS' });
 
       expectTypeOf(response.status).toEqualTypeOf<200>();
-      expect(response.status).toBe(200);
+      expectResponseStatus(response, 200);
       expect(await response.text()).toBe('');
 
       expect(response).toBeInstanceOf(Response);
@@ -1104,7 +1109,7 @@ describe('FetchClient > Methods', () => {
       const response = await fetch(request);
 
       expectTypeOf(response.status).toEqualTypeOf<200>();
-      expect(response.status).toBe(200);
+      expectResponseStatus(response, 200);
       expect(await response.text()).toBe('');
 
       expect(response).toBeInstanceOf(Response);
@@ -1245,7 +1250,7 @@ describe('FetchClient > Methods', () => {
         POST: {
           request: {
             headers: { 'content-type': 'application/json' };
-            body: User;
+            body: Omit<User, 'id'>;
           };
           response: { 201: { body: User } };
         };

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.pathParams.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.pathParams.test.ts
@@ -3,6 +3,7 @@ import joinURL from '@zimic/utils/url/joinURL';
 import { describe, expect, expectTypeOf, it } from 'vitest';
 
 import { usingHttpInterceptor } from '@tests/utils/interceptors';
+import { expectResponseStatus } from '@tests/utils/requests';
 
 import createFetch from '../factory';
 import { FetchResponse, FetchRequest } from '../types/requests';
@@ -41,7 +42,7 @@ describe('FetchClient > Path params', () => {
       const response = await fetch(`/${users[0].username}`, { method: 'GET' });
 
       expectTypeOf(response.status).toEqualTypeOf<200>();
-      expect(response.status).toBe(200);
+      expectResponseStatus(response, 200);
 
       expect(await response.json()).toEqual(users[0]);
 
@@ -88,7 +89,7 @@ describe('FetchClient > Path params', () => {
       const response = await fetch(`/users/${users[0].username}/get`, { method: 'GET' });
 
       expectTypeOf(response.status).toEqualTypeOf<200>();
-      expect(response.status).toBe(200);
+      expectResponseStatus(response, 200);
 
       expect(await response.json()).toEqual(users[0]);
 
@@ -137,7 +138,7 @@ describe('FetchClient > Path params', () => {
       const response = await fetch(`/users/${users[0].username}`, { method: 'GET' });
 
       expectTypeOf(response.status).toEqualTypeOf<200>();
-      expect(response.status).toBe(200);
+      expectResponseStatus(response, 200);
 
       expect(await response.json()).toEqual(users[0]);
 
@@ -184,7 +185,7 @@ describe('FetchClient > Path params', () => {
       const response = await fetch(`/users/${users[0].username}/get/${users[1].username}`, { method: 'GET' });
 
       expectTypeOf(response.status).toEqualTypeOf<200>();
-      expect(response.status).toBe(200);
+      expectResponseStatus(response, 200);
 
       expect(await response.json()).toEqual(users[0]);
 
@@ -235,7 +236,7 @@ describe('FetchClient > Path params', () => {
       const response = await fetch(`/users/${users[0].username}/${users[1].username}`, { method: 'GET' });
 
       expectTypeOf(response.status).toEqualTypeOf<200>();
-      expect(response.status).toBe(200);
+      expectResponseStatus(response, 200);
 
       expect(await response.json()).toEqual(users[0]);
 
@@ -286,7 +287,7 @@ describe('FetchClient > Path params', () => {
       const response = await fetch(`/users/${users[0].username}/${users[1].username}/get`, { method: 'GET' });
 
       expectTypeOf(response.status).toEqualTypeOf<200>();
-      expect(response.status).toBe(200);
+      expectResponseStatus(response, 200);
 
       expect(await response.json()).toEqual(users[0]);
 
@@ -345,7 +346,7 @@ describe('FetchClient > Path params', () => {
       const response = await fetch('/users', { method: 'GET' });
 
       expectTypeOf(response.status).toEqualTypeOf<200>();
-      expect(response.status).toBe(200);
+      expectResponseStatus(response, 200);
 
       expect(await response.json()).toEqual(users);
 

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.redirects.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.redirects.test.ts
@@ -1,0 +1,183 @@
+import { HttpSchema, HttpSchemaPath } from '@zimic/http';
+import expectFetchError from '@zimic/utils/fetch/expectFetchError';
+import { describe, expect, expectTypeOf, it } from 'vitest';
+
+import { isClientSide } from '@/utils/environment';
+import { usingHttpInterceptor } from '@tests/utils/interceptors';
+import { expectResponseStatus } from '@tests/utils/requests';
+
+import createFetch from '../factory';
+
+describe('FetchClient > Redirects', () => {
+  const baseURL = 'http://localhost:3000';
+
+  it.each(['manual'] as const)('should support making requests with redirect: %s', async (redirect) => {
+    type Schema = HttpSchema<{
+      '/:slug': {
+        GET: {
+          response: {
+            200: {
+              headers: { 'content-type': 'text/html' };
+              body: string;
+            };
+            301: { headers: { location: HttpSchemaPath<Schema> } };
+            304: {};
+            307: { headers: { location: HttpSchemaPath<Schema> } };
+            308: { headers: { location: HttpSchemaPath<Schema> } };
+          };
+        };
+      };
+    }>;
+
+    await usingHttpInterceptor<Schema>({ type: 'local', baseURL }, async (interceptor) => {
+      await interceptor
+        .get('/original')
+        .respond({
+          status: 301,
+          headers: { location: '/redirected' },
+        })
+        .times(1);
+
+      await interceptor
+        .get('/redirected')
+        .respond({
+          status: 200,
+          headers: { 'content-type': 'text/html' },
+          body: '<html></html>',
+        })
+        .times(1);
+
+      const fetch = createFetch<Schema>({ baseURL });
+
+      const firstResponse = await fetch('/original', {
+        method: 'GET',
+        redirect,
+      });
+
+      expectTypeOf(firstResponse.status).toEqualTypeOf<200 | 301 | 304 | 307 | 308>();
+
+      let redirectPath: HttpSchemaPath<Schema> | undefined;
+
+      if (isClientSide()) {
+        // In the browser, the response is opaque and the status is 0. No headers are available.
+        expectResponseStatus(firstResponse, 0);
+        redirectPath = '/redirected';
+      } else {
+        expectResponseStatus(firstResponse, 301);
+        redirectPath = firstResponse.headers.get('location');
+      }
+
+      expect(redirectPath).not.toBe(null);
+
+      const secondResponse = await fetch(redirectPath, {
+        method: 'GET',
+        redirect: 'manual',
+      });
+
+      expectTypeOf(secondResponse.status).toEqualTypeOf<200 | 301 | 304 | 307 | 308>();
+      expectResponseStatus(secondResponse, 200);
+
+      expect(secondResponse.headers.get('content-type')).toBe('text/html');
+
+      expect(await secondResponse.text()).toBe('<html></html>');
+    });
+  });
+
+  it.each(['follow', undefined] as const)('should support making requests with redirect: %s', async (redirect) => {
+    type Schema = HttpSchema<{
+      '/:slug': {
+        GET: {
+          response: {
+            200: {
+              headers: { 'content-type': 'text/html' };
+              body: string;
+            };
+            301: { headers: { location: HttpSchemaPath<Schema> } };
+            304: {};
+            307: { headers: { location: HttpSchemaPath<Schema> } };
+            308: { headers: { location: HttpSchemaPath<Schema> } };
+          };
+        };
+      };
+    }>;
+
+    await usingHttpInterceptor<Schema>({ type: 'local', baseURL }, async (interceptor) => {
+      await interceptor
+        .get('/original')
+        .respond({
+          status: 301,
+          headers: { location: '/redirected' },
+        })
+        .times(1);
+
+      await interceptor
+        .get('/redirected')
+        .respond({
+          status: 200,
+          headers: { 'content-type': 'text/html' },
+          body: '<html></html>',
+        })
+        .times(1);
+
+      const fetch = createFetch<Schema>({ baseURL });
+
+      const response = await fetch('/original', {
+        method: 'GET',
+        redirect,
+      });
+
+      expectTypeOf(response.status).toEqualTypeOf<200 | 304>();
+      expectResponseStatus(response, 200);
+
+      expect(response.headers.get('content-type')).toBe('text/html');
+
+      expect(await response.text()).toBe('<html></html>');
+    });
+  });
+
+  it.each(['error'] as const)('should support making requests with redirect: %s', async (redirect) => {
+    type Schema = HttpSchema<{
+      '/:slug': {
+        GET: {
+          response: {
+            200: {
+              headers: { 'content-type': 'text/html' };
+              body: string;
+            };
+            301: { headers: { location: HttpSchemaPath<Schema> } };
+            304: {};
+            307: { headers: { location: HttpSchemaPath<Schema> } };
+            308: { headers: { location: HttpSchemaPath<Schema> } };
+          };
+        };
+      };
+    }>;
+
+    await usingHttpInterceptor<Schema>({ type: 'local', baseURL }, async (interceptor) => {
+      await interceptor
+        .get('/original')
+        .respond({
+          status: 301,
+          headers: { location: '/redirected' },
+        })
+        .times(1);
+
+      await interceptor
+        .get('/redirected')
+        .respond({
+          status: 200,
+          headers: { 'content-type': 'text/html' },
+          body: '<html></html>',
+        })
+        .times(0);
+
+      const fetch = createFetch<Schema>({ baseURL });
+
+      const responsePromise = fetch('/original', {
+        method: 'GET',
+        redirect,
+      });
+      await expectFetchError(responsePromise);
+    });
+  });
+});

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.searchParams.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.searchParams.test.ts
@@ -3,6 +3,7 @@ import joinURL from '@zimic/utils/url/joinURL';
 import { describe, expect, expectTypeOf, it } from 'vitest';
 
 import { usingHttpInterceptor } from '@tests/utils/interceptors';
+import { expectResponseStatus } from '@tests/utils/requests';
 
 import createFetch from '../factory';
 import { FetchRequest } from '../types/requests';
@@ -11,10 +12,14 @@ describe('FetchClient > Search params', () => {
   const baseURL = 'http://localhost:3000';
 
   interface User {
+    id: string;
     name: string;
   }
 
-  const users: User[] = [{ name: 'User 1' }, { name: 'User 2' }];
+  const users: User[] = [
+    { id: '1', name: 'User 1' },
+    { id: '2', name: 'User 2' },
+  ];
 
   it('should support requests with search params as object', async () => {
     type RequestSearchParams = HttpSchema.SearchParams<{
@@ -64,7 +69,7 @@ describe('FetchClient > Search params', () => {
 
       for (const response of responses) {
         expectTypeOf(response.status).toEqualTypeOf<200>();
-        expect(response.status).toBe(200);
+        expectResponseStatus(response, 200);
 
         expect(await response.json()).toEqual(users);
       }
@@ -119,7 +124,7 @@ describe('FetchClient > Search params', () => {
 
       for (const response of responses) {
         expectTypeOf(response.status).toEqualTypeOf<200>();
-        expect(response.status).toBe(200);
+        expectResponseStatus(response, 200);
 
         expect(await response.json()).toEqual(users);
       }
@@ -188,7 +193,7 @@ describe('FetchClient > Search params', () => {
 
       for (const response of responses) {
         expectTypeOf(response.status).toEqualTypeOf<200>();
-        expect(response.status).toBe(200);
+        expectResponseStatus(response, 200);
 
         expect(await response.json()).toEqual(users);
       }
@@ -242,7 +247,7 @@ describe('FetchClient > Search params', () => {
 
       for (const response of responses) {
         expectTypeOf(response.status).toEqualTypeOf<200>();
-        expect(response.status).toBe(200);
+        expectResponseStatus(response, 200);
 
         expect(await response.json()).toEqual(users);
       }

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.types.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.types.test.ts
@@ -13,10 +13,14 @@ describe('FetchClient > Types', () => {
   const baseURL = 'http://localhost:3000';
 
   interface User {
+    id: string;
     name: string;
   }
 
-  const users: User[] = [{ name: 'User 1' }, { name: 'User 2' }];
+  const users: User[] = [
+    { id: '1', name: 'User 1' },
+    { id: '2', name: 'User 2' },
+  ];
 
   it('should correctly type responses with merged status codes', async () => {
     type Schema = HttpSchema<{

--- a/packages/zimic-fetch/src/client/errors/FetchResponseError.ts
+++ b/packages/zimic-fetch/src/client/errors/FetchResponseError.ts
@@ -9,7 +9,7 @@ class FetchResponseError<
 > extends Error {
   constructor(
     public request: FetchRequest<Schema, Method, Path>,
-    public response: FetchResponse<Schema, Method, Path, true>,
+    public response: FetchResponse<Schema, Method, Path, true, 'manual'>,
   ) {
     super(`${request.method} ${request.url} failed with status ${response.status}: ${response.statusText}`);
     this.name = 'FetchResponseError';

--- a/packages/zimic-fetch/src/client/types/public.ts
+++ b/packages/zimic-fetch/src/client/types/public.ts
@@ -11,15 +11,23 @@ export type FetchInput<
 > = Path | URL | FetchRequest<Schema, Method, LiteralHttpSchemaPathFromNonLiteral<Schema, Method, Path>>;
 
 interface FetchFunction<Schema extends HttpSchema> {
-  <Method extends HttpSchemaMethod<Schema>, Path extends HttpSchemaPath.NonLiteral<Schema, Method>>(
+  <
+    Method extends HttpSchemaMethod<Schema>,
+    Path extends HttpSchemaPath.NonLiteral<Schema, Method>,
+    Redirect extends RequestRedirect = 'follow',
+  >(
     input: Path | URL,
-    init: FetchRequestInit<Schema, Method, LiteralHttpSchemaPathFromNonLiteral<Schema, Method, Path>>,
-  ): Promise<FetchResponse<Schema, Method, LiteralHttpSchemaPathFromNonLiteral<Schema, Method, Path>>>;
+    init: FetchRequestInit<Schema, Method, LiteralHttpSchemaPathFromNonLiteral<Schema, Method, Path>, Redirect>,
+  ): Promise<FetchResponse<Schema, Method, LiteralHttpSchemaPathFromNonLiteral<Schema, Method, Path>, false, Redirect>>;
 
-  <Method extends HttpSchemaMethod<Schema>, Path extends HttpSchemaPath.NonLiteral<Schema, Method>>(
+  <
+    Method extends HttpSchemaMethod<Schema>,
+    Path extends HttpSchemaPath.NonLiteral<Schema, Method>,
+    Redirect extends RequestRedirect = 'follow',
+  >(
     input: FetchRequest<Schema, Method, LiteralHttpSchemaPathFromNonLiteral<Schema, Method, Path>>,
-    init?: FetchRequestInit<Schema, Method, LiteralHttpSchemaPathFromNonLiteral<Schema, Method, Path>>,
-  ): Promise<FetchResponse<Schema, Method, LiteralHttpSchemaPathFromNonLiteral<Schema, Method, Path>>>;
+    init?: FetchRequestInit<Schema, Method, LiteralHttpSchemaPathFromNonLiteral<Schema, Method, Path>, Redirect>,
+  ): Promise<FetchResponse<Schema, Method, LiteralHttpSchemaPathFromNonLiteral<Schema, Method, Path>, false, Redirect>>;
 }
 
 export interface FetchOptions<Schema extends HttpSchema> extends Omit<FetchRequestInit.Defaults, 'method'> {

--- a/packages/zimic-fetch/src/utils/environment.ts
+++ b/packages/zimic-fetch/src/utils/environment.ts
@@ -1,0 +1,3 @@
+export function isClientSide() {
+  return typeof window !== 'undefined';
+}

--- a/packages/zimic-fetch/tests/utils/requests.ts
+++ b/packages/zimic-fetch/tests/utils/requests.ts
@@ -1,0 +1,8 @@
+import { expect } from 'vitest';
+
+export function expectResponseStatus<Response extends globalThis.Response, Status extends number>(
+  response: Response,
+  status: Status,
+): asserts response is Extract<Response, { status: Status }> {
+  expect(response.status).toBe(status);
+}


### PR DESCRIPTION
### Features
- [fetch] Added support to handle redirect settings when typing fetch responses. Now, using `redirect: 'follow' | 'error' | undefined` will automatically exclude the redirection status codes from the type of `response.status`, as redirections will be handled automatically. Only when using `redirect: 'manual'` that redirection codes are preserved in `response.status`.

```ts
type Schema = HttpSchema<{
  '/:slug': {
    GET: {
      response: {
        200: { headers: { 'content-type': 'text/html' }; body: string; };
        301: { headers: { location: HttpSchemaPath<Schema> } };
        304: {};
        307: { headers: { location: HttpSchemaPath<Schema> } };
        308: { headers: { location: HttpSchemaPath<Schema> } };
      };
    };
  };
}>;

const response = await fetch('/original', { method: 'GET' });
response.status // 200 | 304

const otherResponse = await fetch('/original', {
  method: 'GET',
  redirect: 'manual',
});
otherResponse.status // 200 | 301 | 304 | 307 | 308
```