### PR TITLE
docs(root): publish local package `README.md` files

### DIFF
--- a/packages/zimic-fetch/package.json
+++ b/packages/zimic-fetch/package.json
@@ -67,9 +67,7 @@
     "test": "dotenv -v NODE_ENV=test -- vitest",
     "test:turbo": "dotenv -v CI=true -- pnpm run test run --coverage",
     "types:check": "tsc --noEmit",
-    "deps:init": "playwright install chromium",
-    "prepublish:patch-relative-paths": "sed -E -i 's/\\]\\(\\.\\/([^\\)]+)\\)/](..\\/..\\/\\1)/g;s/\"\\.\\/([^\"]+)\"/\"..\\/..\\/\\1\"/g'",
-    "prepublishOnly": "cp ../../README.md ../../LICENSE.md . && pnpm prepublish:patch-relative-paths README.md"
+    "deps:init": "playwright install chromium"
   },
   "devDependencies": {
     "@types/node": "^22.13.8",

--- a/packages/zimic-http/package.json
+++ b/packages/zimic-http/package.json
@@ -77,9 +77,7 @@
     "test:turbo": "dotenv -v CI=true -- pnpm run test run --coverage",
     "types:check": "tsc --noEmit",
     "typegen:fixtures": "tsx ./scripts/typegen/generateFixtureTypes.ts",
-    "deps:init": "playwright install chromium",
-    "prepublish:patch-relative-paths": "sed -E -i 's/\\]\\(\\.\\/([^\\)]+)\\)/](..\\/..\\/\\1)/g;s/\"\\.\\/([^\"]+)\"/\"..\\/..\\/\\1\"/g'",
-    "prepublishOnly": "cp ../../README.md ../../LICENSE.md . && pnpm prepublish:patch-relative-paths README.md"
+    "deps:init": "playwright install chromium"
   },
   "dependencies": {
     "chalk": "4.1.2",

--- a/packages/zimic-interceptor/README.md
+++ b/packages/zimic-interceptor/README.md
@@ -241,7 +241,7 @@ Check our [getting started guide](https://github.com/zimicjs/zimic/wiki/getting�
 
 > [!NOTE]
 >
-> The 5.2 checks the application requests manually. This is optional in this example because the
+> Step 5.2 manually verifies the requests made by the application. This is optional in this example because the
 > [`with`](https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlerwithrestriction) and
 > [`times`](https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlertimes) calls (step 5.1) already
 > act as a declarative validation, expressing that exactly one request is expected with specific data. If fewer or more


### PR DESCRIPTION
### Documentation
- [fetch] [http] Removed the legacy commands that copied the root `README.md` file before publishing the packages. Each package now has their own `README.md` and the copy is no longer necessary.
