### PR TITLE
refactor(interceptor)!: deprecate `TrackedHttpInterceptorRequest`

### DIFF
--- a/apps/zimic-test-client/tests/exports/exports.test.ts
+++ b/apps/zimic-test-client/tests/exports/exports.test.ts
@@ -69,6 +69,7 @@ import {
   type HttpInterceptorRequest,
   type HttpInterceptorResponse,
   type TrackedHttpInterceptorRequest,
+  type InterceptedHttpInterceptorRequest,
   type UnhandledHttpInterceptorRequest,
   type HttpRequestHandler,
   type LocalHttpRequestHandler,
@@ -215,7 +216,9 @@ describe('Exports', () => {
     expectTypeOf<InferHttpInterceptorSchema<never>>().not.toBeAny();
     expectTypeOf<HttpInterceptorRequest<never, never>>().not.toBeAny();
     expectTypeOf<HttpInterceptorResponse<never, never>>().not.toBeAny();
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
     expectTypeOf<TrackedHttpInterceptorRequest<never, {}>>().not.toBeAny();
+    expectTypeOf<InterceptedHttpInterceptorRequest<never, {}>>().not.toBeAny();
     expectTypeOf<UnhandledHttpInterceptorRequest>().not.toBeAny();
 
     expectTypeOf<HttpRequestHandler<never, never, never>>().not.toBeAny();

--- a/packages/zimic-interceptor/src/http/index.ts
+++ b/packages/zimic-interceptor/src/http/index.ts
@@ -1,4 +1,7 @@
+import { HttpMethodSchema, HttpStatusCode } from '@zimic/http';
+
 import HttpInterceptorNamespace from './namespace/HttpInterceptorNamespace';
+import { InterceptedHttpInterceptorRequest } from './requestHandler/types/requests';
 
 export { default as InvalidJSONError } from './interceptorWorker/errors/InvalidJSONError';
 export { default as InvalidFormDataError } from './interceptorWorker/errors/InvalidFormDataError';
@@ -14,8 +17,18 @@ export type {
   HttpRequestHandlerResponseDeclarationFactory,
   HttpInterceptorRequest,
   HttpInterceptorResponse,
-  TrackedHttpInterceptorRequest,
+  InterceptedHttpInterceptorRequest,
 } from './requestHandler/types/requests';
+
+/**
+ * @deprecated This type was renamed to {@link InterceptedHttpInterceptorRequest `InterceptedHttpInterceptorRequest`}.
+ *   Please use it instead.
+ */
+export type TrackedHttpInterceptorRequest<
+  Path extends string,
+  MethodSchema extends HttpMethodSchema,
+  StatusCode extends HttpStatusCode = never,
+> = InterceptedHttpInterceptorRequest<Path, MethodSchema, StatusCode>;
 
 export type {
   LocalHttpRequestHandler,

--- a/packages/zimic-interceptor/src/http/requestHandler/HttpRequestHandlerClient.ts
+++ b/packages/zimic-interceptor/src/http/requestHandler/HttpRequestHandlerClient.ts
@@ -26,7 +26,7 @@ import {
   HttpInterceptorResponse,
   HttpRequestHandlerResponseDeclaration,
   HttpRequestHandlerResponseDeclarationFactory,
-  TrackedHttpInterceptorRequest,
+  InterceptedHttpInterceptorRequest,
 } from './types/requests';
 import {
   HttpRequestHandlerRestriction,
@@ -58,7 +58,8 @@ class HttpRequestHandlerClient<
 
   private numberOfMatchedRequests = 0;
   private unmatchedRequestGroups: UnmatchedHttpInterceptorRequestGroup[] = [];
-  private interceptedRequests: TrackedHttpInterceptorRequest<Path, Default<Schema[Path][Method]>, StatusCode>[] = [];
+  private interceptedRequests: InterceptedHttpInterceptorRequest<Path, Default<Schema[Path][Method]>, StatusCode>[] =
+    [];
 
   private createResponseDeclaration?: HttpRequestHandlerResponseDeclarationFactory<
     Path,
@@ -394,7 +395,7 @@ class HttpRequestHandlerClient<
     request: HttpInterceptorRequest<Path, Default<Schema[Path][Method]>>,
     response: HttpInterceptorResponse<Default<Schema[Path][Method]>, StatusCode>,
   ) {
-    const interceptedRequest = request as unknown as TrackedHttpInterceptorRequest<
+    const interceptedRequest = request as unknown as InterceptedHttpInterceptorRequest<
       Path,
       Default<Schema[Path][Method]>,
       StatusCode
@@ -410,7 +411,7 @@ class HttpRequestHandlerClient<
     return interceptedRequest;
   }
 
-  requests(): readonly TrackedHttpInterceptorRequest<Path, Default<Schema[Path][Method]>, StatusCode>[] {
+  requests(): readonly InterceptedHttpInterceptorRequest<Path, Default<Schema[Path][Method]>, StatusCode>[] {
     if (!this.interceptor.shouldSaveRequests()) {
       throw new DisabledRequestSavingError();
     }

--- a/packages/zimic-interceptor/src/http/requestHandler/LocalHttpRequestHandler.ts
+++ b/packages/zimic-interceptor/src/http/requestHandler/LocalHttpRequestHandler.ts
@@ -9,7 +9,7 @@ import {
   HttpInterceptorResponse,
   HttpRequestHandlerResponseDeclaration,
   HttpRequestHandlerResponseDeclarationFactory,
-  TrackedHttpInterceptorRequest,
+  InterceptedHttpInterceptorRequest,
 } from './types/requests';
 import { HttpRequestHandlerRestriction } from './types/restrictions';
 
@@ -70,7 +70,7 @@ class LocalHttpRequestHandler<
     return this;
   }
 
-  requests(): readonly TrackedHttpInterceptorRequest<Path, Default<Schema[Path][Method]>, StatusCode>[] {
+  requests(): readonly InterceptedHttpInterceptorRequest<Path, Default<Schema[Path][Method]>, StatusCode>[] {
     return this._client.requests();
   }
 

--- a/packages/zimic-interceptor/src/http/requestHandler/RemoteHttpRequestHandler.ts
+++ b/packages/zimic-interceptor/src/http/requestHandler/RemoteHttpRequestHandler.ts
@@ -12,7 +12,7 @@ import {
   HttpInterceptorResponse,
   HttpRequestHandlerResponseDeclaration,
   HttpRequestHandlerResponseDeclarationFactory,
-  TrackedHttpInterceptorRequest,
+  InterceptedHttpInterceptorRequest,
 } from './types/requests';
 import { HttpRequestHandlerRestriction } from './types/restrictions';
 
@@ -110,7 +110,7 @@ class RemoteHttpRequestHandler<
     return this.unsynced;
   }
 
-  requests(): Promise<readonly TrackedHttpInterceptorRequest<Path, Default<Schema[Path][Method]>, StatusCode>[]> {
+  requests(): Promise<readonly InterceptedHttpInterceptorRequest<Path, Default<Schema[Path][Method]>, StatusCode>[]> {
     return new Promise((resolve, reject) => {
       try {
         resolve(this._client.requests());

--- a/packages/zimic-interceptor/src/http/requestHandler/types/public.ts
+++ b/packages/zimic-interceptor/src/http/requestHandler/types/public.ts
@@ -11,7 +11,7 @@ import HttpRequestHandlerClient from '../HttpRequestHandlerClient';
 import {
   HttpRequestHandlerResponseDeclaration,
   HttpRequestHandlerResponseDeclarationFactory,
-  TrackedHttpInterceptorRequest,
+  InterceptedHttpInterceptorRequest,
 } from './requests';
 import { HttpRequestHandlerRestriction } from './restrictions';
 
@@ -181,7 +181,7 @@ export interface LocalHttpRequestHandler<
    * @throws {DisabledRequestSavingError} If the interceptor was not created with `saveRequests: true`.
    * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlerrequests `handler.requests()` API reference}
    */
-  requests: () => readonly TrackedHttpInterceptorRequest<Path, Default<Schema[Path][Method]>, StatusCode>[];
+  requests: () => readonly InterceptedHttpInterceptorRequest<Path, Default<Schema[Path][Method]>, StatusCode>[];
 }
 
 /**
@@ -317,7 +317,9 @@ export interface SyncedRemoteHttpRequestHandler<
    * @throws {DisabledRequestSavingError} If the interceptor was not created with `saveRequests: true`.
    * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlerrequests `handler.requests()` API reference}
    */
-  requests: () => Promise<readonly TrackedHttpInterceptorRequest<Path, Default<Schema[Path][Method]>, StatusCode>[]>;
+  requests: () => Promise<
+    readonly InterceptedHttpInterceptorRequest<Path, Default<Schema[Path][Method]>, StatusCode>[]
+  >;
 }
 
 /**

--- a/packages/zimic-interceptor/src/http/requestHandler/types/requests.ts
+++ b/packages/zimic-interceptor/src/http/requestHandler/types/requests.ts
@@ -115,7 +115,7 @@ export const HTTP_INTERCEPTOR_RESPONSE_HIDDEN_PROPERTIES = Object.freeze(
  * A strict representation of an intercepted HTTP request, along with its response. The body, search params and path
  * params are already parsed by default.
  */
-export interface TrackedHttpInterceptorRequest<
+export interface InterceptedHttpInterceptorRequest<
   Path extends string,
   MethodSchema extends HttpMethodSchema,
   StatusCode extends HttpStatusCode = never,


### PR DESCRIPTION
### Refactoring
- [interceptor] Renamed the type `TrackedHttpInterceptorRequest` to `InterceptedHttpInterceptorRequest`, which is a more appropriate name. The original `TrackedHttpInterceptorRequest` is now marked as deprecated.