### PR TITLE
fix(ci): support `@` and `/` in ref names when syncing docs

### DIFF
--- a/.github/actions/zimic-release-comments/action.yaml
+++ b/.github/actions/zimic-release-comments/action.yaml
@@ -3,10 +3,10 @@ description: Zimic Release Comments
 
 inputs:
   ref-name:
-    description: The Git reference name to release
+    description: The Git reference name to create release comments for
     required: true
   project-name:
-    description: The project name to release
+    description: The project name to create release comments for
     required: true
 
 runs:

--- a/.github/workflows/release-comments.yaml
+++ b/.github/workflows/release-comments.yaml
@@ -1,0 +1,32 @@
+name: Release Comments
+
+on:
+  workflow_dispatch:
+    inputs:
+      project-name:
+        description: The project name to create release comments for
+        required: true
+
+concurrency:
+  group: release-comments-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  publish-release-comments:
+    name: Publish release comments
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Publish release comments
+        uses: ./.github/actions/zimic-release-comments
+        with:
+          ref-name: ${{ github.ref_name }}
+          project-name: ${{ inputs.project-name }}

--- a/scripts/docs/sync-wiki.sh
+++ b/scripts/docs/sync-wiki.sh
@@ -25,7 +25,7 @@ rsync ../zimic/docs/wiki/ . \
 
 echo "Pointing local links to 'zimicjs/zimic/tree/$refName'..."
 sed -E -i \
-  "s/\\]\\(\\.\\.\\/\\.\\.\\/([^\\)]*)\\)/](https:\\/\\/github.com\\/zimicjs\\/zimic\\/tree\\/$refName\\/\\1)/g" \
+  "s;\\]\\(\\.\\.\\/\\.\\.\\/([^\\)]*)\\);](https:\\/\\/github.com\\/zimicjs\\/zimic\\/tree\\/$refName\\/\\1);g" \
   ./*.md
 
 echo 'Pointing image links to local files...'


### PR DESCRIPTION
- fix(ci): support `@` and `/` in ref names when syncing docs
- chore(ci): support creating release comments manually
