### PR TITLE
refactor(interceptor): change getter methods to getter properties (#490)

### DIFF
--- a/apps/zimic-test-client/tests/fetch/FetchClient.test.ts
+++ b/apps/zimic-test-client/tests/fetch/FetchClient.test.ts
@@ -16,6 +16,7 @@ import {
   ValidationError,
 } from '@tests/types/schema';
 import { importCrypto } from '@tests/utils/crypto';
+import { expectResponseStatus } from '@tests/utils/requests';
 
 describe('Fetch client', async () => {
   const crypto = await importCrypto();
@@ -126,7 +127,7 @@ describe('Fetch client', async () => {
 
         const response = await createUser(creationPayload);
         expectTypeOf(response.status).toEqualTypeOf<201>();
-        expect(response.status).toBe(201);
+        expectResponseStatus(response, 201);
 
         const createdUser = await response.json();
         expect(createdUser).toEqual<JSONSerialized<User>>({
@@ -136,32 +137,35 @@ describe('Fetch client', async () => {
           birthDate: creationPayload.birthDate,
         });
 
-        const creationRequests = creationHandler.requests();
-        expect(creationRequests).toHaveLength(1);
+        expect(creationHandler.requests).toHaveLength(1);
 
-        expectTypeOf(creationRequests[0].headers).toEqualTypeOf<HttpHeaders<{ 'content-type': 'application/json' }>>();
+        expectTypeOf(creationHandler.requests[0].headers).toEqualTypeOf<
+          HttpHeaders<{ 'content-type': 'application/json' }>
+        >();
 
-        expectTypeOf(creationRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
-        expect(creationRequests[0].searchParams.size).toBe(0);
+        expectTypeOf(creationHandler.requests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
+        expect(creationHandler.requests[0].searchParams.size).toBe(0);
 
         expect(response.headers.get('x-user-id')).toBe(createdUser.id);
-        expect(creationRequests[0].response.headers.get('x-user-id')).toBe(createdUser.id);
+        expect(creationHandler.requests[0].response.headers.get('x-user-id')).toBe(createdUser.id);
 
-        expectTypeOf(creationRequests[0].body).toEqualTypeOf<UserCreationRequestBody>();
-        expect(creationRequests[0].body).toEqual(creationPayload);
+        expectTypeOf(creationHandler.requests[0].body).toEqualTypeOf<UserCreationRequestBody>();
+        expect(creationHandler.requests[0].body).toEqual(creationPayload);
 
-        expectTypeOf(creationRequests[0].raw).toEqualTypeOf<HttpRequest<UserCreationRequestBody>>();
-        expect(creationRequests[0].raw).toBeInstanceOf(Request);
-        expectTypeOf(creationRequests[0].raw.json).toEqualTypeOf<() => Promise<UserCreationRequestBody>>();
-        expect(await creationRequests[0].raw.json()).toEqual(creationPayload);
+        expectTypeOf(creationHandler.requests[0].raw).toEqualTypeOf<HttpRequest<UserCreationRequestBody>>();
+        expect(creationHandler.requests[0].raw).toBeInstanceOf(Request);
+        expectTypeOf(creationHandler.requests[0].raw.json).toEqualTypeOf<() => Promise<UserCreationRequestBody>>();
+        expect(await creationHandler.requests[0].raw.json()).toEqual(creationPayload);
 
-        expectTypeOf(creationRequests[0].response.body).toEqualTypeOf<JSONSerialized<User>>();
-        expect(creationRequests[0].response.body).toEqual(createdUser);
+        expectTypeOf(creationHandler.requests[0].response.body).toEqualTypeOf<JSONSerialized<User>>();
+        expect(creationHandler.requests[0].response.body).toEqual(createdUser);
 
-        expectTypeOf(creationRequests[0].response.raw).toEqualTypeOf<HttpResponse<JSONSerialized<User>, 201>>();
-        expect(creationRequests[0].response.raw).toBeInstanceOf(Response);
-        expectTypeOf(creationRequests[0].response.raw.json).toEqualTypeOf<() => Promise<JSONSerialized<User>>>();
-        expect(await creationRequests[0].response.raw.json()).toEqual(createdUser);
+        expectTypeOf(creationHandler.requests[0].response.raw).toEqualTypeOf<HttpResponse<JSONSerialized<User>, 201>>();
+        expect(creationHandler.requests[0].response.raw).toBeInstanceOf(Response);
+        expectTypeOf(creationHandler.requests[0].response.raw.json).toEqualTypeOf<
+          () => Promise<JSONSerialized<User>>
+        >();
+        expect(await creationHandler.requests[0].response.raw.json()).toEqual(createdUser);
       });
 
       it('should return an error if the payload is not valid', async () => {
@@ -179,38 +183,39 @@ describe('Fetch client', async () => {
           .respond({ status: 400, body: validationError })
           .times(1);
 
-        const error = await expectToThrow(createUser(invalidPayload), {
-          is: (error): error is FetchResponseError<AuthServiceSchema, 'POST', '/users'> =>
+        const error = await expectToThrow(
+          createUser(invalidPayload),
+          (error): error is FetchResponseError<AuthServiceSchema, 'POST', '/users'> =>
             authFetch.isResponseError(error, 'POST', '/users'),
-        });
-        const { response } = error;
+        );
 
-        expectTypeOf(response.status).toEqualTypeOf<400 | 409 | 500>();
-        expect(response.status).toBe(400);
+        expectTypeOf(error.response.status).toEqualTypeOf<400 | 409 | 500>();
+        expectResponseStatus(error.response, 400);
 
-        const creationRequests = creationHandler.requests();
-        expect(creationRequests).toHaveLength(1);
+        expect(creationHandler.requests).toHaveLength(1);
 
-        expectTypeOf(creationRequests[0].headers).toEqualTypeOf<HttpHeaders<{ 'content-type': 'application/json' }>>();
+        expectTypeOf(creationHandler.requests[0].headers).toEqualTypeOf<
+          HttpHeaders<{ 'content-type': 'application/json' }>
+        >();
 
-        expectTypeOf(creationRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
-        expect(creationRequests[0].searchParams.size).toBe(0);
+        expectTypeOf(creationHandler.requests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
+        expect(creationHandler.requests[0].searchParams.size).toBe(0);
 
-        expectTypeOf(creationRequests[0].body).toEqualTypeOf<UserCreationRequestBody>();
-        expect(creationRequests[0].body).toEqual(invalidPayload);
+        expectTypeOf(creationHandler.requests[0].body).toEqualTypeOf<UserCreationRequestBody>();
+        expect(creationHandler.requests[0].body).toEqual(invalidPayload);
 
-        expectTypeOf(creationRequests[0].raw).toEqualTypeOf<HttpRequest<UserCreationRequestBody>>();
-        expect(creationRequests[0].raw).toBeInstanceOf(Request);
-        expectTypeOf(creationRequests[0].raw.json).toEqualTypeOf<() => Promise<UserCreationRequestBody>>();
-        expect(await creationRequests[0].raw.json()).toEqual(invalidPayload);
+        expectTypeOf(creationHandler.requests[0].raw).toEqualTypeOf<HttpRequest<UserCreationRequestBody>>();
+        expect(creationHandler.requests[0].raw).toBeInstanceOf(Request);
+        expectTypeOf(creationHandler.requests[0].raw.json).toEqualTypeOf<() => Promise<UserCreationRequestBody>>();
+        expect(await creationHandler.requests[0].raw.json()).toEqual(invalidPayload);
 
-        expectTypeOf(creationRequests[0].response.body).toEqualTypeOf<ValidationError>();
-        expect(creationRequests[0].response.body).toEqual(validationError);
+        expectTypeOf(creationHandler.requests[0].response.body).toEqualTypeOf<ValidationError>();
+        expect(creationHandler.requests[0].response.body).toEqual(validationError);
 
-        expectTypeOf(creationRequests[0].response.raw).toEqualTypeOf<HttpResponse<ValidationError, 400>>();
-        expect(creationRequests[0].response.raw).toBeInstanceOf(Response);
-        expectTypeOf(creationRequests[0].response.raw.json).toEqualTypeOf<() => Promise<ValidationError>>();
-        expect(await creationRequests[0].response.raw.json()).toEqual(validationError);
+        expectTypeOf(creationHandler.requests[0].response.raw).toEqualTypeOf<HttpResponse<ValidationError, 400>>();
+        expect(creationHandler.requests[0].response.raw).toBeInstanceOf(Response);
+        expectTypeOf(creationHandler.requests[0].response.raw.json).toEqualTypeOf<() => Promise<ValidationError>>();
+        expect(await creationHandler.requests[0].response.raw.json()).toEqual(validationError);
       });
 
       it('should return an error if the payload is not valid', async () => {
@@ -227,38 +232,39 @@ describe('Fetch client', async () => {
           .respond({ status: 409, body: conflictError })
           .times(1);
 
-        const error = await expectToThrow(createUser(conflictingPayload), {
-          is: (error): error is FetchResponseError<AuthServiceSchema, 'POST', '/users'> =>
+        const error = await expectToThrow(
+          createUser(conflictingPayload),
+          (error): error is FetchResponseError<AuthServiceSchema, 'POST', '/users'> =>
             authFetch.isResponseError(error, 'POST', '/users'),
-        });
-        const { response } = error;
+        );
 
-        expectTypeOf(response.status).toEqualTypeOf<400 | 409 | 500>();
-        expect(response.status).toBe(409);
+        expectTypeOf(error.response.status).toEqualTypeOf<400 | 409 | 500>();
+        expectResponseStatus(error.response, 409);
 
-        const creationRequests = creationHandler.requests();
-        expect(creationRequests).toHaveLength(1);
+        expect(creationHandler.requests).toHaveLength(1);
 
-        expectTypeOf(creationRequests[0].headers).toEqualTypeOf<HttpHeaders<{ 'content-type': 'application/json' }>>();
+        expectTypeOf(creationHandler.requests[0].headers).toEqualTypeOf<
+          HttpHeaders<{ 'content-type': 'application/json' }>
+        >();
 
-        expectTypeOf(creationRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
-        expect(creationRequests[0].searchParams.size).toBe(0);
+        expectTypeOf(creationHandler.requests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
+        expect(creationHandler.requests[0].searchParams.size).toBe(0);
 
-        expectTypeOf(creationRequests[0].body).toEqualTypeOf<UserCreationRequestBody>();
-        expect(creationRequests[0].body).toEqual(conflictingPayload);
+        expectTypeOf(creationHandler.requests[0].body).toEqualTypeOf<UserCreationRequestBody>();
+        expect(creationHandler.requests[0].body).toEqual(conflictingPayload);
 
-        expectTypeOf(creationRequests[0].raw).toEqualTypeOf<HttpRequest<UserCreationRequestBody>>();
-        expect(creationRequests[0].raw).toBeInstanceOf(Request);
-        expectTypeOf(creationRequests[0].raw.json).toEqualTypeOf<() => Promise<UserCreationRequestBody>>();
-        expect(await creationRequests[0].raw.json()).toEqual(creationPayload);
+        expectTypeOf(creationHandler.requests[0].raw).toEqualTypeOf<HttpRequest<UserCreationRequestBody>>();
+        expect(creationHandler.requests[0].raw).toBeInstanceOf(Request);
+        expectTypeOf(creationHandler.requests[0].raw.json).toEqualTypeOf<() => Promise<UserCreationRequestBody>>();
+        expect(await creationHandler.requests[0].raw.json()).toEqual(creationPayload);
 
-        expectTypeOf(creationRequests[0].response.body).toEqualTypeOf<ConflictError>();
-        expect(creationRequests[0].response.body).toEqual(conflictError);
+        expectTypeOf(creationHandler.requests[0].response.body).toEqualTypeOf<ConflictError>();
+        expect(creationHandler.requests[0].response.body).toEqual(conflictError);
 
-        expectTypeOf(creationRequests[0].response.raw).toEqualTypeOf<HttpResponse<ConflictError, 409>>();
-        expect(creationRequests[0].response.raw).toBeInstanceOf(Response);
-        expectTypeOf(creationRequests[0].response.raw.json).toEqualTypeOf<() => Promise<ConflictError>>();
-        expect(await creationRequests[0].response.raw.json()).toEqual(conflictError);
+        expectTypeOf(creationHandler.requests[0].response.raw).toEqualTypeOf<HttpResponse<ConflictError, 409>>();
+        expect(creationHandler.requests[0].response.raw).toBeInstanceOf(Response);
+        expectTypeOf(creationHandler.requests[0].response.raw.json).toEqualTypeOf<() => Promise<ConflictError>>();
+        expect(await creationHandler.requests[0].response.raw.json()).toEqual(conflictError);
       });
     });
 
@@ -312,37 +318,36 @@ describe('Fetch client', async () => {
 
         const response = await listUsers();
         expectTypeOf(response.status).toEqualTypeOf<200>();
-        expect(response.status).toBe(200);
+        expectResponseStatus(response, 200);
 
         const returnedUsers = await response.json();
         expect(returnedUsers).toEqual(users.map(serializeUser));
 
-        const listRequests = listHandler.requests();
-        expect(listRequests).toHaveLength(1);
+        expect(listHandler.requests).toHaveLength(1);
 
-        expectTypeOf(listRequests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
+        expectTypeOf(listHandler.requests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
 
-        expectTypeOf(listRequests[0].searchParams).toEqualTypeOf<
+        expectTypeOf(listHandler.requests[0].searchParams).toEqualTypeOf<
           HttpSearchParams<HttpSchema.SearchParams<UserListSearchParams>>
         >();
-        expect(listRequests[0].searchParams.get('name')).toBe(null);
-        expect(listRequests[0].searchParams.getAll('orderBy')).toEqual([]);
+        expect(listHandler.requests[0].searchParams.get('name')).toBe(null);
+        expect(listHandler.requests[0].searchParams.getAll('orderBy')).toEqual([]);
 
-        expectTypeOf(listRequests[0].body).toEqualTypeOf<null>();
-        expect(listRequests[0].body).toBe(null);
+        expectTypeOf(listHandler.requests[0].body).toEqualTypeOf<null>();
+        expect(listHandler.requests[0].body).toBe(null);
 
-        expectTypeOf(listRequests[0].raw).toEqualTypeOf<HttpRequest<null>>();
-        expect(listRequests[0].raw).toBeInstanceOf(Request);
-        expectTypeOf(listRequests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
-        expect(await listRequests[0].raw.text()).toBe('');
+        expectTypeOf(listHandler.requests[0].raw).toEqualTypeOf<HttpRequest<null>>();
+        expect(listHandler.requests[0].raw).toBeInstanceOf(Request);
+        expectTypeOf(listHandler.requests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
+        expect(await listHandler.requests[0].raw.text()).toBe('');
 
-        expectTypeOf(listRequests[0].response.body).toEqualTypeOf<JSONSerialized<User>[]>();
-        expect(listRequests[0].response.body).toEqual(users.map(serializeUser));
+        expectTypeOf(listHandler.requests[0].response.body).toEqualTypeOf<JSONSerialized<User>[]>();
+        expect(listHandler.requests[0].response.body).toEqual(users.map(serializeUser));
 
-        expectTypeOf(listRequests[0].response.raw).toEqualTypeOf<HttpResponse<JSONSerialized<User>[], 200>>();
-        expect(listRequests[0].response.raw).toBeInstanceOf(Response);
-        expectTypeOf(listRequests[0].response.raw.json).toEqualTypeOf<() => Promise<JSONSerialized<User>[]>>();
-        expect(await listRequests[0].response.raw.json()).toEqual(users.map(serializeUser));
+        expectTypeOf(listHandler.requests[0].response.raw).toEqualTypeOf<HttpResponse<JSONSerialized<User>[], 200>>();
+        expect(listHandler.requests[0].response.raw).toBeInstanceOf(Response);
+        expectTypeOf(listHandler.requests[0].response.raw.json).toEqualTypeOf<() => Promise<JSONSerialized<User>[]>>();
+        expect(await listHandler.requests[0].response.raw.json()).toEqual(users.map(serializeUser));
       });
 
       it('should list users filtered by name', async () => {
@@ -356,38 +361,37 @@ describe('Fetch client', async () => {
 
         const response = await listUsers({ name: user.name });
         expectTypeOf(response.status).toEqualTypeOf<200>();
-        expect(response.status).toBe(200);
+        expectResponseStatus(response, 200);
 
         const returnedUsers = await response.json();
         expect(returnedUsers).toEqual([serializeUser(user)]);
 
-        const listRequests = listHandler.requests();
-        expect(listRequests).toHaveLength(1);
+        expect(listHandler.requests).toHaveLength(1);
 
-        expectTypeOf(listRequests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
+        expectTypeOf(listHandler.requests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
 
-        expectTypeOf(listRequests[0].searchParams).toEqualTypeOf<
+        expectTypeOf(listHandler.requests[0].searchParams).toEqualTypeOf<
           HttpSearchParams<HttpSchema.SearchParams<UserListSearchParams>>
         >();
-        expect(listRequests[0].searchParams.size).toBe(1);
-        expect(listRequests[0].searchParams.get('name')).toBe(user.name);
-        expect(listRequests[0].searchParams.getAll('orderBy')).toEqual([]);
+        expect(listHandler.requests[0].searchParams.size).toBe(1);
+        expect(listHandler.requests[0].searchParams.get('name')).toBe(user.name);
+        expect(listHandler.requests[0].searchParams.getAll('orderBy')).toEqual([]);
 
-        expectTypeOf(listRequests[0].body).toEqualTypeOf<null>();
-        expect(listRequests[0].body).toBe(null);
+        expectTypeOf(listHandler.requests[0].body).toEqualTypeOf<null>();
+        expect(listHandler.requests[0].body).toBe(null);
 
-        expectTypeOf(listRequests[0].raw).toEqualTypeOf<HttpRequest<null>>();
-        expect(listRequests[0].raw).toBeInstanceOf(Request);
-        expectTypeOf(listRequests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
-        expect(await listRequests[0].raw.text()).toBe('');
+        expectTypeOf(listHandler.requests[0].raw).toEqualTypeOf<HttpRequest<null>>();
+        expect(listHandler.requests[0].raw).toBeInstanceOf(Request);
+        expectTypeOf(listHandler.requests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
+        expect(await listHandler.requests[0].raw.text()).toBe('');
 
-        expectTypeOf(listRequests[0].response.body).toEqualTypeOf<JSONSerialized<User>[]>();
-        expect(listRequests[0].response.body).toEqual([serializeUser(user)]);
+        expectTypeOf(listHandler.requests[0].response.body).toEqualTypeOf<JSONSerialized<User>[]>();
+        expect(listHandler.requests[0].response.body).toEqual([serializeUser(user)]);
 
-        expectTypeOf(listRequests[0].response.raw).toEqualTypeOf<HttpResponse<JSONSerialized<User>[], 200>>();
-        expect(listRequests[0].response.raw).toBeInstanceOf(Response);
-        expectTypeOf(listRequests[0].response.raw.json).toEqualTypeOf<() => Promise<JSONSerialized<User>[]>>();
-        expect(await listRequests[0].response.raw.json()).toEqual([serializeUser(user)]);
+        expectTypeOf(listHandler.requests[0].response.raw).toEqualTypeOf<HttpResponse<JSONSerialized<User>[], 200>>();
+        expect(listHandler.requests[0].response.raw).toBeInstanceOf(Response);
+        expectTypeOf(listHandler.requests[0].response.raw.json).toEqualTypeOf<() => Promise<JSONSerialized<User>[]>>();
+        expect(await listHandler.requests[0].response.raw.json()).toEqual([serializeUser(user)]);
       });
 
       it('should list users with ordering', async () => {
@@ -405,38 +409,39 @@ describe('Fetch client', async () => {
           orderBy: ['email.desc'],
         });
         expectTypeOf(response.status).toEqualTypeOf<200>();
-        expect(response.status).toBe(200);
+        expectResponseStatus(response, 200);
 
         const returnedUsers = await response.json();
         expect(returnedUsers).toEqual(usersSortedByDescendingEmail.map(serializeUser));
 
-        const listRequests = listHandler.requests();
-        expect(listRequests).toHaveLength(1);
+        expect(listHandler.requests).toHaveLength(1);
 
-        expectTypeOf(listRequests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
+        expectTypeOf(listHandler.requests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
 
-        expectTypeOf(listRequests[0].searchParams).toEqualTypeOf<
+        expectTypeOf(listHandler.requests[0].searchParams).toEqualTypeOf<
           HttpSearchParams<HttpSchema.SearchParams<UserListSearchParams>>
         >();
-        expect(listRequests[0].searchParams.size).toBe(1);
-        expect(listRequests[0].searchParams.get('name')).toBe(null);
-        expect(listRequests[0].searchParams.getAll('orderBy')).toEqual(['email.desc']);
+        expect(listHandler.requests[0].searchParams.size).toBe(1);
+        expect(listHandler.requests[0].searchParams.get('name')).toBe(null);
+        expect(listHandler.requests[0].searchParams.getAll('orderBy')).toEqual(['email.desc']);
 
-        expectTypeOf(listRequests[0].body).toEqualTypeOf<null>();
-        expect(listRequests[0].body).toBe(null);
+        expectTypeOf(listHandler.requests[0].body).toEqualTypeOf<null>();
+        expect(listHandler.requests[0].body).toBe(null);
 
-        expectTypeOf(listRequests[0].raw).toEqualTypeOf<HttpRequest<null>>();
-        expect(listRequests[0].raw).toBeInstanceOf(Request);
-        expectTypeOf(listRequests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
-        expect(await listRequests[0].raw.text()).toBe('');
+        expectTypeOf(listHandler.requests[0].raw).toEqualTypeOf<HttpRequest<null>>();
+        expect(listHandler.requests[0].raw).toBeInstanceOf(Request);
+        expectTypeOf(listHandler.requests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
+        expect(await listHandler.requests[0].raw.text()).toBe('');
 
-        expectTypeOf(listRequests[0].response.body).toEqualTypeOf<JSONSerialized<User>[]>();
-        expect(listRequests[0].response.body).toEqual(usersSortedByDescendingEmail.map(serializeUser));
+        expectTypeOf(listHandler.requests[0].response.body).toEqualTypeOf<JSONSerialized<User>[]>();
+        expect(listHandler.requests[0].response.body).toEqual(usersSortedByDescendingEmail.map(serializeUser));
 
-        expectTypeOf(listRequests[0].response.raw).toEqualTypeOf<HttpResponse<JSONSerialized<User>[], 200>>();
-        expect(listRequests[0].response.raw).toBeInstanceOf(Response);
-        expectTypeOf(listRequests[0].response.raw.json).toEqualTypeOf<() => Promise<JSONSerialized<User>[]>>();
-        expect(await listRequests[0].response.raw.json()).toEqual(usersSortedByDescendingEmail.map(serializeUser));
+        expectTypeOf(listHandler.requests[0].response.raw).toEqualTypeOf<HttpResponse<JSONSerialized<User>[], 200>>();
+        expect(listHandler.requests[0].response.raw).toBeInstanceOf(Response);
+        expectTypeOf(listHandler.requests[0].response.raw.json).toEqualTypeOf<() => Promise<JSONSerialized<User>[]>>();
+        expect(await listHandler.requests[0].response.raw.json()).toEqual(
+          usersSortedByDescendingEmail.map(serializeUser),
+        );
       });
     });
 
@@ -462,35 +467,34 @@ describe('Fetch client', async () => {
 
         const response = await getUserById(user.id);
         expectTypeOf(response.status).toEqualTypeOf<200>();
-        expect(response.status).toBe(200);
+        expectResponseStatus(response, 200);
 
         const returnedUsers = await response.json();
         expect(returnedUsers).toEqual(serializeUser(user));
 
-        const getRequests = getHandler.requests();
-        expect(getRequests).toHaveLength(1);
-        expect(getRequests[0].url).toBe(`${authFetch.defaults.baseURL}/users/${user.id}`);
+        expect(getHandler.requests).toHaveLength(1);
+        expect(getHandler.requests[0].url).toBe(`${authFetch.defaults.baseURL}/users/${user.id}`);
 
-        expectTypeOf(getRequests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
+        expectTypeOf(getHandler.requests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
 
-        expectTypeOf(getRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
-        expect(getRequests[0].searchParams.size).toBe(0);
+        expectTypeOf(getHandler.requests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
+        expect(getHandler.requests[0].searchParams.size).toBe(0);
 
-        expectTypeOf(getRequests[0].body).toEqualTypeOf<null>();
-        expect(getRequests[0].body).toBe(null);
+        expectTypeOf(getHandler.requests[0].body).toEqualTypeOf<null>();
+        expect(getHandler.requests[0].body).toBe(null);
 
-        expectTypeOf(getRequests[0].raw).toEqualTypeOf<HttpRequest<null>>();
-        expect(getRequests[0].raw).toBeInstanceOf(Request);
-        expectTypeOf(getRequests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
-        expect(await getRequests[0].raw.text()).toBe('');
+        expectTypeOf(getHandler.requests[0].raw).toEqualTypeOf<HttpRequest<null>>();
+        expect(getHandler.requests[0].raw).toBeInstanceOf(Request);
+        expectTypeOf(getHandler.requests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
+        expect(await getHandler.requests[0].raw.text()).toBe('');
 
-        expectTypeOf(getRequests[0].response.body).toEqualTypeOf<JSONSerialized<User>>();
-        expect(getRequests[0].response.body).toEqual(serializeUser(user));
+        expectTypeOf(getHandler.requests[0].response.body).toEqualTypeOf<JSONSerialized<User>>();
+        expect(getHandler.requests[0].response.body).toEqual(serializeUser(user));
 
-        expectTypeOf(getRequests[0].response.raw).toEqualTypeOf<HttpResponse<JSONSerialized<User>, 200>>();
-        expect(getRequests[0].response.raw).toBeInstanceOf(Response);
-        expectTypeOf(getRequests[0].response.raw.json).toEqualTypeOf<() => Promise<JSONSerialized<User>>>();
-        expect(await getRequests[0].response.raw.json()).toEqual(serializeUser(user));
+        expectTypeOf(getHandler.requests[0].response.raw).toEqualTypeOf<HttpResponse<JSONSerialized<User>, 200>>();
+        expect(getHandler.requests[0].response.raw).toBeInstanceOf(Response);
+        expectTypeOf(getHandler.requests[0].response.raw.json).toEqualTypeOf<() => Promise<JSONSerialized<User>>>();
+        expect(await getHandler.requests[0].response.raw.json()).toEqual(serializeUser(user));
       });
 
       it('should return an error if the user was not found', async () => {
@@ -507,42 +511,41 @@ describe('Fetch client', async () => {
           })
           .times(1);
 
-        const error = await expectToThrow(getUserById(user.id), {
-          is: (error): error is FetchResponseError<AuthServiceSchema, 'GET', '/users/:userId'> =>
+        const error = await expectToThrow(
+          getUserById(user.id),
+          (error): error is FetchResponseError<AuthServiceSchema, 'GET', '/users/:userId'> =>
             authFetch.isResponseError(error, 'GET', '/users/:userId'),
-        });
-        const { response } = error;
+        );
 
-        expectTypeOf(response.status).toEqualTypeOf<404 | 500>();
-        expect(response.status).toBe(404);
+        expectTypeOf(error.response.status).toEqualTypeOf<404 | 500>();
+        expectResponseStatus(error.response, 404);
 
-        const getRequests = getHandler.requests();
-        expect(getRequests).toHaveLength(1);
-        expect(getRequests[0].url).toBe(`${authFetch.defaults.baseURL}/users/${user.id}`);
+        expect(getHandler.requests).toHaveLength(1);
+        expect(getHandler.requests[0].url).toBe(`${authFetch.defaults.baseURL}/users/${user.id}`);
 
-        expectTypeOf(getRequests[0].pathParams).toEqualTypeOf<{ userId: string }>();
-        expect(getRequests[0].pathParams).toEqual({ userId: user.id });
+        expectTypeOf(getHandler.requests[0].pathParams).toEqualTypeOf<{ userId: string }>();
+        expect(getHandler.requests[0].pathParams).toEqual({ userId: user.id });
 
-        expectTypeOf(getRequests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
+        expectTypeOf(getHandler.requests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
 
-        expectTypeOf(getRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
-        expect(getRequests[0].searchParams.size).toBe(0);
+        expectTypeOf(getHandler.requests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
+        expect(getHandler.requests[0].searchParams.size).toBe(0);
 
-        expectTypeOf(getRequests[0].body).toEqualTypeOf<null>();
-        expect(getRequests[0].body).toBe(null);
+        expectTypeOf(getHandler.requests[0].body).toEqualTypeOf<null>();
+        expect(getHandler.requests[0].body).toBe(null);
 
-        expectTypeOf(getRequests[0].raw).toEqualTypeOf<HttpRequest<null>>();
-        expect(getRequests[0].raw).toBeInstanceOf(Request);
-        expectTypeOf(getRequests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
-        expect(await getRequests[0].raw.text()).toBe('');
+        expectTypeOf(getHandler.requests[0].raw).toEqualTypeOf<HttpRequest<null>>();
+        expect(getHandler.requests[0].raw).toBeInstanceOf(Request);
+        expectTypeOf(getHandler.requests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
+        expect(await getHandler.requests[0].raw.text()).toBe('');
 
-        expectTypeOf(getRequests[0].response.body).toEqualTypeOf<NotFoundError>();
-        expect(getRequests[0].response.body).toEqual(notFoundError);
+        expectTypeOf(getHandler.requests[0].response.body).toEqualTypeOf<NotFoundError>();
+        expect(getHandler.requests[0].response.body).toEqual(notFoundError);
 
-        expectTypeOf(getRequests[0].response.raw).toEqualTypeOf<HttpResponse<NotFoundError, 404>>();
-        expect(getRequests[0].response.raw).toBeInstanceOf(Response);
-        expectTypeOf(getRequests[0].response.raw.json).toEqualTypeOf<() => Promise<NotFoundError>>();
-        expect(await getRequests[0].response.raw.json()).toEqual(notFoundError);
+        expectTypeOf(getHandler.requests[0].response.raw).toEqualTypeOf<HttpResponse<NotFoundError, 404>>();
+        expect(getHandler.requests[0].response.raw).toBeInstanceOf(Response);
+        expectTypeOf(getHandler.requests[0].response.raw.json).toEqualTypeOf<() => Promise<NotFoundError>>();
+        expect(await getHandler.requests[0].response.raw.json()).toEqual(notFoundError);
       });
     });
 
@@ -563,35 +566,34 @@ describe('Fetch client', async () => {
 
         const response = await deleteUserById(user.id);
         expectTypeOf(response.status).toEqualTypeOf<204>();
-        expect(response.status).toBe(204);
+        expectResponseStatus(response, 204);
 
-        const deleteRequests = deleteHandler.requests();
-        expect(deleteRequests).toHaveLength(1);
-        expect(deleteRequests[0].url).toBe(`${authFetch.defaults.baseURL}/users/${user.id}`);
+        expect(deleteHandler.requests).toHaveLength(1);
+        expect(deleteHandler.requests[0].url).toBe(`${authFetch.defaults.baseURL}/users/${user.id}`);
 
-        expectTypeOf(deleteRequests[0].pathParams).toEqualTypeOf<{ userId: string }>();
-        expect(deleteRequests[0].pathParams).toEqual({});
+        expectTypeOf(deleteHandler.requests[0].pathParams).toEqualTypeOf<{ userId: string }>();
+        expect(deleteHandler.requests[0].pathParams).toEqual({});
 
-        expectTypeOf(deleteRequests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
+        expectTypeOf(deleteHandler.requests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
 
-        expectTypeOf(deleteRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
-        expect(deleteRequests[0].searchParams.size).toBe(0);
+        expectTypeOf(deleteHandler.requests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
+        expect(deleteHandler.requests[0].searchParams.size).toBe(0);
 
-        expectTypeOf(deleteRequests[0].body).toEqualTypeOf<null>();
-        expect(deleteRequests[0].body).toBe(null);
+        expectTypeOf(deleteHandler.requests[0].body).toEqualTypeOf<null>();
+        expect(deleteHandler.requests[0].body).toBe(null);
 
-        expectTypeOf(deleteRequests[0].raw).toEqualTypeOf<HttpRequest<null>>();
-        expect(deleteRequests[0].raw).toBeInstanceOf(Request);
-        expectTypeOf(deleteRequests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
-        expect(await deleteRequests[0].raw.text()).toBe('');
+        expectTypeOf(deleteHandler.requests[0].raw).toEqualTypeOf<HttpRequest<null>>();
+        expect(deleteHandler.requests[0].raw).toBeInstanceOf(Request);
+        expectTypeOf(deleteHandler.requests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
+        expect(await deleteHandler.requests[0].raw.text()).toBe('');
 
-        expectTypeOf(deleteRequests[0].response.body).toEqualTypeOf<null>();
-        expect(deleteRequests[0].response.body).toBe(null);
+        expectTypeOf(deleteHandler.requests[0].response.body).toEqualTypeOf<null>();
+        expect(deleteHandler.requests[0].response.body).toBe(null);
 
-        expectTypeOf(deleteRequests[0].response.raw).toEqualTypeOf<HttpResponse<null, 204>>();
-        expect(deleteRequests[0].response.raw).toBeInstanceOf(Response);
-        expectTypeOf(deleteRequests[0].response.raw.json).toEqualTypeOf<() => Promise<null>>();
-        expect(await deleteRequests[0].response.raw.text()).toBe('');
+        expectTypeOf(deleteHandler.requests[0].response.raw).toEqualTypeOf<HttpResponse<null, 204>>();
+        expect(deleteHandler.requests[0].response.raw).toBeInstanceOf(Response);
+        expectTypeOf(deleteHandler.requests[0].response.raw.json).toEqualTypeOf<() => Promise<null>>();
+        expect(await deleteHandler.requests[0].response.raw.text()).toBe('');
       });
 
       it('should return an error if the user was not found', async () => {
@@ -599,47 +601,46 @@ describe('Fetch client', async () => {
           code: 'not_found',
           message: 'User not found',
         };
-        const getHandler = authInterceptor
+        const deleteHandler = authInterceptor
           .delete('/users/:userId')
           .respond({ status: 404, body: notFoundError })
           .times(1);
 
-        const error = await expectToThrow(deleteUserById(user.id), {
-          is: (error): error is FetchResponseError<AuthServiceSchema, 'DELETE', '/users/:userId'> =>
+        const error = await expectToThrow(
+          deleteUserById(user.id),
+          (error): error is FetchResponseError<AuthServiceSchema, 'DELETE', '/users/:userId'> =>
             authFetch.isResponseError(error, 'DELETE', '/users/:userId'),
-        });
-        const { response } = error;
+        );
 
-        expectTypeOf(response.status).toEqualTypeOf<404 | 500>();
-        expect(response.status).toBe(404);
+        expectTypeOf(error.response.status).toEqualTypeOf<404 | 500>();
+        expectResponseStatus(error.response, 404);
 
-        const deleteRequests = getHandler.requests();
-        expect(deleteRequests).toHaveLength(1);
-        expect(deleteRequests[0].url).toBe(`${authFetch.defaults.baseURL}/users/${user.id}`);
+        expect(deleteHandler.requests).toHaveLength(1);
+        expect(deleteHandler.requests[0].url).toBe(`${authFetch.defaults.baseURL}/users/${user.id}`);
 
-        expectTypeOf(deleteRequests[0].pathParams).toEqualTypeOf<{ userId: string }>();
-        expect(deleteRequests[0].pathParams).toEqual({ userId: user.id });
+        expectTypeOf(deleteHandler.requests[0].pathParams).toEqualTypeOf<{ userId: string }>();
+        expect(deleteHandler.requests[0].pathParams).toEqual({ userId: user.id });
 
-        expectTypeOf(deleteRequests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
+        expectTypeOf(deleteHandler.requests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
 
-        expectTypeOf(deleteRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
-        expect(deleteRequests[0].searchParams.size).toBe(0);
+        expectTypeOf(deleteHandler.requests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
+        expect(deleteHandler.requests[0].searchParams.size).toBe(0);
 
-        expectTypeOf(deleteRequests[0].body).toEqualTypeOf<null>();
-        expect(deleteRequests[0].body).toBe(null);
+        expectTypeOf(deleteHandler.requests[0].body).toEqualTypeOf<null>();
+        expect(deleteHandler.requests[0].body).toBe(null);
 
-        expectTypeOf(deleteRequests[0].raw).toEqualTypeOf<HttpRequest<null>>();
-        expect(deleteRequests[0].raw).toBeInstanceOf(Request);
-        expectTypeOf(deleteRequests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
-        expect(await deleteRequests[0].raw.text()).toBe('');
+        expectTypeOf(deleteHandler.requests[0].raw).toEqualTypeOf<HttpRequest<null>>();
+        expect(deleteHandler.requests[0].raw).toBeInstanceOf(Request);
+        expectTypeOf(deleteHandler.requests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
+        expect(await deleteHandler.requests[0].raw.text()).toBe('');
 
-        expectTypeOf(deleteRequests[0].response.body).toEqualTypeOf<NotFoundError>();
-        expect(deleteRequests[0].response.body).toEqual(notFoundError);
+        expectTypeOf(deleteHandler.requests[0].response.body).toEqualTypeOf<NotFoundError>();
+        expect(deleteHandler.requests[0].response.body).toEqual(notFoundError);
 
-        expectTypeOf(deleteRequests[0].response.raw).toEqualTypeOf<HttpResponse<NotFoundError, 404>>();
-        expect(deleteRequests[0].response.raw).toBeInstanceOf(Response);
-        expectTypeOf(deleteRequests[0].response.raw.json).toEqualTypeOf<() => Promise<NotFoundError>>();
-        expect(await deleteRequests[0].response.raw.json()).toEqual(notFoundError);
+        expectTypeOf(deleteHandler.requests[0].response.raw).toEqualTypeOf<HttpResponse<NotFoundError, 404>>();
+        expect(deleteHandler.requests[0].response.raw).toBeInstanceOf(Response);
+        expectTypeOf(deleteHandler.requests[0].response.raw.json).toEqualTypeOf<() => Promise<NotFoundError>>();
+        expect(await deleteHandler.requests[0].response.raw.json()).toEqual(notFoundError);
       });
     });
   });
@@ -684,50 +685,50 @@ describe('Fetch client', async () => {
 
         let response = await listNotifications(notification.userId);
         expectTypeOf(response.status).toEqualTypeOf<200>();
-        expect(response.status).toBe(200);
+        expectResponseStatus(response, 200);
 
         let returnedNotifications = await response.json();
         expect(returnedNotifications).toEqual([notification]);
 
-        const listRequests = listHandler.requests();
-        expect(listRequests).toHaveLength(1);
-        expect(listRequests[0].url).toBe(`${notificationFetch.defaults.baseURL}/notifications/${notification.userId}`);
+        expect(listHandler.requests).toHaveLength(1);
+        expect(listHandler.requests[0].url).toBe(
+          `${notificationFetch.defaults.baseURL}/notifications/${notification.userId}`,
+        );
 
-        expectTypeOf(listRequests[0].pathParams).toEqualTypeOf<{ userId: string }>();
-        expect(listRequests[0].pathParams).toEqual({ userId: notification.userId });
+        expectTypeOf(listHandler.requests[0].pathParams).toEqualTypeOf<{ userId: string }>();
+        expect(listHandler.requests[0].pathParams).toEqual({ userId: notification.userId });
 
-        expectTypeOf(listRequests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
+        expectTypeOf(listHandler.requests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
 
-        expectTypeOf(listRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
-        expect(listRequests[0].searchParams.size).toBe(0);
+        expectTypeOf(listHandler.requests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
+        expect(listHandler.requests[0].searchParams.size).toBe(0);
 
-        expectTypeOf(listRequests[0].body).toEqualTypeOf<null>();
-        expect(listRequests[0].body).toBe(null);
+        expectTypeOf(listHandler.requests[0].body).toEqualTypeOf<null>();
+        expect(listHandler.requests[0].body).toBe(null);
 
-        expectTypeOf(listRequests[0].raw).toEqualTypeOf<HttpRequest<null>>();
-        expect(listRequests[0].raw).toBeInstanceOf(Request);
-        expectTypeOf(listRequests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
-        expect(await listRequests[0].raw.text()).toBe('');
+        expectTypeOf(listHandler.requests[0].raw).toEqualTypeOf<HttpRequest<null>>();
+        expect(listHandler.requests[0].raw).toBeInstanceOf(Request);
+        expectTypeOf(listHandler.requests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
+        expect(await listHandler.requests[0].raw.text()).toBe('');
 
-        expectTypeOf(listRequests[0].response.body).toEqualTypeOf<Notification[]>();
-        expect(listRequests[0].response.body).toEqual([notification]);
+        expectTypeOf(listHandler.requests[0].response.body).toEqualTypeOf<Notification[]>();
+        expect(listHandler.requests[0].response.body).toEqual([notification]);
 
-        expectTypeOf(listRequests[0].response.raw).toEqualTypeOf<HttpResponse<Notification[], 200>>();
-        expect(listRequests[0].response.raw).toBeInstanceOf(Response);
-        expectTypeOf(listRequests[0].response.raw.json).toEqualTypeOf<() => Promise<Notification[]>>();
-        expect(await listRequests[0].response.raw.json()).toEqual([notification]);
+        expectTypeOf(listHandler.requests[0].response.raw).toEqualTypeOf<HttpResponse<Notification[], 200>>();
+        expect(listHandler.requests[0].response.raw).toBeInstanceOf(Response);
+        expectTypeOf(listHandler.requests[0].response.raw.json).toEqualTypeOf<() => Promise<Notification[]>>();
+        expect(await listHandler.requests[0].response.raw.json()).toEqual([notification]);
 
         listHandler.clear();
 
         response = await listNotifications(notification.userId);
         expectTypeOf(response.status).toEqualTypeOf<200>();
-        expect(response.status).toBe(200);
+        expectResponseStatus(response, 200);
 
         returnedNotifications = await response.json();
         expect(returnedNotifications).toEqual([]);
 
-        expect(listRequests).toHaveLength(1);
-        expect(listHandler.requests()).toHaveLength(0);
+        expect(listHandler.requests).toHaveLength(0);
       });
     });
   });

--- a/apps/zimic-test-client/tests/interceptor/thirdParty/shared/httpInterceptor.ts
+++ b/apps/zimic-test-client/tests/interceptor/thirdParty/shared/httpInterceptor.ts
@@ -48,15 +48,15 @@ async function declareHttpInterceptorTests(options: ClientTestOptionsByWorkerTyp
 
   const interceptors = [authInterceptor, notificationInterceptor];
 
-  const authBaseURL = authInterceptor.baseURL();
-  const notificationBaseURL = notificationInterceptor.baseURL();
+  const authBaseURL = authInterceptor.baseURL;
+  const notificationBaseURL = notificationInterceptor.baseURL;
 
   beforeAll(async () => {
     await Promise.all(
       interceptors.map(async (interceptor) => {
         await interceptor.start();
-        expect(interceptor.isRunning()).toBe(true);
-        expect(interceptor.platform()).toBe(platform);
+        expect(interceptor.isRunning).toBe(true);
+        expect(interceptor.platform).toBe(platform);
       }),
     );
   });
@@ -81,7 +81,7 @@ async function declareHttpInterceptorTests(options: ClientTestOptionsByWorkerTyp
     await Promise.all(
       interceptors.map(async (interceptor) => {
         await interceptor.stop();
-        expect(interceptor.isRunning()).toBe(false);
+        expect(interceptor.isRunning).toBe(false);
       }),
     );
   });
@@ -158,32 +158,35 @@ async function declareHttpInterceptorTests(options: ClientTestOptionsByWorkerTyp
           birthDate: creationPayload.birthDate,
         });
 
-        const creationRequests = await creationHandler.requests();
-        expect(creationRequests).toHaveLength(1);
+        expect(creationHandler.requests).toHaveLength(1);
 
-        expectTypeOf(creationRequests[0].headers).toEqualTypeOf<HttpHeaders<{ 'content-type': 'application/json' }>>();
+        expectTypeOf(creationHandler.requests[0].headers).toEqualTypeOf<
+          HttpHeaders<{ 'content-type': 'application/json' }>
+        >();
 
-        expectTypeOf(creationRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
-        expect(creationRequests[0].searchParams.size).toBe(0);
+        expectTypeOf(creationHandler.requests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
+        expect(creationHandler.requests[0].searchParams.size).toBe(0);
 
         expect(response.headers.get('x-user-id')).toBe(createdUser.id);
-        expect(creationRequests[0].response.headers.get('x-user-id')).toBe(createdUser.id);
+        expect(creationHandler.requests[0].response.headers.get('x-user-id')).toBe(createdUser.id);
 
-        expectTypeOf(creationRequests[0].body).toEqualTypeOf<UserCreationRequestBody>();
-        expect(creationRequests[0].body).toEqual(creationPayload);
+        expectTypeOf(creationHandler.requests[0].body).toEqualTypeOf<UserCreationRequestBody>();
+        expect(creationHandler.requests[0].body).toEqual(creationPayload);
 
-        expectTypeOf(creationRequests[0].raw).toEqualTypeOf<HttpRequest<UserCreationRequestBody>>();
-        expect(creationRequests[0].raw).toBeInstanceOf(Request);
-        expectTypeOf(creationRequests[0].raw.json).toEqualTypeOf<() => Promise<UserCreationRequestBody>>();
-        expect(await creationRequests[0].raw.json()).toEqual(creationPayload);
+        expectTypeOf(creationHandler.requests[0].raw).toEqualTypeOf<HttpRequest<UserCreationRequestBody>>();
+        expect(creationHandler.requests[0].raw).toBeInstanceOf(Request);
+        expectTypeOf(creationHandler.requests[0].raw.json).toEqualTypeOf<() => Promise<UserCreationRequestBody>>();
+        expect(await creationHandler.requests[0].raw.json()).toEqual(creationPayload);
 
-        expectTypeOf(creationRequests[0].response.body).toEqualTypeOf<JSONSerialized<User>>();
-        expect(creationRequests[0].response.body).toEqual(createdUser);
+        expectTypeOf(creationHandler.requests[0].response.body).toEqualTypeOf<JSONSerialized<User>>();
+        expect(creationHandler.requests[0].response.body).toEqual(createdUser);
 
-        expectTypeOf(creationRequests[0].response.raw).toEqualTypeOf<HttpResponse<JSONSerialized<User>, 201>>();
-        expect(creationRequests[0].response.raw).toBeInstanceOf(Response);
-        expectTypeOf(creationRequests[0].response.raw.json).toEqualTypeOf<() => Promise<JSONSerialized<User>>>();
-        expect(await creationRequests[0].response.raw.json()).toEqual(createdUser);
+        expectTypeOf(creationHandler.requests[0].response.raw).toEqualTypeOf<HttpResponse<JSONSerialized<User>, 201>>();
+        expect(creationHandler.requests[0].response.raw).toBeInstanceOf(Response);
+        expectTypeOf(creationHandler.requests[0].response.raw.json).toEqualTypeOf<
+          () => Promise<JSONSerialized<User>>
+        >();
+        expect(await creationHandler.requests[0].response.raw.json()).toEqual(createdUser);
       });
 
       it('should return an error if the payload is not valid', async () => {
@@ -204,29 +207,30 @@ async function declareHttpInterceptorTests(options: ClientTestOptionsByWorkerTyp
         const response = await createUser(invalidPayload);
         expect(response.status).toBe(400);
 
-        const creationRequests = await creationHandler.requests();
-        expect(creationRequests).toHaveLength(1);
+        expect(creationHandler.requests).toHaveLength(1);
 
-        expectTypeOf(creationRequests[0].headers).toEqualTypeOf<HttpHeaders<{ 'content-type': 'application/json' }>>();
+        expectTypeOf(creationHandler.requests[0].headers).toEqualTypeOf<
+          HttpHeaders<{ 'content-type': 'application/json' }>
+        >();
 
-        expectTypeOf(creationRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
-        expect(creationRequests[0].searchParams.size).toBe(0);
+        expectTypeOf(creationHandler.requests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
+        expect(creationHandler.requests[0].searchParams.size).toBe(0);
 
-        expectTypeOf(creationRequests[0].body).toEqualTypeOf<UserCreationRequestBody>();
-        expect(creationRequests[0].body).toEqual(invalidPayload);
+        expectTypeOf(creationHandler.requests[0].body).toEqualTypeOf<UserCreationRequestBody>();
+        expect(creationHandler.requests[0].body).toEqual(invalidPayload);
 
-        expectTypeOf(creationRequests[0].raw).toEqualTypeOf<HttpRequest<UserCreationRequestBody>>();
-        expect(creationRequests[0].raw).toBeInstanceOf(Request);
-        expectTypeOf(creationRequests[0].raw.json).toEqualTypeOf<() => Promise<UserCreationRequestBody>>();
-        expect(await creationRequests[0].raw.json()).toEqual(invalidPayload);
+        expectTypeOf(creationHandler.requests[0].raw).toEqualTypeOf<HttpRequest<UserCreationRequestBody>>();
+        expect(creationHandler.requests[0].raw).toBeInstanceOf(Request);
+        expectTypeOf(creationHandler.requests[0].raw.json).toEqualTypeOf<() => Promise<UserCreationRequestBody>>();
+        expect(await creationHandler.requests[0].raw.json()).toEqual(invalidPayload);
 
-        expectTypeOf(creationRequests[0].response.body).toEqualTypeOf<ValidationError>();
-        expect(creationRequests[0].response.body).toEqual(validationError);
+        expectTypeOf(creationHandler.requests[0].response.body).toEqualTypeOf<ValidationError>();
+        expect(creationHandler.requests[0].response.body).toEqual(validationError);
 
-        expectTypeOf(creationRequests[0].response.raw).toEqualTypeOf<HttpResponse<ValidationError, 400>>();
-        expect(creationRequests[0].response.raw).toBeInstanceOf(Response);
-        expectTypeOf(creationRequests[0].response.raw.json).toEqualTypeOf<() => Promise<ValidationError>>();
-        expect(await creationRequests[0].response.raw.json()).toEqual(validationError);
+        expectTypeOf(creationHandler.requests[0].response.raw).toEqualTypeOf<HttpResponse<ValidationError, 400>>();
+        expect(creationHandler.requests[0].response.raw).toBeInstanceOf(Response);
+        expectTypeOf(creationHandler.requests[0].response.raw.json).toEqualTypeOf<() => Promise<ValidationError>>();
+        expect(await creationHandler.requests[0].response.raw.json()).toEqual(validationError);
       });
 
       it('should return an error if the payload is not valid', async () => {
@@ -245,29 +249,30 @@ async function declareHttpInterceptorTests(options: ClientTestOptionsByWorkerTyp
         const response = await createUser(conflictingPayload);
         expect(response.status).toBe(409);
 
-        const creationRequests = await creationHandler.requests();
-        expect(creationRequests).toHaveLength(1);
+        expect(creationHandler.requests).toHaveLength(1);
 
-        expectTypeOf(creationRequests[0].headers).toEqualTypeOf<HttpHeaders<{ 'content-type': 'application/json' }>>();
+        expectTypeOf(creationHandler.requests[0].headers).toEqualTypeOf<
+          HttpHeaders<{ 'content-type': 'application/json' }>
+        >();
 
-        expectTypeOf(creationRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
-        expect(creationRequests[0].searchParams.size).toBe(0);
+        expectTypeOf(creationHandler.requests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
+        expect(creationHandler.requests[0].searchParams.size).toBe(0);
 
-        expectTypeOf(creationRequests[0].body).toEqualTypeOf<UserCreationRequestBody>();
-        expect(creationRequests[0].body).toEqual(conflictingPayload);
+        expectTypeOf(creationHandler.requests[0].body).toEqualTypeOf<UserCreationRequestBody>();
+        expect(creationHandler.requests[0].body).toEqual(conflictingPayload);
 
-        expectTypeOf(creationRequests[0].raw).toEqualTypeOf<HttpRequest<UserCreationRequestBody>>();
-        expect(creationRequests[0].raw).toBeInstanceOf(Request);
-        expectTypeOf(creationRequests[0].raw.json).toEqualTypeOf<() => Promise<UserCreationRequestBody>>();
-        expect(await creationRequests[0].raw.json()).toEqual(creationPayload);
+        expectTypeOf(creationHandler.requests[0].raw).toEqualTypeOf<HttpRequest<UserCreationRequestBody>>();
+        expect(creationHandler.requests[0].raw).toBeInstanceOf(Request);
+        expectTypeOf(creationHandler.requests[0].raw.json).toEqualTypeOf<() => Promise<UserCreationRequestBody>>();
+        expect(await creationHandler.requests[0].raw.json()).toEqual(creationPayload);
 
-        expectTypeOf(creationRequests[0].response.body).toEqualTypeOf<ConflictError>();
-        expect(creationRequests[0].response.body).toEqual(conflictError);
+        expectTypeOf(creationHandler.requests[0].response.body).toEqualTypeOf<ConflictError>();
+        expect(creationHandler.requests[0].response.body).toEqual(conflictError);
 
-        expectTypeOf(creationRequests[0].response.raw).toEqualTypeOf<HttpResponse<ConflictError, 409>>();
-        expect(creationRequests[0].response.raw).toBeInstanceOf(Response);
-        expectTypeOf(creationRequests[0].response.raw.json).toEqualTypeOf<() => Promise<ConflictError>>();
-        expect(await creationRequests[0].response.raw.json()).toEqual(conflictError);
+        expectTypeOf(creationHandler.requests[0].response.raw).toEqualTypeOf<HttpResponse<ConflictError, 409>>();
+        expect(creationHandler.requests[0].response.raw).toBeInstanceOf(Response);
+        expectTypeOf(creationHandler.requests[0].response.raw.json).toEqualTypeOf<() => Promise<ConflictError>>();
+        expect(await creationHandler.requests[0].response.raw.json()).toEqual(conflictError);
       });
     });
 
@@ -320,32 +325,31 @@ async function declareHttpInterceptorTests(options: ClientTestOptionsByWorkerTyp
         const returnedUsers = (await response.json()) as User[];
         expect(returnedUsers).toEqual(users.map(serializeUser));
 
-        const listRequests = await listHandler.requests();
-        expect(listRequests).toHaveLength(1);
+        expect(listHandler.requests).toHaveLength(1);
 
-        expectTypeOf(listRequests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
+        expectTypeOf(listHandler.requests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
 
-        expectTypeOf(listRequests[0].searchParams).toEqualTypeOf<
+        expectTypeOf(listHandler.requests[0].searchParams).toEqualTypeOf<
           HttpSearchParams<HttpSchema.SearchParams<UserListSearchParams>>
         >();
-        expect(listRequests[0].searchParams.get('name')).toBe(null);
-        expect(listRequests[0].searchParams.getAll('orderBy')).toEqual([]);
+        expect(listHandler.requests[0].searchParams.get('name')).toBe(null);
+        expect(listHandler.requests[0].searchParams.getAll('orderBy')).toEqual([]);
 
-        expectTypeOf(listRequests[0].body).toEqualTypeOf<null>();
-        expect(listRequests[0].body).toBe(null);
+        expectTypeOf(listHandler.requests[0].body).toEqualTypeOf<null>();
+        expect(listHandler.requests[0].body).toBe(null);
 
-        expectTypeOf(listRequests[0].raw).toEqualTypeOf<HttpRequest<null>>();
-        expect(listRequests[0].raw).toBeInstanceOf(Request);
-        expectTypeOf(listRequests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
-        expect(await listRequests[0].raw.text()).toBe('');
+        expectTypeOf(listHandler.requests[0].raw).toEqualTypeOf<HttpRequest<null>>();
+        expect(listHandler.requests[0].raw).toBeInstanceOf(Request);
+        expectTypeOf(listHandler.requests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
+        expect(await listHandler.requests[0].raw.text()).toBe('');
 
-        expectTypeOf(listRequests[0].response.body).toEqualTypeOf<JSONSerialized<User>[]>();
-        expect(listRequests[0].response.body).toEqual(users.map(serializeUser));
+        expectTypeOf(listHandler.requests[0].response.body).toEqualTypeOf<JSONSerialized<User>[]>();
+        expect(listHandler.requests[0].response.body).toEqual(users.map(serializeUser));
 
-        expectTypeOf(listRequests[0].response.raw).toEqualTypeOf<HttpResponse<JSONSerialized<User>[], 200>>();
-        expect(listRequests[0].response.raw).toBeInstanceOf(Response);
-        expectTypeOf(listRequests[0].response.raw.json).toEqualTypeOf<() => Promise<JSONSerialized<User>[]>>();
-        expect(await listRequests[0].response.raw.json()).toEqual(users.map(serializeUser));
+        expectTypeOf(listHandler.requests[0].response.raw).toEqualTypeOf<HttpResponse<JSONSerialized<User>[], 200>>();
+        expect(listHandler.requests[0].response.raw).toBeInstanceOf(Response);
+        expectTypeOf(listHandler.requests[0].response.raw.json).toEqualTypeOf<() => Promise<JSONSerialized<User>[]>>();
+        expect(await listHandler.requests[0].response.raw.json()).toEqual(users.map(serializeUser));
       });
 
       it('should list users filtered by name', async () => {
@@ -363,33 +367,32 @@ async function declareHttpInterceptorTests(options: ClientTestOptionsByWorkerTyp
         const returnedUsers = (await response.json()) as User[];
         expect(returnedUsers).toEqual([serializeUser(user)]);
 
-        const listRequests = await listHandler.requests();
-        expect(listRequests).toHaveLength(1);
+        expect(listHandler.requests).toHaveLength(1);
 
-        expectTypeOf(listRequests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
+        expectTypeOf(listHandler.requests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
 
-        expectTypeOf(listRequests[0].searchParams).toEqualTypeOf<
+        expectTypeOf(listHandler.requests[0].searchParams).toEqualTypeOf<
           HttpSearchParams<HttpSchema.SearchParams<UserListSearchParams>>
         >();
-        expect(listRequests[0].searchParams.size).toBe(1);
-        expect(listRequests[0].searchParams.get('name')).toBe(user.name);
-        expect(listRequests[0].searchParams.getAll('orderBy')).toEqual([]);
+        expect(listHandler.requests[0].searchParams.size).toBe(1);
+        expect(listHandler.requests[0].searchParams.get('name')).toBe(user.name);
+        expect(listHandler.requests[0].searchParams.getAll('orderBy')).toEqual([]);
 
-        expectTypeOf(listRequests[0].body).toEqualTypeOf<null>();
-        expect(listRequests[0].body).toBe(null);
+        expectTypeOf(listHandler.requests[0].body).toEqualTypeOf<null>();
+        expect(listHandler.requests[0].body).toBe(null);
 
-        expectTypeOf(listRequests[0].raw).toEqualTypeOf<HttpRequest<null>>();
-        expect(listRequests[0].raw).toBeInstanceOf(Request);
-        expectTypeOf(listRequests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
-        expect(await listRequests[0].raw.text()).toBe('');
+        expectTypeOf(listHandler.requests[0].raw).toEqualTypeOf<HttpRequest<null>>();
+        expect(listHandler.requests[0].raw).toBeInstanceOf(Request);
+        expectTypeOf(listHandler.requests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
+        expect(await listHandler.requests[0].raw.text()).toBe('');
 
-        expectTypeOf(listRequests[0].response.body).toEqualTypeOf<JSONSerialized<User>[]>();
-        expect(listRequests[0].response.body).toEqual([serializeUser(user)]);
+        expectTypeOf(listHandler.requests[0].response.body).toEqualTypeOf<JSONSerialized<User>[]>();
+        expect(listHandler.requests[0].response.body).toEqual([serializeUser(user)]);
 
-        expectTypeOf(listRequests[0].response.raw).toEqualTypeOf<HttpResponse<JSONSerialized<User>[], 200>>();
-        expect(listRequests[0].response.raw).toBeInstanceOf(Response);
-        expectTypeOf(listRequests[0].response.raw.json).toEqualTypeOf<() => Promise<JSONSerialized<User>[]>>();
-        expect(await listRequests[0].response.raw.json()).toEqual([serializeUser(user)]);
+        expectTypeOf(listHandler.requests[0].response.raw).toEqualTypeOf<HttpResponse<JSONSerialized<User>[], 200>>();
+        expect(listHandler.requests[0].response.raw).toBeInstanceOf(Response);
+        expectTypeOf(listHandler.requests[0].response.raw.json).toEqualTypeOf<() => Promise<JSONSerialized<User>[]>>();
+        expect(await listHandler.requests[0].response.raw.json()).toEqual([serializeUser(user)]);
       });
 
       it('should list users with ordering', async () => {
@@ -411,33 +414,34 @@ async function declareHttpInterceptorTests(options: ClientTestOptionsByWorkerTyp
         const returnedUsers = (await response.json()) as User[];
         expect(returnedUsers).toEqual(usersSortedByDescendingEmail.map(serializeUser));
 
-        const listRequests = await listHandler.requests();
-        expect(listRequests).toHaveLength(1);
+        expect(listHandler.requests).toHaveLength(1);
 
-        expectTypeOf(listRequests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
+        expectTypeOf(listHandler.requests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
 
-        expectTypeOf(listRequests[0].searchParams).toEqualTypeOf<
+        expectTypeOf(listHandler.requests[0].searchParams).toEqualTypeOf<
           HttpSearchParams<HttpSchema.SearchParams<UserListSearchParams>>
         >();
-        expect(listRequests[0].searchParams.size).toBe(1);
-        expect(listRequests[0].searchParams.get('name')).toBe(null);
-        expect(listRequests[0].searchParams.getAll('orderBy')).toEqual(['email.desc']);
+        expect(listHandler.requests[0].searchParams.size).toBe(1);
+        expect(listHandler.requests[0].searchParams.get('name')).toBe(null);
+        expect(listHandler.requests[0].searchParams.getAll('orderBy')).toEqual(['email.desc']);
 
-        expectTypeOf(listRequests[0].body).toEqualTypeOf<null>();
-        expect(listRequests[0].body).toBe(null);
+        expectTypeOf(listHandler.requests[0].body).toEqualTypeOf<null>();
+        expect(listHandler.requests[0].body).toBe(null);
 
-        expectTypeOf(listRequests[0].raw).toEqualTypeOf<HttpRequest<null>>();
-        expect(listRequests[0].raw).toBeInstanceOf(Request);
-        expectTypeOf(listRequests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
-        expect(await listRequests[0].raw.text()).toBe('');
+        expectTypeOf(listHandler.requests[0].raw).toEqualTypeOf<HttpRequest<null>>();
+        expect(listHandler.requests[0].raw).toBeInstanceOf(Request);
+        expectTypeOf(listHandler.requests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
+        expect(await listHandler.requests[0].raw.text()).toBe('');
 
-        expectTypeOf(listRequests[0].response.body).toEqualTypeOf<JSONSerialized<User>[]>();
-        expect(listRequests[0].response.body).toEqual(usersSortedByDescendingEmail.map(serializeUser));
+        expectTypeOf(listHandler.requests[0].response.body).toEqualTypeOf<JSONSerialized<User>[]>();
+        expect(listHandler.requests[0].response.body).toEqual(usersSortedByDescendingEmail.map(serializeUser));
 
-        expectTypeOf(listRequests[0].response.raw).toEqualTypeOf<HttpResponse<JSONSerialized<User>[], 200>>();
-        expect(listRequests[0].response.raw).toBeInstanceOf(Response);
-        expectTypeOf(listRequests[0].response.raw.json).toEqualTypeOf<() => Promise<JSONSerialized<User>[]>>();
-        expect(await listRequests[0].response.raw.json()).toEqual(usersSortedByDescendingEmail.map(serializeUser));
+        expectTypeOf(listHandler.requests[0].response.raw).toEqualTypeOf<HttpResponse<JSONSerialized<User>[], 200>>();
+        expect(listHandler.requests[0].response.raw).toBeInstanceOf(Response);
+        expectTypeOf(listHandler.requests[0].response.raw.json).toEqualTypeOf<() => Promise<JSONSerialized<User>[]>>();
+        expect(await listHandler.requests[0].response.raw.json()).toEqual(
+          usersSortedByDescendingEmail.map(serializeUser),
+        );
       });
     });
 
@@ -459,30 +463,29 @@ async function declareHttpInterceptorTests(options: ClientTestOptionsByWorkerTyp
         const returnedUsers = (await response.json()) as User[];
         expect(returnedUsers).toEqual(serializeUser(user));
 
-        const getRequests = await getHandler.requests();
-        expect(getRequests).toHaveLength(1);
-        expect(getRequests[0].url).toBe(`${authBaseURL}/users/${user.id}`);
+        expect(getHandler.requests).toHaveLength(1);
+        expect(getHandler.requests[0].url).toBe(`${authBaseURL}/users/${user.id}`);
 
-        expectTypeOf(getRequests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
+        expectTypeOf(getHandler.requests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
 
-        expectTypeOf(getRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
-        expect(getRequests[0].searchParams.size).toBe(0);
+        expectTypeOf(getHandler.requests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
+        expect(getHandler.requests[0].searchParams.size).toBe(0);
 
-        expectTypeOf(getRequests[0].body).toEqualTypeOf<null>();
-        expect(getRequests[0].body).toBe(null);
+        expectTypeOf(getHandler.requests[0].body).toEqualTypeOf<null>();
+        expect(getHandler.requests[0].body).toBe(null);
 
-        expectTypeOf(getRequests[0].raw).toEqualTypeOf<HttpRequest<null>>();
-        expect(getRequests[0].raw).toBeInstanceOf(Request);
-        expectTypeOf(getRequests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
-        expect(await getRequests[0].raw.text()).toBe('');
+        expectTypeOf(getHandler.requests[0].raw).toEqualTypeOf<HttpRequest<null>>();
+        expect(getHandler.requests[0].raw).toBeInstanceOf(Request);
+        expectTypeOf(getHandler.requests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
+        expect(await getHandler.requests[0].raw.text()).toBe('');
 
-        expectTypeOf(getRequests[0].response.body).toEqualTypeOf<JSONSerialized<User>>();
-        expect(getRequests[0].response.body).toEqual(serializeUser(user));
+        expectTypeOf(getHandler.requests[0].response.body).toEqualTypeOf<JSONSerialized<User>>();
+        expect(getHandler.requests[0].response.body).toEqual(serializeUser(user));
 
-        expectTypeOf(getRequests[0].response.raw).toEqualTypeOf<HttpResponse<JSONSerialized<User>, 200>>();
-        expect(getRequests[0].response.raw).toBeInstanceOf(Response);
-        expectTypeOf(getRequests[0].response.raw.json).toEqualTypeOf<() => Promise<JSONSerialized<User>>>();
-        expect(await getRequests[0].response.raw.json()).toEqual(serializeUser(user));
+        expectTypeOf(getHandler.requests[0].response.raw).toEqualTypeOf<HttpResponse<JSONSerialized<User>, 200>>();
+        expect(getHandler.requests[0].response.raw).toBeInstanceOf(Response);
+        expectTypeOf(getHandler.requests[0].response.raw.json).toEqualTypeOf<() => Promise<JSONSerialized<User>>>();
+        expect(await getHandler.requests[0].response.raw.json()).toEqual(serializeUser(user));
       });
 
       it('should return an error if the user was not found', async () => {
@@ -499,33 +502,32 @@ async function declareHttpInterceptorTests(options: ClientTestOptionsByWorkerTyp
         const response = await getUserById(user.id);
         expect(response.status).toBe(404);
 
-        const getRequests = await getHandler.requests();
-        expect(getRequests).toHaveLength(1);
-        expect(getRequests[0].url).toBe(`${authBaseURL}/users/${user.id}`);
+        expect(getHandler.requests).toHaveLength(1);
+        expect(getHandler.requests[0].url).toBe(`${authBaseURL}/users/${user.id}`);
 
-        expectTypeOf(getRequests[0].pathParams).toEqualTypeOf<{ userId: string }>();
-        expect(getRequests[0].pathParams).toEqual({ userId: user.id });
+        expectTypeOf(getHandler.requests[0].pathParams).toEqualTypeOf<{ userId: string }>();
+        expect(getHandler.requests[0].pathParams).toEqual({ userId: user.id });
 
-        expectTypeOf(getRequests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
+        expectTypeOf(getHandler.requests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
 
-        expectTypeOf(getRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
-        expect(getRequests[0].searchParams.size).toBe(0);
+        expectTypeOf(getHandler.requests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
+        expect(getHandler.requests[0].searchParams.size).toBe(0);
 
-        expectTypeOf(getRequests[0].body).toEqualTypeOf<null>();
-        expect(getRequests[0].body).toBe(null);
+        expectTypeOf(getHandler.requests[0].body).toEqualTypeOf<null>();
+        expect(getHandler.requests[0].body).toBe(null);
 
-        expectTypeOf(getRequests[0].raw).toEqualTypeOf<HttpRequest<null>>();
-        expect(getRequests[0].raw).toBeInstanceOf(Request);
-        expectTypeOf(getRequests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
-        expect(await getRequests[0].raw.text()).toBe('');
+        expectTypeOf(getHandler.requests[0].raw).toEqualTypeOf<HttpRequest<null>>();
+        expect(getHandler.requests[0].raw).toBeInstanceOf(Request);
+        expectTypeOf(getHandler.requests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
+        expect(await getHandler.requests[0].raw.text()).toBe('');
 
-        expectTypeOf(getRequests[0].response.body).toEqualTypeOf<NotFoundError>();
-        expect(getRequests[0].response.body).toEqual(notFoundError);
+        expectTypeOf(getHandler.requests[0].response.body).toEqualTypeOf<NotFoundError>();
+        expect(getHandler.requests[0].response.body).toEqual(notFoundError);
 
-        expectTypeOf(getRequests[0].response.raw).toEqualTypeOf<HttpResponse<NotFoundError, 404>>();
-        expect(getRequests[0].response.raw).toBeInstanceOf(Response);
-        expectTypeOf(getRequests[0].response.raw.json).toEqualTypeOf<() => Promise<NotFoundError>>();
-        expect(await getRequests[0].response.raw.json()).toEqual(notFoundError);
+        expectTypeOf(getHandler.requests[0].response.raw).toEqualTypeOf<HttpResponse<NotFoundError, 404>>();
+        expect(getHandler.requests[0].response.raw).toBeInstanceOf(Response);
+        expectTypeOf(getHandler.requests[0].response.raw.json).toEqualTypeOf<() => Promise<NotFoundError>>();
+        expect(await getHandler.requests[0].response.raw.json()).toEqual(notFoundError);
       });
     });
 
@@ -541,33 +543,32 @@ async function declareHttpInterceptorTests(options: ClientTestOptionsByWorkerTyp
         const response = await deleteUserById(user.id);
         expect(response.status).toBe(204);
 
-        const deleteRequests = await deleteHandler.requests();
-        expect(deleteRequests).toHaveLength(1);
-        expect(deleteRequests[0].url).toBe(`${authBaseURL}/users/${user.id}`);
+        expect(deleteHandler.requests).toHaveLength(1);
+        expect(deleteHandler.requests[0].url).toBe(`${authBaseURL}/users/${user.id}`);
 
-        expectTypeOf(deleteRequests[0].pathParams).toEqualTypeOf<{ userId: string }>();
-        expect(deleteRequests[0].pathParams).toEqual({});
+        expectTypeOf(deleteHandler.requests[0].pathParams).toEqualTypeOf<{ userId: string }>();
+        expect(deleteHandler.requests[0].pathParams).toEqual({});
 
-        expectTypeOf(deleteRequests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
+        expectTypeOf(deleteHandler.requests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
 
-        expectTypeOf(deleteRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
-        expect(deleteRequests[0].searchParams.size).toBe(0);
+        expectTypeOf(deleteHandler.requests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
+        expect(deleteHandler.requests[0].searchParams.size).toBe(0);
 
-        expectTypeOf(deleteRequests[0].body).toEqualTypeOf<null>();
-        expect(deleteRequests[0].body).toBe(null);
+        expectTypeOf(deleteHandler.requests[0].body).toEqualTypeOf<null>();
+        expect(deleteHandler.requests[0].body).toBe(null);
 
-        expectTypeOf(deleteRequests[0].raw).toEqualTypeOf<HttpRequest<null>>();
-        expect(deleteRequests[0].raw).toBeInstanceOf(Request);
-        expectTypeOf(deleteRequests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
-        expect(await deleteRequests[0].raw.text()).toBe('');
+        expectTypeOf(deleteHandler.requests[0].raw).toEqualTypeOf<HttpRequest<null>>();
+        expect(deleteHandler.requests[0].raw).toBeInstanceOf(Request);
+        expectTypeOf(deleteHandler.requests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
+        expect(await deleteHandler.requests[0].raw.text()).toBe('');
 
-        expectTypeOf(deleteRequests[0].response.body).toEqualTypeOf<null>();
-        expect(deleteRequests[0].response.body).toBe(null);
+        expectTypeOf(deleteHandler.requests[0].response.body).toEqualTypeOf<null>();
+        expect(deleteHandler.requests[0].response.body).toBe(null);
 
-        expectTypeOf(deleteRequests[0].response.raw).toEqualTypeOf<HttpResponse<null, 204>>();
-        expect(deleteRequests[0].response.raw).toBeInstanceOf(Response);
-        expectTypeOf(deleteRequests[0].response.raw.json).toEqualTypeOf<() => Promise<null>>();
-        expect(await deleteRequests[0].response.raw.text()).toBe('');
+        expectTypeOf(deleteHandler.requests[0].response.raw).toEqualTypeOf<HttpResponse<null, 204>>();
+        expect(deleteHandler.requests[0].response.raw).toBeInstanceOf(Response);
+        expectTypeOf(deleteHandler.requests[0].response.raw.json).toEqualTypeOf<() => Promise<null>>();
+        expect(await deleteHandler.requests[0].response.raw.text()).toBe('');
       });
 
       it('should return an error if the user was not found', async () => {
@@ -576,7 +577,7 @@ async function declareHttpInterceptorTests(options: ClientTestOptionsByWorkerTyp
           message: 'User not found',
         };
 
-        const getHandler = await authInterceptor
+        const deleteHandler = await authInterceptor
           .delete('/users/:userId')
           .respond({ status: 404, body: notFoundError })
           .times(1);
@@ -584,33 +585,32 @@ async function declareHttpInterceptorTests(options: ClientTestOptionsByWorkerTyp
         const response = await deleteUserById(user.id);
         expect(response.status).toBe(404);
 
-        const deleteRequests = await getHandler.requests();
-        expect(deleteRequests).toHaveLength(1);
-        expect(deleteRequests[0].url).toBe(`${authBaseURL}/users/${user.id}`);
+        expect(deleteHandler.requests).toHaveLength(1);
+        expect(deleteHandler.requests[0].url).toBe(`${authBaseURL}/users/${user.id}`);
 
-        expectTypeOf(deleteRequests[0].pathParams).toEqualTypeOf<{ userId: string }>();
-        expect(deleteRequests[0].pathParams).toEqual({ userId: user.id });
+        expectTypeOf(deleteHandler.requests[0].pathParams).toEqualTypeOf<{ userId: string }>();
+        expect(deleteHandler.requests[0].pathParams).toEqual({ userId: user.id });
 
-        expectTypeOf(deleteRequests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
+        expectTypeOf(deleteHandler.requests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
 
-        expectTypeOf(deleteRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
-        expect(deleteRequests[0].searchParams.size).toBe(0);
+        expectTypeOf(deleteHandler.requests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
+        expect(deleteHandler.requests[0].searchParams.size).toBe(0);
 
-        expectTypeOf(deleteRequests[0].body).toEqualTypeOf<null>();
-        expect(deleteRequests[0].body).toBe(null);
+        expectTypeOf(deleteHandler.requests[0].body).toEqualTypeOf<null>();
+        expect(deleteHandler.requests[0].body).toBe(null);
 
-        expectTypeOf(deleteRequests[0].raw).toEqualTypeOf<HttpRequest<null>>();
-        expect(deleteRequests[0].raw).toBeInstanceOf(Request);
-        expectTypeOf(deleteRequests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
-        expect(await deleteRequests[0].raw.text()).toBe('');
+        expectTypeOf(deleteHandler.requests[0].raw).toEqualTypeOf<HttpRequest<null>>();
+        expect(deleteHandler.requests[0].raw).toBeInstanceOf(Request);
+        expectTypeOf(deleteHandler.requests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
+        expect(await deleteHandler.requests[0].raw.text()).toBe('');
 
-        expectTypeOf(deleteRequests[0].response.body).toEqualTypeOf<NotFoundError>();
-        expect(deleteRequests[0].response.body).toEqual(notFoundError);
+        expectTypeOf(deleteHandler.requests[0].response.body).toEqualTypeOf<NotFoundError>();
+        expect(deleteHandler.requests[0].response.body).toEqual(notFoundError);
 
-        expectTypeOf(deleteRequests[0].response.raw).toEqualTypeOf<HttpResponse<NotFoundError, 404>>();
-        expect(deleteRequests[0].response.raw).toBeInstanceOf(Response);
-        expectTypeOf(deleteRequests[0].response.raw.json).toEqualTypeOf<() => Promise<NotFoundError>>();
-        expect(await deleteRequests[0].response.raw.json()).toEqual(notFoundError);
+        expectTypeOf(deleteHandler.requests[0].response.raw).toEqualTypeOf<HttpResponse<NotFoundError, 404>>();
+        expect(deleteHandler.requests[0].response.raw).toBeInstanceOf(Response);
+        expectTypeOf(deleteHandler.requests[0].response.raw.json).toEqualTypeOf<() => Promise<NotFoundError>>();
+        expect(await deleteHandler.requests[0].response.raw.json()).toEqual(notFoundError);
       });
     });
   });
@@ -649,33 +649,32 @@ async function declareHttpInterceptorTests(options: ClientTestOptionsByWorkerTyp
         let returnedNotifications = (await response.json()) as Notification[];
         expect(returnedNotifications).toEqual([notification]);
 
-        const listRequests = await listHandler.requests();
-        expect(listRequests).toHaveLength(1);
-        expect(listRequests[0].url).toBe(`${notificationBaseURL}/notifications/${notification.userId}`);
+        expect(listHandler.requests).toHaveLength(1);
+        expect(listHandler.requests[0].url).toBe(`${notificationBaseURL}/notifications/${notification.userId}`);
 
-        expectTypeOf(listRequests[0].pathParams).toEqualTypeOf<{ userId: string }>();
-        expect(listRequests[0].pathParams).toEqual({ userId: notification.userId });
+        expectTypeOf(listHandler.requests[0].pathParams).toEqualTypeOf<{ userId: string }>();
+        expect(listHandler.requests[0].pathParams).toEqual({ userId: notification.userId });
 
-        expectTypeOf(listRequests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
+        expectTypeOf(listHandler.requests[0].headers).toEqualTypeOf<HttpHeaders<never>>();
 
-        expectTypeOf(listRequests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
-        expect(listRequests[0].searchParams.size).toBe(0);
+        expectTypeOf(listHandler.requests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();
+        expect(listHandler.requests[0].searchParams.size).toBe(0);
 
-        expectTypeOf(listRequests[0].body).toEqualTypeOf<null>();
-        expect(listRequests[0].body).toBe(null);
+        expectTypeOf(listHandler.requests[0].body).toEqualTypeOf<null>();
+        expect(listHandler.requests[0].body).toBe(null);
 
-        expectTypeOf(listRequests[0].raw).toEqualTypeOf<HttpRequest<null>>();
-        expect(listRequests[0].raw).toBeInstanceOf(Request);
-        expectTypeOf(listRequests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
-        expect(await listRequests[0].raw.text()).toBe('');
+        expectTypeOf(listHandler.requests[0].raw).toEqualTypeOf<HttpRequest<null>>();
+        expect(listHandler.requests[0].raw).toBeInstanceOf(Request);
+        expectTypeOf(listHandler.requests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
+        expect(await listHandler.requests[0].raw.text()).toBe('');
 
-        expectTypeOf(listRequests[0].response.body).toEqualTypeOf<Notification[]>();
-        expect(listRequests[0].response.body).toEqual([notification]);
+        expectTypeOf(listHandler.requests[0].response.body).toEqualTypeOf<Notification[]>();
+        expect(listHandler.requests[0].response.body).toEqual([notification]);
 
-        expectTypeOf(listRequests[0].response.raw).toEqualTypeOf<HttpResponse<Notification[], 200>>();
-        expect(listRequests[0].response.raw).toBeInstanceOf(Response);
-        expectTypeOf(listRequests[0].response.raw.json).toEqualTypeOf<() => Promise<Notification[]>>();
-        expect(await listRequests[0].response.raw.json()).toEqual([notification]);
+        expectTypeOf(listHandler.requests[0].response.raw).toEqualTypeOf<HttpResponse<Notification[], 200>>();
+        expect(listHandler.requests[0].response.raw).toBeInstanceOf(Response);
+        expectTypeOf(listHandler.requests[0].response.raw.json).toEqualTypeOf<() => Promise<Notification[]>>();
+        expect(await listHandler.requests[0].response.raw.json()).toEqual([notification]);
 
         await listHandler.clear();
 
@@ -685,8 +684,7 @@ async function declareHttpInterceptorTests(options: ClientTestOptionsByWorkerTyp
         returnedNotifications = (await response.json()) as Notification[];
         expect(returnedNotifications).toEqual([]);
 
-        expect(listRequests).toHaveLength(1);
-        expect(await listHandler.requests()).toHaveLength(0);
+        expect(listHandler.requests).toHaveLength(0);
       });
     });
   });

--- a/apps/zimic-test-client/tests/utils/requests.ts
+++ b/apps/zimic-test-client/tests/utils/requests.ts
@@ -1,0 +1,8 @@
+import { expect } from 'vitest';
+
+export function expectResponseStatus<Response extends globalThis.Response, Status extends Response['status']>(
+  response: Response,
+  status: Status,
+): asserts response is Extract<Response, { status: Status }> {
+  expect(response.status).toBe(status);
+}

--- a/apps/zimic-test-client/vitest.config.mts
+++ b/apps/zimic-test-client/vitest.config.mts
@@ -1,11 +1,7 @@
 /// <reference types="vitest" />
 
-import os from 'os';
 import path from 'path';
 import { defineConfig } from 'vitest/config';
-
-const numberOfCPUs = os.cpus().length;
-const maxWorkers = process.env.CI === 'true' ? numberOfCPUs : Math.ceil(numberOfCPUs / 2);
 
 export default defineConfig({
   publicDir: './public',
@@ -13,8 +9,7 @@ export default defineConfig({
     globals: false,
     testTimeout: 5000,
     minWorkers: 1,
-    maxWorkers,
-    maxConcurrency: maxWorkers,
+    maxWorkers: process.env.CI === 'true' ? '50%' : '25%',
     clearMocks: true,
     coverage: {
       provider: 'istanbul',

--- a/docs/wiki/api‐zimic‐interceptor‐http.md
+++ b/docs/wiki/api‐zimic‐interceptor‐http.md
@@ -11,9 +11,9 @@
     - [Saving requests](#saving-requests)
   - [HTTP `interceptor.start()`](#http-interceptorstart)
   - [HTTP `interceptor.stop()`](#http-interceptorstop)
-  - [HTTP `interceptor.isRunning()`](#http-interceptorisrunning)
-  - [HTTP `interceptor.baseURL()`](#http-interceptorbaseurl)
-  - [HTTP `interceptor.platform()`](#http-interceptorplatform)
+  - [HTTP `interceptor.isRunning`](#http-interceptorisrunning)
+  - [HTTP `interceptor.baseURL`](#http-interceptorbaseurl)
+  - [HTTP `interceptor.platform`](#http-interceptorplatform)
   - [HTTP `interceptor.<method>(path)`](#http-interceptormethodpath)
     - [Path parameters](#path-parameters)
   - [HTTP `interceptor.checkTimes()`](#http-interceptorchecktimes)
@@ -21,8 +21,8 @@
   - [`HttpInterceptor` utility types](#httpinterceptor-utility-types)
     - [`InferHttpInterceptorSchema`](#inferhttpinterceptorschema)
 - [`HttpRequestHandler`](#httprequesthandler)
-  - [HTTP `handler.method()`](#http-handlermethod)
-  - [HTTP `handler.path()`](#http-handlerpath)
+  - [HTTP `handler.method`](#http-handlermethod)
+  - [HTTP `handler.path`](#http-handlerpath)
   - [HTTP `handler.with(restriction)`](#http-handlerwithrestriction)
     - [Static restrictions](#static-restrictions)
     - [Computed restrictions](#computed-restrictions)
@@ -32,7 +32,7 @@
   - [HTTP `handler.times()`](#http-handlertimes)
   - [HTTP `handler.checkTimes()`](#http-handlerchecktimes)
   - [HTTP `handler.clear()`](#http-handlerclear)
-  - [HTTP `handler.requests()`](#http-handlerrequests)
+  - [HTTP `handler.requests`](#http-handlerrequests)
 - [Intercepted HTTP resources](#intercepted-http-resources)
 - [Guides](#guides)
 
@@ -132,7 +132,7 @@ const interceptor = httpInterceptor.create<{
 });
 
 // Your application should use this base URL when making requests
-const baseURL = interceptor.baseURL();
+console.log(interceptor.baseURL);
 ```
 
 #### Unhandled requests
@@ -333,7 +333,7 @@ httpInterceptor.default.remote.onUnhandledRequest = (request) => {
 #### Saving requests
 
 The option `saveRequests` indicates whether [request handlers](#httprequesthandler) should save their intercepted
-requests in memory and make them accessible through [`handler.requests()`](#http-handlerrequests).
+requests in memory and make them accessible through [`handler.requests`](#http-handlerrequests).
 
 This setting is configured per interceptor and is `false` by default. If set to `true`, each handler will keep track of
 their intercepted requests in memory.
@@ -426,28 +426,28 @@ called.
 await interceptor.stop();
 ```
 
-### HTTP `interceptor.isRunning()`
+### HTTP `interceptor.isRunning`
 
-Returns whether the interceptor is currently running and ready to use.
+Whether the interceptor is currently running and ready to use.
 
 ```ts
-const isRunning = interceptor.isRunning();
+const isRunning = interceptor.isRunning;
 ```
 
-### HTTP `interceptor.baseURL()`
+### HTTP `interceptor.baseURL`
 
-Returns the base URL of the interceptor.
+The base URL of the interceptor.
 
 ```ts
-const baseURL = interceptor.baseURL();
+console.log(interceptor.baseURL);
 ```
 
-### HTTP `interceptor.platform()`
+### HTTP `interceptor.platform`
 
-Returns the platform used by the interceptor (`browser` or `node`).
+The platform used by the interceptor (`browser` or `node`).
 
 ```ts
-const platform = interceptor.platform();
+console.log(interceptor.platform);
 ```
 
 ### HTTP `interceptor.<method>(path)`
@@ -694,29 +694,27 @@ correct.
 When multiple handlers match the same method and path, the _last_ created with
 [`interceptor.<method>(path)`](#http-interceptormethodpath) will be used.
 
-### HTTP `handler.method()`
+### HTTP `handler.method`
 
 Returns the method that matches a handler.
 
 <table><tr><td width="900px" valign="top"><details open><summary><b>Using a local interceptor</b></summary>
 
 ```ts
-const creationHandler = interceptor.post('/users');
-const method = creationHandler.method();
-console.log(method); // 'POST'
+const handler = interceptor.post('/users');
+console.log(handler.method); // 'POST'
 ```
 
 </details></td><td width="900px" valign="top"><details open><summary><b>Using a remote interceptor</b></summary>
 
 ```ts
 const handler = await interceptor.post('/users');
-const method = handler.method();
-console.log(method); // 'POST'
+console.log(handler.method); // 'POST'
 ```
 
 </details></td></tr></table>
 
-### HTTP `handler.path()`
+### HTTP `handler.path`
 
 Returns the path that matches a handler. The base URL of the interceptor is not included, but it is used when matching
 requests.
@@ -724,17 +722,15 @@ requests.
 <table><tr><td width="900px" valign="top"><details open><summary><b>Using a local interceptor</b></summary>
 
 ```ts
-const listHandler = interceptor.get('/users');
-const path = listHandler.path();
-console.log(path); // '/users'
+const handler = interceptor.get('/users');
+console.log(handler.path); // '/users'
 ```
 
 </details></td><td width="900px" valign="top"><details open><summary><b>Using a remote interceptor</b></summary>
 
 ```ts
 const handler = await interceptor.get('/users');
-const path = handler.path();
-console.log(path); // '/users'
+console.log(handler.path); // '/users'
 ```
 
 </details></td></tr></table>
@@ -1547,10 +1543,10 @@ const rangeListHandler = await interceptor
 
 > [!TIP]
 >
-> Prior to v0.12.0, a common strategy to check the number of requests was to assert the length of `handler.requests()`.
+> Prior to v0.12.0, a common strategy to check the number of requests was to assert the length of `handler.requests`.
 > [`handler.times()`](#http-handlertimes), combined with [`handler.checkTimes()`](#http-handlerchecktimes) or
 > [`interceptor.checkTimes()`](#http-interceptorchecktimes), archives the same purpose in a shorter and more declarative
-> way. In most cases, these methods are preferred over manually checking the length of `handler.requests()`.
+> way. In most cases, these methods are preferred over manually checking the length of `handler.requests`.
 
 ### HTTP `handler.checkTimes()`
 
@@ -1607,44 +1603,44 @@ To make the handler match requests again, register a new response with `handler.
 <table><tr><td width="900px" valign="top"><details open><summary><b>Using a local interceptor</b></summary>
 
 ```ts
-const genericListHandler = interceptor.get('/users').respond({
+const genericHandler = interceptor.get('/users').respond({
   status: 200,
   body: [],
 });
 
-const specificListHandler = interceptor.get('/users').respond({
+const specificHandler = interceptor.get('/users').respond({
   status: 200,
   body: [{ username: 'me' }],
 });
 
-specificListHandler.clear();
-// Now, requests GET /users will match `genericListHandler` and receive an empty array
+specificHandler.clear();
+// Now, requests GET /users will match `genericHandler` and receive an empty array
 
-specificListHandler.requests(); // Now empty
+console.log(specificHandler.requests); // []
 ```
 
 </details></td><td width="900px" valign="top"><details open><summary><b>Using a remote interceptor</b></summary>
 
 ```ts
-const genericListHandler = await interceptor.get('/users').respond({
+const genericHandler = await interceptor.get('/users').respond({
   status: 200,
   body: [],
 });
 
-const specificListHandler = await interceptor.get('/users').respond({
+const specificHandler = await interceptor.get('/users').respond({
   status: 200,
   body: [{ username: 'me' }],
 });
 
-await specificListHandler.clear();
-// Now, requests GET /users will match `genericListHandler` and receive an empty array
+await specificHandler.clear();
+// Now, requests GET /users will match `genericHandler` and receive an empty array
 
-await specificListHandler.requests(); // Now empty
+console.log(specificHandler.requests); // []
 ```
 
 </details></td></tr></table>
 
-### HTTP `handler.requests()`
+### HTTP `handler.requests`
 
 Returns the intercepted requests that matched this handler, along with the responses returned to each of them. This is
 useful for testing that the correct requests were made by your application. Learn more about the `request` and
@@ -1672,12 +1668,11 @@ await fetch(`http://localhost:3000/users/${1}`, {
   body: JSON.stringify({ username: 'new' }),
 });
 
-const updateRequests = await updateHandler.requests();
-expect(updateRequests).toHaveLength(1);
-expect(updateRequests[0].pathParams).toEqual({ id: '1' });
-expect(updateRequests[0].body).toEqual({ username: 'new' });
-expect(updateRequests[0].response.status).toBe(200);
-expect(updateRequests[0].response.body).toEqual([{ username: 'new' }]);
+expect(updateHandler.requests).toHaveLength(1);
+expect(updateHandler.requests[0].pathParams).toEqual({ id: '1' });
+expect(updateHandler.requests[0].body).toEqual({ username: 'new' });
+expect(updateHandler.requests[0].response.status).toBe(200);
+expect(updateHandler.requests[0].response.body).toEqual([{ username: 'new' }]);
 ```
 
 </details></td><td width="900px" valign="top"><details open><summary><b>Using a remote interceptor</b></summary>
@@ -1697,12 +1692,11 @@ await fetch(`http://localhost:3000/users/${1}`, {
   body: JSON.stringify({ username: 'new' }),
 });
 
-const updateRequests = await updateHandler.requests();
-expect(updateRequests).toHaveLength(1);
-expect(updateRequests[0].pathParams).toEqual({ id: '1' });
-expect(updateRequests[0].body).toEqual({ username: 'new' });
-expect(updateRequests[0].response.status).toBe(200);
-expect(updateRequests[0].response.body).toEqual([{ username: 'new' }]);
+expect(updateHandler.requests).toHaveLength(1);
+expect(updateHandler.requests[0].pathParams).toEqual({ id: '1' });
+expect(updateHandler.requests[0].body).toEqual({ username: 'new' });
+expect(updateHandler.requests[0].response.status).toBe(200);
+expect(updateHandler.requests[0].response.body).toEqual([{ username: 'new' }]);
 ```
 
 </details></td></tr></table>

--- a/docs/wiki/getting‐started‐interceptor.md
+++ b/docs/wiki/getting‐started‐interceptor.md
@@ -207,7 +207,7 @@ use remote interceptors.
     const interceptor = httpInterceptor.create<Schema>({
       type: 'local',
       baseURL: 'http://localhost:3000',
-      saveRequests: true, // Allow access to `handler.requests()`
+      saveRequests: true, // Allow access to `handler.requests`
     });
     ```
 
@@ -220,7 +220,7 @@ use remote interceptors.
       type: 'remote',
       // The interceptor server is at http://localhost:4000
       baseURL: 'http://localhost:4000/my-service',
-      saveRequests: true, // Allow access to `handler.requests()`
+      saveRequests: true, // Allow access to `handler.requests`
     });
     ```
 
@@ -349,39 +349,18 @@ use remote interceptors.
 
     5.2. After your application made requests, check if they are as you expect:
 
-    <table><tr><td width="900px" valign="top"><details open><summary><b>Using a local interceptor</b></summary>
-
     ```ts
     // Your application makes requests...
 
-    const requests = handler.requests();
-    expect(requests).toHaveLength(1);
+    expect(handler.requests).toHaveLength(1);
 
-    expect(requests[0].headers.get('authorization')).toBe('Bearer my-token');
+    expect(handler.requests[0].headers.get('authorization')).toBe('Bearer my-token');
 
-    expect(requests[0].searchParams.size).toBe(1);
-    expect(requests[0].searchParams.get('username')).toBe('my');
+    expect(handler.requests[0].searchParams.size).toBe(1);
+    expect(handler.requests[0].searchParams.get('username')).toBe('my');
 
-    expect(requests[0].body).toBe(null);
+    expect(handler.requests[0].body).toBe(null);
     ```
-
-    </details></td><td width="900px" valign="top"><details open><summary><b>Using a remote interceptor</b></summary>
-
-    ```ts
-    // Your application makes requests...
-
-    const requests = await handler.requests();
-    expect(requests).toHaveLength(1);
-
-    expect(requests[0].headers.get('authorization')).toBe('Bearer my-token');
-
-    expect(requests[0].searchParams.size).toBe(1);
-    expect(requests[0].searchParams.get('username')).toBe('my');
-
-    expect(requests[0].body).toBe(null);
-    ```
-
-    </details></td></tr></table>
 
     NOTE: The code above checks the requests manually. This is optional in this example because the
     [`with`](api‐zimic‐interceptor‐http#http-handlerwithrestriction) and

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.redirects.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.redirects.test.ts
@@ -60,6 +60,7 @@ describe('FetchClient > Redirects', () => {
 
       if (isClientSide()) {
         // In the browser, the response is opaque and the status is 0. No headers are available.
+        // @ts-expect-error The status 0 is not in the schema.
         expectResponseStatus(firstResponse, 0);
         redirectPath = '/redirected';
       } else {

--- a/packages/zimic-fetch/tests/utils/requests.ts
+++ b/packages/zimic-fetch/tests/utils/requests.ts
@@ -1,6 +1,6 @@
 import { expect } from 'vitest';
 
-export function expectResponseStatus<Response extends globalThis.Response, Status extends number>(
+export function expectResponseStatus<Response extends globalThis.Response, Status extends Response['status']>(
   response: Response,
   status: Status,
 ): asserts response is Extract<Response, { status: Status }> {

--- a/packages/zimic-http/src/cli/typegen/__tests__/openapi.node.test.ts
+++ b/packages/zimic-http/src/cli/typegen/__tests__/openapi.node.test.ts
@@ -236,7 +236,7 @@ describe('Type generation (OpenAPI)', () => {
           const inputFilePath = path.join(inputDirectory, `${inputFileNameWithoutExtension}.${fileType}`);
 
           const inputFilePathOrURL = fixtureCase.shouldUseURLAsInput
-            ? joinURL(schemaInterceptor.baseURL(), 'spec', fixtureName)
+            ? joinURL(schemaInterceptor.baseURL, 'spec', fixtureName)
             : inputFilePath;
 
           const bufferedInputFileContent = await filesystem.readFile(inputFilePath);
@@ -315,8 +315,7 @@ describe('Type generation (OpenAPI)', () => {
 
           expect(generatedOutputContent).toBe(expectedOutputContent);
 
-          const schemaRequests = getSchemaHandler.requests();
-          expect(schemaRequests).toHaveLength(fixtureCase.shouldUseURLAsInput ? 1 : 0);
+          expect(getSchemaHandler.requests).toHaveLength(fixtureCase.shouldUseURLAsInput ? 1 : 0);
         });
       }
     });

--- a/packages/zimic-interceptor/README.md
+++ b/packages/zimic-interceptor/README.md
@@ -149,7 +149,7 @@ Check our [getting started guide](https://github.com/zimicjs/zimic/wiki/gettingâ
     const interceptor = httpInterceptor.create<Schema>({
       type: 'local',
       baseURL: 'http://localhost:3000',
-      saveRequests: true, // Allow access to `handler.requests()`
+      saveRequests: true, // Allow access to `handler.requests`
     });
     ```
 
@@ -227,15 +227,14 @@ Check our [getting started guide](https://github.com/zimicjs/zimic/wiki/gettingâ
     test('example', async () => {
       // Your application makes requests...
 
-      const requests = handler.requests();
-      expect(requests).toHaveLength(1);
+      expect(handler.requests).toHaveLength(1);
 
-      expect(requests[0].headers.get('authorization')).toBe('Bearer my-token');
+      expect(handler.requests[0].headers.get('authorization')).toBe('Bearer my-token');
 
-      expect(requests[0].searchParams.size).toBe(1);
-      expect(requests[0].searchParams.get('username')).toBe('my');
+      expect(handler.requests[0].searchParams.size).toBe(1);
+      expect(handler.requests[0].searchParams.get('username')).toBe('my');
 
-      expect(requests[0].body).toBe(null);
+      expect(handler.requests[0].body).toBe(null);
     });
     ```
 

--- a/packages/zimic-interceptor/src/cli/server/__tests__/server.node.test.ts
+++ b/packages/zimic-interceptor/src/cli/server/__tests__/server.node.test.ts
@@ -145,9 +145,9 @@ describe('CLI (server)', async () => {
         await runCLI();
 
         expect(server).toBeDefined();
-        expect(server!.isRunning()).toBe(true);
-        expect(server!.hostname()).toBe('localhost');
-        expect(server!.port()).toBe(6500);
+        expect(server!.isRunning).toBe(true);
+        expect(server!.hostname).toBe('localhost');
+        expect(server!.port).toBe(6500);
 
         expect(spies.log).toHaveBeenCalledTimes(1);
         expect(spies.log).toHaveBeenCalledWith(
@@ -173,9 +173,9 @@ describe('CLI (server)', async () => {
         await runCLI();
 
         expect(server).toBeDefined();
-        expect(server!.isRunning()).toBe(true);
-        expect(server!.hostname()).toBe('0.0.0.0');
-        expect(server!.port()).toBe(3000);
+        expect(server!.isRunning).toBe(true);
+        expect(server!.hostname).toBe('0.0.0.0');
+        expect(server!.port).toBe(3000);
 
         expect(spies.log).toHaveBeenCalledTimes(1);
         expect(spies.log).toHaveBeenCalledWith(
@@ -192,14 +192,14 @@ describe('CLI (server)', async () => {
         await runCLI();
 
         expect(server).toBeDefined();
-        expect(server!.isRunning()).toBe(true);
-        expect(server!.hostname()).toBe('localhost');
-        expect(server!.port()).toBeGreaterThan(0);
+        expect(server!.isRunning).toBe(true);
+        expect(server!.hostname).toBe('localhost');
+        expect(server!.port).toBeGreaterThan(0);
 
         expect(spies.log).toHaveBeenCalledTimes(1);
         expect(spies.log).toHaveBeenCalledWith(
           chalk.cyan('[@zimic/interceptor]'),
-          `Server is running on http://localhost:${server!.port()}`,
+          `Server is running on http://localhost:${server!.port}`,
         );
       });
     });
@@ -241,9 +241,9 @@ describe('CLI (server)', async () => {
         const initialServer = server;
 
         expect(initialServer).toBeDefined();
-        expect(initialServer!.isRunning()).toBe(true);
-        expect(initialServer!.hostname()).toBe('0.0.0.0');
-        expect(initialServer!.port()).toBe(3000);
+        expect(initialServer!.isRunning).toBe(true);
+        expect(initialServer!.hostname).toBe('0.0.0.0');
+        expect(initialServer!.port).toBe(3000);
 
         try {
           await expect(runCLI()).rejects.toThrowError('EADDRINUSE: address already in use');
@@ -309,14 +309,14 @@ describe('CLI (server)', async () => {
         await runCLI();
 
         expect(server).toBeDefined();
-        expect(server!.isRunning()).toBe(false);
-        expect(server!.hostname()).toBe('localhost');
-        expect(server!.port()).toBeGreaterThan(0);
+        expect(server!.isRunning).toBe(false);
+        expect(server!.hostname).toBe('localhost');
+        expect(server!.port).toBeGreaterThan(0);
 
         expect(spies.log).toHaveBeenCalledTimes(1);
         expect(spies.log).toHaveBeenCalledWith(
           chalk.cyan('[@zimic/interceptor]'),
-          `Ephemeral server is running on http://localhost:${server!.port()}`,
+          `Ephemeral server is running on http://localhost:${server!.port}`,
         );
 
         const savedFile = await filesystem.readFile(temporarySaveFile, 'utf-8');
@@ -353,14 +353,14 @@ describe('CLI (server)', async () => {
           await runCLI();
 
           expect(server).toBeDefined();
-          expect(server!.isRunning()).toBe(true);
-          expect(server!.hostname()).toBe('localhost');
-          expect(server!.port()).toBeGreaterThan(0);
+          expect(server!.isRunning).toBe(true);
+          expect(server!.hostname).toBe('localhost');
+          expect(server!.port).toBeGreaterThan(0);
 
           expect(spies.log).toHaveBeenCalledTimes(1);
           expect(spies.log).toHaveBeenCalledWith(
             chalk.cyan('[@zimic/interceptor]'),
-            `Server is running on http://localhost:${server!.port()}`,
+            `Server is running on http://localhost:${server!.port}`,
           );
 
           const savedFile = await filesystem.readFile(temporarySaveFile, 'utf-8');
@@ -533,14 +533,14 @@ describe('CLI (server)', async () => {
           await runCLI();
 
           expect(server).toBeDefined();
-          expect(server!.isRunning()).toBe(true);
-          expect(server!.hostname()).toBe('localhost');
-          expect(server!.port()).toBeGreaterThan(0);
+          expect(server!.isRunning).toBe(true);
+          expect(server!.hostname).toBe('localhost');
+          expect(server!.port).toBeGreaterThan(0);
 
           expect(spies.log).toHaveBeenCalledTimes(1);
           expect(spies.log).toHaveBeenCalledWith(
             chalk.cyan('[@zimic/interceptor]'),
-            `Server is running on http://localhost:${server!.port()}`,
+            `Server is running on http://localhost:${server!.port}`,
           );
 
           expect(exitEventListeners).toHaveLength(1);
@@ -549,7 +549,7 @@ describe('CLI (server)', async () => {
             await listener();
           }
 
-          expect(server!.isRunning()).toBe(false);
+          expect(server!.isRunning).toBe(false);
 
           const exitCode = PROCESS_EXIT_CODE_BY_EXIT_EVENT[exitEvent];
           if (exitCode === undefined) {
@@ -574,28 +574,28 @@ describe('CLI (server)', async () => {
         await runCLI();
 
         expect(server).toBeDefined();
-        expect(server!.isRunning()).toBe(true);
-        expect(server!.hostname()).toBe('localhost');
-        expect(server!.port()).toBeGreaterThan(0);
+        expect(server!.isRunning).toBe(true);
+        expect(server!.hostname).toBe('localhost');
+        expect(server!.port).toBeGreaterThan(0);
 
         expect(spies.log).toHaveBeenCalledTimes(1);
         expect(spies.log).toHaveBeenCalledWith(
           chalk.cyan('[@zimic/interceptor]'),
-          `Server is running on http://localhost:${server!.port()}`,
+          `Server is running on http://localhost:${server!.port}`,
         );
 
         const webSocketClient = new WebSocketClient({
-          url: `ws://localhost:${server!.port()}`,
+          url: `ws://localhost:${server!.port}`,
         });
 
         try {
           await webSocketClient.start();
-          expect(webSocketClient.isRunning()).toBe(true);
+          expect(webSocketClient.isRunning).toBe(true);
 
           await server?.stop();
 
-          expect(server!.isRunning()).toBe(false);
-          expect(webSocketClient.isRunning()).toBe(false);
+          expect(server!.isRunning).toBe(false);
+          expect(webSocketClient.isRunning).toBe(false);
         } finally {
           await webSocketClient.stop();
         }
@@ -617,10 +617,10 @@ describe('CLI (server)', async () => {
           await runCLI();
 
           expect(server).toBeDefined();
-          expect(server!.isRunning()).toBe(true);
-          expect(server!.hostname()).toBe('localhost');
-          expect(server!.port()).toBeGreaterThan(0);
-          expect(server!.logUnhandledRequests()).toBe(true);
+          expect(server!.isRunning).toBe(true);
+          expect(server!.hostname).toBe('localhost');
+          expect(server!.port).toBeGreaterThan(0);
+          expect(server!.logUnhandledRequests).toBe(true);
 
           expect(spies.log).toHaveBeenCalledTimes(1);
           expect(spies.warn).toHaveBeenCalledTimes(0);
@@ -628,10 +628,10 @@ describe('CLI (server)', async () => {
 
           expect(spies.log).toHaveBeenCalledWith(
             chalk.cyan('[@zimic/interceptor]'),
-            `Server is running on http://localhost:${server!.port()}`,
+            `Server is running on http://localhost:${server!.port}`,
           );
 
-          const request = new Request(`http://localhost:${server!.port()}`);
+          const request = new Request(`http://localhost:${server!.port}`);
 
           const response = fetch(request);
           await expectFetchError(response);
@@ -666,10 +666,10 @@ describe('CLI (server)', async () => {
           await runCLI();
 
           expect(server).toBeDefined();
-          expect(server!.isRunning()).toBe(true);
-          expect(server!.hostname()).toBe('localhost');
-          expect(server!.port()).toBeGreaterThan(0);
-          expect(server!.logUnhandledRequests()).toBe(false);
+          expect(server!.isRunning).toBe(true);
+          expect(server!.hostname).toBe('localhost');
+          expect(server!.port).toBeGreaterThan(0);
+          expect(server!.logUnhandledRequests).toBe(false);
 
           expect(spies.log).toHaveBeenCalledTimes(1);
           expect(spies.warn).toHaveBeenCalledTimes(0);
@@ -677,10 +677,10 @@ describe('CLI (server)', async () => {
 
           expect(spies.log).toHaveBeenCalledWith(
             chalk.cyan('[@zimic/interceptor]'),
-            `Server is running on http://localhost:${server!.port()}`,
+            `Server is running on http://localhost:${server!.port}`,
           );
 
-          const request = new Request(`http://localhost:${server!.port()}`);
+          const request = new Request(`http://localhost:${server!.port}`);
 
           const response = fetch(request);
           await expectFetchError(response);
@@ -716,9 +716,9 @@ describe('CLI (server)', async () => {
         await runCLI();
 
         expect(server).toBeDefined();
-        expect(server!.isRunning()).toBe(true);
-        expect(server!.hostname()).toBe('localhost');
-        expect(server!.port()).toBe(5001);
+        expect(server!.isRunning).toBe(true);
+        expect(server!.hostname).toBe('localhost');
+        expect(server!.port).toBe(5001);
 
         const webSocketServerRequestSpy = vi.spyOn(WebSocketServer.prototype, 'request');
 
@@ -733,7 +733,7 @@ describe('CLI (server)', async () => {
           const responsePromise = fetch(request);
           await expectFetchError(responsePromise);
 
-          expect(server!.isRunning()).toBe(true);
+          expect(server!.isRunning).toBe(true);
 
           expect(spies.error).toHaveBeenCalledTimes(2);
           expect(spies.error.mock.calls[0]).toEqual([error]);
@@ -775,13 +775,13 @@ describe('CLI (server)', async () => {
         await runCLI();
 
         expect(server).toBeDefined();
-        expect(server!.isRunning()).toBe(true);
-        expect(server!.hostname()).toBe('localhost');
-        expect(server!.port()).toBe(5001);
+        expect(server!.isRunning).toBe(true);
+        expect(server!.hostname).toBe('localhost');
+        expect(server!.port).toBe(5001);
 
         try {
           await interceptor.start();
-          expect(interceptor.isRunning()).toBe(true);
+          expect(interceptor.isRunning).toBe(true);
 
           let responseFactoryPromise: Promise<{ status: 204 }> | undefined;
 
@@ -800,7 +800,7 @@ describe('CLI (server)', async () => {
           });
 
           await interceptor.stop();
-          expect(interceptor.isRunning()).toBe(false);
+          expect(interceptor.isRunning).toBe(false);
 
           // Wait for request to fail due to stopped interceptor
           await responsePromise;
@@ -842,13 +842,13 @@ describe('CLI (server)', async () => {
         await runCLI();
 
         expect(server).toBeDefined();
-        expect(server!.isRunning()).toBe(true);
-        expect(server!.hostname()).toBe('localhost');
-        expect(server!.port()).toBe(5001);
+        expect(server!.isRunning).toBe(true);
+        expect(server!.hostname).toBe('localhost');
+        expect(server!.port).toBe(5001);
 
         try {
           await interceptor.start();
-          expect(interceptor.isRunning()).toBe(true);
+          expect(interceptor.isRunning).toBe(true);
 
           let wasResponseFactoryCalled = false;
 
@@ -873,7 +873,7 @@ describe('CLI (server)', async () => {
 
           // @ts-expect-error Force the internal web socket client to stop.
           // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-          await interceptor._client.worker._webSocketClient.stop();
+          await interceptor.client.worker.webSocketClient.stop();
 
           await responsePromise;
 

--- a/packages/zimic-interceptor/src/cli/server/start.ts
+++ b/packages/zimic-interceptor/src/cli/server/start.ts
@@ -59,7 +59,7 @@ async function startInterceptorServer({
 
   await server.start();
 
-  logWithPrefix(`${ephemeral ? 'Ephemeral s' : 'S'}erver is running on ${server.httpURL()}`);
+  logWithPrefix(`${ephemeral ? 'Ephemeral s' : 'S'}erver is running on ${server.httpURL}`);
 
   if (onReady) {
     try {

--- a/packages/zimic-interceptor/src/http/interceptor/HttpInterceptorStore.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/HttpInterceptorStore.ts
@@ -16,7 +16,7 @@ class HttpInterceptorStore {
 
   private class = HttpInterceptorStore;
 
-  localWorker() {
+  get localWorker() {
     return this.class._localWorker;
   }
 
@@ -24,7 +24,7 @@ class HttpInterceptorStore {
     return this.class.remoteWorkers.get(baseURL.origin);
   }
 
-  numberOfRunningLocalInterceptors() {
+  get numberOfRunningLocalInterceptors() {
     return this.class.runningLocalInterceptors.size;
   }
 

--- a/packages/zimic-interceptor/src/http/interceptor/LocalHttpInterceptor.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/LocalHttpInterceptor.ts
@@ -13,7 +13,8 @@ class LocalHttpInterceptor<Schema extends HttpSchema> implements PublicLocalHttp
   readonly type: 'local';
 
   private store = new HttpInterceptorStore();
-  private _client: HttpInterceptorClient<Schema>;
+
+  client: HttpInterceptorClient<Schema>;
 
   constructor(options: LocalHttpInterceptorOptions) {
     this.type = options.type;
@@ -24,7 +25,7 @@ class LocalHttpInterceptor<Schema extends HttpSchema> implements PublicLocalHttp
 
     const worker = this.store.getOrCreateLocalWorker({});
 
-    this._client = new HttpInterceptorClient<Schema>({
+    this.client = new HttpInterceptorClient<Schema>({
       worker,
       store: this.store,
       baseURL,
@@ -34,73 +35,69 @@ class LocalHttpInterceptor<Schema extends HttpSchema> implements PublicLocalHttp
     });
   }
 
-  client() {
-    return this._client;
+  get baseURL() {
+    return this.client.baseURLAsString;
   }
 
-  baseURL() {
-    return this._client.baseURL();
+  get platform() {
+    return this.client.platform;
   }
 
-  platform() {
-    return this._client.platform();
-  }
-
-  isRunning() {
-    return this._client.isRunning();
+  get isRunning() {
+    return this.client.isRunning;
   }
 
   async start() {
-    if (this.isRunning()) {
+    if (this.isRunning) {
       return;
     }
 
-    await this._client.start();
+    await this.client.start();
   }
 
   async stop() {
-    if (!this.isRunning()) {
+    if (!this.isRunning) {
       return;
     }
 
     this.clear();
-    await this._client.stop();
+    await this.client.stop();
   }
 
   get = ((path: HttpSchemaPath<Schema, HttpSchemaMethod<Schema>>) => {
-    return this._client.get(path);
+    return this.client.get(path);
   }) as unknown as SyncHttpInterceptorMethodHandler<Schema, 'GET'>;
 
   post = ((path: HttpSchemaPath<Schema, HttpSchemaMethod<Schema>>) => {
-    return this._client.post(path);
+    return this.client.post(path);
   }) as unknown as SyncHttpInterceptorMethodHandler<Schema, 'POST'>;
 
   patch = ((path: HttpSchemaPath<Schema, HttpSchemaMethod<Schema>>) => {
-    return this._client.patch(path);
+    return this.client.patch(path);
   }) as unknown as SyncHttpInterceptorMethodHandler<Schema, 'PATCH'>;
 
   put = ((path: HttpSchemaPath<Schema, HttpSchemaMethod<Schema>>) => {
-    return this._client.put(path);
+    return this.client.put(path);
   }) as unknown as SyncHttpInterceptorMethodHandler<Schema, 'PUT'>;
 
   delete = ((path: HttpSchemaPath<Schema, HttpSchemaMethod<Schema>>) => {
-    return this._client.delete(path);
+    return this.client.delete(path);
   }) as unknown as SyncHttpInterceptorMethodHandler<Schema, 'DELETE'>;
 
   head = ((path: HttpSchemaPath<Schema, HttpSchemaMethod<Schema>>) => {
-    return this._client.head(path);
+    return this.client.head(path);
   }) as unknown as SyncHttpInterceptorMethodHandler<Schema, 'HEAD'>;
 
   options = ((path: HttpSchemaPath<Schema, HttpSchemaMethod<Schema>>) => {
-    return this._client.options(path);
+    return this.client.options(path);
   }) as unknown as SyncHttpInterceptorMethodHandler<Schema, 'OPTIONS'>;
 
   checkTimes() {
-    this._client.checkTimes();
+    this.client.checkTimes();
   }
 
   clear() {
-    this._client.clear();
+    this.client.clear();
   }
 }
 

--- a/packages/zimic-interceptor/src/http/interceptor/RemoteHttpInterceptor.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/RemoteHttpInterceptor.ts
@@ -13,7 +13,8 @@ class RemoteHttpInterceptor<Schema extends HttpSchema> implements PublicRemoteHt
   readonly type: 'remote';
 
   private store = new HttpInterceptorStore();
-  private _client: HttpInterceptorClient<Schema, typeof RemoteHttpRequestHandler>;
+
+  client: HttpInterceptorClient<Schema, typeof RemoteHttpRequestHandler>;
 
   constructor(options: RemoteHttpInterceptorOptions) {
     this.type = options.type;
@@ -26,7 +27,7 @@ class RemoteHttpInterceptor<Schema extends HttpSchema> implements PublicRemoteHt
 
     const worker = this.store.getOrCreateRemoteWorker({ serverURL });
 
-    this._client = new HttpInterceptorClient<Schema, typeof RemoteHttpRequestHandler>({
+    this.client = new HttpInterceptorClient<Schema, typeof RemoteHttpRequestHandler>({
       worker,
       store: this.store,
       baseURL,
@@ -36,71 +37,67 @@ class RemoteHttpInterceptor<Schema extends HttpSchema> implements PublicRemoteHt
     });
   }
 
-  client() {
-    return this._client;
+  get baseURL() {
+    return this.client.baseURLAsString;
   }
 
-  baseURL() {
-    return this._client.baseURL();
+  get platform() {
+    return this.client.platform;
   }
 
-  platform() {
-    return this._client.platform();
-  }
-
-  isRunning() {
-    return this._client.isRunning();
+  get isRunning() {
+    return this.client.isRunning;
   }
 
   async start() {
-    if (this.isRunning()) {
+    if (this.isRunning) {
       return;
     }
 
-    await this._client.start();
+    await this.client.start();
   }
 
   async stop() {
-    if (!this.isRunning()) {
+    if (!this.isRunning) {
       return;
     }
 
     await this.clear();
-    await this._client.stop();
+    await this.client.stop();
   }
 
   get = ((path: HttpSchemaPath<Schema, HttpSchemaMethod<Schema>>) => {
-    return this._client.get(path);
+    return this.client.get(path);
   }) as unknown as AsyncHttpInterceptorMethodHandler<Schema, 'GET'>;
 
   post = ((path: HttpSchemaPath<Schema, HttpSchemaMethod<Schema>>) => {
-    return this._client.post(path);
+    return this.client.post(path);
   }) as unknown as AsyncHttpInterceptorMethodHandler<Schema, 'POST'>;
 
   patch = ((path: HttpSchemaPath<Schema, HttpSchemaMethod<Schema>>) => {
-    return this._client.patch(path);
+    return this.client.patch(path);
   }) as unknown as AsyncHttpInterceptorMethodHandler<Schema, 'PATCH'>;
 
   put = ((path: HttpSchemaPath<Schema, HttpSchemaMethod<Schema>>) => {
-    return this._client.put(path);
+    return this.client.put(path);
   }) as unknown as AsyncHttpInterceptorMethodHandler<Schema, 'PUT'>;
 
   delete = ((path: HttpSchemaPath<Schema, HttpSchemaMethod<Schema>>) => {
-    return this._client.delete(path);
+    return this.client.delete(path);
   }) as unknown as AsyncHttpInterceptorMethodHandler<Schema, 'DELETE'>;
 
   head = ((path: HttpSchemaPath<Schema, HttpSchemaMethod<Schema>>) => {
-    return this._client.head(path);
+    return this.client.head(path);
   }) as unknown as AsyncHttpInterceptorMethodHandler<Schema, 'HEAD'>;
 
   options = ((path: HttpSchemaPath<Schema, HttpSchemaMethod<Schema>>) => {
-    return this._client.options(path);
+    return this.client.options(path);
   }) as unknown as AsyncHttpInterceptorMethodHandler<Schema, 'OPTIONS'>;
 
   checkTimes() {
     return new Promise<void>((resolve, reject) => {
       try {
-        this._client.checkTimes();
+        this.client.checkTimes();
         resolve();
       } catch (error) {
         reject(error);
@@ -110,7 +107,7 @@ class RemoteHttpInterceptor<Schema extends HttpSchema> implements PublicRemoteHt
 
   async clear() {
     await new Promise<void>((resolve, reject) => {
-      this._client.clear({
+      this.client.clear({
         onCommitSuccess: resolve,
         onCommitError: reject,
       });

--- a/packages/zimic-interceptor/src/http/interceptor/__tests__/HttpInterceptor.handlers.browser.test.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/__tests__/HttpInterceptor.handlers.browser.test.ts
@@ -5,7 +5,7 @@ import { getBrowserBaseURL } from '@tests/utils/interceptors';
 import { declareHandlerHttpInterceptorTests } from './shared/handlers';
 import testMatrix from './shared/matrix';
 
-describe.each(testMatrix)('HttpInterceptor (browser, $type) > Bypass', async ({ type }) => {
+describe.each(testMatrix)('HttpInterceptor (browser, $type) > Handlers', async ({ type }) => {
   let baseURL: URL;
 
   beforeAll(async () => {

--- a/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/baseURLs.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/baseURLs.ts
@@ -36,21 +36,19 @@ export function declareBaseURLHttpInterceptorTests(options: RuntimeSharedHttpInt
           };
         };
       }>({ ...interceptorOptions, baseURL }, async (interceptor) => {
-        expect(interceptor.baseURL()).toBe(baseURL.replace(/\/$/, ''));
+        expect(interceptor.baseURL).toBe(baseURL.replace(/\/$/, ''));
 
         const handler = await promiseIfRemote(interceptor.get(path).respond({ status: 200 }), interceptor);
 
-        let requests = await handler.requests();
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
         const url = joinURL(baseURL, path);
 
         const response = await fetch(url, { method: 'GET' });
         expect(response.status).toBe(200);
 
-        requests = await handler.requests();
-        expect(requests).toHaveLength(1);
-        const [request] = requests;
+        expect(handler.requests).toHaveLength(1);
+        const [request] = handler.requests;
         expect(request).toBeInstanceOf(Request);
 
         expectTypeOf(request.body).toEqualTypeOf<null>();

--- a/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/bodies/blob.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/bodies/blob.ts
@@ -114,8 +114,7 @@ export async function declareBlobBodyHttpInterceptorTests(options: RuntimeShared
         );
         expect(handler).toBeInstanceOf(Handler);
 
-        let requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
         const requestFile = await createRandomFile(contentType);
 
@@ -132,9 +131,8 @@ export async function declareBlobBodyHttpInterceptorTests(options: RuntimeShared
         expect(fetchedFile.size).toBe(responseFile.size);
         expect(await fetchedFile.text()).toEqual(await responseFile.text());
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(1);
-        const [request] = requests;
+        expect(handler.requests).toHaveLength(1);
+        const [request] = handler.requests;
 
         expect(request).toBeInstanceOf(Request);
         expect(request.headers.get('content-type')).toBe(contentType);
@@ -211,8 +209,7 @@ export async function declareBlobBodyHttpInterceptorTests(options: RuntimeShared
         );
         expect(handler).toBeInstanceOf(Handler);
 
-        let requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
         const response = await fetch(joinURL(baseURL, `/users/${users[0].id}`), {
           method,
@@ -224,9 +221,8 @@ export async function declareBlobBodyHttpInterceptorTests(options: RuntimeShared
         expect(fetchedFile).toBeInstanceOf(Blob);
         expect(fetchedFile.size).toBe(0);
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(1);
-        const [request] = requests;
+        expect(handler.requests).toHaveLength(1);
+        const [request] = handler.requests;
 
         expect(request).toBeInstanceOf(Request);
         expect(request.headers.get('content-type')).toBe('application/octet-stream');
@@ -284,8 +280,7 @@ export async function declareBlobBodyHttpInterceptorTests(options: RuntimeShared
         );
         expect(handler).toBeInstanceOf(Handler);
 
-        let requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
         const requestBuffer = new ArrayBuffer(2);
         const requestView = new Uint8Array(requestBuffer);
@@ -305,9 +300,8 @@ export async function declareBlobBodyHttpInterceptorTests(options: RuntimeShared
         expect(fetchedFile.size).toBe(2);
         expect(await fetchedFile.arrayBuffer()).toEqual(responseBuffer);
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(1);
-        const [request] = requests;
+        expect(handler.requests).toHaveLength(1);
+        const [request] = handler.requests;
 
         expect(request).toBeInstanceOf(Request);
         expect(request.headers.get('content-type')).toBe('application/octet-stream');

--- a/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/bodies/formData.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/bodies/formData.ts
@@ -95,8 +95,7 @@ export async function declareFormDataBodyHttpInterceptorTests(options: RuntimeSh
         );
         expect(handler).toBeInstanceOf(Handler);
 
-        let requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
         const formData = new HttpFormData<UserFormDataSchema>();
         const requestTagFile = new File(['request'], 'tag.txt', { type: 'text/plain' });
@@ -115,9 +114,8 @@ export async function declareFormDataBodyHttpInterceptorTests(options: RuntimeSh
         const fetchedTagFile = fetchedFormData.get('tag')!;
         expect(fetchedTagFile).toEqual(responseTagFile);
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(1);
-        const [request] = requests;
+        expect(handler.requests).toHaveLength(1);
+        const [request] = handler.requests;
 
         expect(request).toBeInstanceOf(Request);
         expect(request.headers.get('content-type')).toMatch(/^multipart\/form-data; boundary=.+$/);
@@ -206,8 +204,7 @@ export async function declareFormDataBodyHttpInterceptorTests(options: RuntimeSh
         );
         expect(handler).toBeInstanceOf(Handler);
 
-        let requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
         await usingIgnoredConsole(['error'], async (spies) => {
           const response = await fetch(joinURL(baseURL, `/users/${users[0].id}`), {
@@ -224,9 +221,8 @@ export async function declareFormDataBodyHttpInterceptorTests(options: RuntimeSh
           ]);
         });
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(1);
-        const [request] = requests;
+        expect(handler.requests).toHaveLength(1);
+        const [request] = handler.requests;
 
         expect(request).toBeInstanceOf(Request);
         expect(request.headers.get('content-type')).toBe('multipart/form-data');
@@ -276,8 +272,7 @@ export async function declareFormDataBodyHttpInterceptorTests(options: RuntimeSh
         );
         expect(handler).toBeInstanceOf(Handler);
 
-        let requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
         const response = await fetch(joinURL(baseURL, `/users/${users[0].id}`), {
           method,
@@ -288,9 +283,8 @@ export async function declareFormDataBodyHttpInterceptorTests(options: RuntimeSh
         const fetchedFormData = await response.text();
         expect(fetchedFormData).toBe('');
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(1);
-        const [request] = requests;
+        expect(handler.requests).toHaveLength(1);
+        const [request] = handler.requests;
 
         expect(request).toBeInstanceOf(Request);
         expect(request.headers.get('content-type')).toBe('multipart/form-data');

--- a/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/bodies/json.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/bodies/json.ts
@@ -89,8 +89,7 @@ export async function declareJSONBodyHttpInterceptorTests(options: RuntimeShared
         );
         expect(handler).toBeInstanceOf(Handler);
 
-        let requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
         const response = await fetch(joinURL(baseURL, `/users/${users[0].id}`), {
           method,
@@ -102,9 +101,8 @@ export async function declareJSONBodyHttpInterceptorTests(options: RuntimeShared
         const fetchedUser = (await response.json()) as UserAsType;
         expect(fetchedUser).toEqual(users[0]);
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(1);
-        const [request] = requests;
+        expect(handler.requests).toHaveLength(1);
+        const [request] = handler.requests;
 
         expect(request).toBeInstanceOf(Request);
         expect(request.headers.get('content-type')).toBe('application/json');
@@ -173,8 +171,7 @@ export async function declareJSONBodyHttpInterceptorTests(options: RuntimeShared
         );
         expect(handler).toBeInstanceOf(Handler);
 
-        let requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
         const response = await fetch(joinURL(baseURL, `/users/${users[0].id}`), {
           method,
@@ -186,9 +183,8 @@ export async function declareJSONBodyHttpInterceptorTests(options: RuntimeShared
         const fetchedUser = (await response.json()) as UserAsInterface;
         expect(fetchedUser).toEqual(users[0]);
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(1);
-        const [request] = requests;
+        expect(handler.requests).toHaveLength(1);
+        const [request] = handler.requests;
 
         expect(request).toBeInstanceOf(Request);
         expect(request.headers.get('content-type')).toBe('application/json');
@@ -274,8 +270,7 @@ export async function declareJSONBodyHttpInterceptorTests(options: RuntimeShared
         );
         expect(handler).toBeInstanceOf(Handler);
 
-        let requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
         const response = await fetch(joinURL(baseURL, `/users/${users[0].id}`), {
           method,
@@ -287,9 +282,8 @@ export async function declareJSONBodyHttpInterceptorTests(options: RuntimeShared
         const fetchedUser = (await response.json()) as UserAsInterface;
         expect(fetchedUser).toEqual({ ...users[0], date: responseDate });
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(1);
-        const [request] = requests;
+        expect(handler.requests).toHaveLength(1);
+        const [request] = handler.requests;
 
         expect(request).toBeInstanceOf(Request);
         expect(request.headers.get('content-type')).toBe('application/json');
@@ -368,8 +362,7 @@ export async function declareJSONBodyHttpInterceptorTests(options: RuntimeShared
         );
         expect(handler).toBeInstanceOf(Handler);
 
-        let requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
         const response = await fetch(joinURL(baseURL, `/users/${users[0].id}`), {
           method,
@@ -381,9 +374,8 @@ export async function declareJSONBodyHttpInterceptorTests(options: RuntimeShared
         const fetchedBody = (await response.json()) as number;
         expect(fetchedBody).toBe(2);
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(1);
-        const [request] = requests;
+        expect(handler.requests).toHaveLength(1);
+        const [request] = handler.requests;
 
         expect(request).toBeInstanceOf(Request);
         expect(request.headers.get('content-type')).toBe('application/json');
@@ -452,8 +444,7 @@ export async function declareJSONBodyHttpInterceptorTests(options: RuntimeShared
         );
         expect(handler).toBeInstanceOf(Handler);
 
-        let requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
         const response = await fetch(joinURL(baseURL, `/users/${users[0].id}`), {
           method,
@@ -465,9 +456,8 @@ export async function declareJSONBodyHttpInterceptorTests(options: RuntimeShared
         const fetchedBody = (await response.json()) as boolean;
         expect(fetchedBody).toBe(false);
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(1);
-        const [request] = requests;
+        expect(handler.requests).toHaveLength(1);
+        const [request] = handler.requests;
 
         expect(request).toBeInstanceOf(Request);
         expect(request.headers.get('content-type')).toBe('application/json');
@@ -540,8 +530,7 @@ export async function declareJSONBodyHttpInterceptorTests(options: RuntimeShared
         );
         expect(handler).toBeInstanceOf(Handler);
 
-        let requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
         const response = await fetch(joinURL(baseURL, `/users/${users[0].id}`), {
           method,
@@ -553,9 +542,8 @@ export async function declareJSONBodyHttpInterceptorTests(options: RuntimeShared
         const fetchedUser = (await response.json()) as UserAsType;
         expect(fetchedUser).toEqual(users[0]);
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(1);
-        const [request] = requests;
+        expect(handler.requests).toHaveLength(1);
+        const [request] = handler.requests;
 
         expect(request).toBeInstanceOf(Request);
         expect(request.headers.get('content-type')).toBe('');
@@ -606,8 +594,7 @@ export async function declareJSONBodyHttpInterceptorTests(options: RuntimeShared
         );
         expect(handler).toBeInstanceOf(Handler);
 
-        let requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
         const response = await fetch(joinURL(baseURL, `/users/${users[0].id}`), {
           method,
@@ -619,9 +606,8 @@ export async function declareJSONBodyHttpInterceptorTests(options: RuntimeShared
         const fetchedBody = await response.text();
         expect(fetchedBody).toBe(invalidResponseJSONString);
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(1);
-        const [request] = requests;
+        expect(handler.requests).toHaveLength(1);
+        const [request] = handler.requests;
 
         expect(request).toBeInstanceOf(Request);
         expect(request.headers.get('content-type')).toBe('');
@@ -672,8 +658,7 @@ export async function declareJSONBodyHttpInterceptorTests(options: RuntimeShared
         );
         expect(handler).toBeInstanceOf(Handler);
 
-        let requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
         const response = await fetch(joinURL(baseURL, `/users/${users[0].id}`), {
           method,
@@ -685,9 +670,8 @@ export async function declareJSONBodyHttpInterceptorTests(options: RuntimeShared
         const fetchedUser = (await response.json()) as UserAsType;
         expect(fetchedUser).toEqual(users[0]);
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(1);
-        const [request] = requests;
+        expect(handler.requests).toHaveLength(1);
+        const [request] = handler.requests;
 
         expect(request).toBeInstanceOf(Request);
         expect(request.headers.get('content-type')).toBe('unknown');
@@ -738,8 +722,7 @@ export async function declareJSONBodyHttpInterceptorTests(options: RuntimeShared
         );
         expect(handler).toBeInstanceOf(Handler);
 
-        let requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
         const response = await fetch(joinURL(baseURL, `/users/${users[0].id}`), {
           method,
@@ -751,9 +734,8 @@ export async function declareJSONBodyHttpInterceptorTests(options: RuntimeShared
         const fetchedBody = await response.text();
         expect(fetchedBody).toBe(invalidResponseJSONString);
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(1);
-        const [request] = requests;
+        expect(handler.requests).toHaveLength(1);
+        const [request] = handler.requests;
 
         expect(request).toBeInstanceOf(Request);
         expect(request.headers.get('content-type')).toBe('unknown');
@@ -804,8 +786,7 @@ export async function declareJSONBodyHttpInterceptorTests(options: RuntimeShared
         );
         expect(handler).toBeInstanceOf(Handler);
 
-        let requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
         await usingIgnoredConsole(['error'], async (spies) => {
           const response = await fetch(joinURL(baseURL, `/users/${users[0].id}`), {
@@ -825,9 +806,8 @@ export async function declareJSONBodyHttpInterceptorTests(options: RuntimeShared
           ]);
         });
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(1);
-        const [request] = requests;
+        expect(handler.requests).toHaveLength(1);
+        const [request] = handler.requests;
 
         expect(request).toBeInstanceOf(Request);
         expect(request.headers.get('content-type')).toBe('application/json');
@@ -877,8 +857,7 @@ export async function declareJSONBodyHttpInterceptorTests(options: RuntimeShared
         );
         expect(handler).toBeInstanceOf(Handler);
 
-        let requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
         const response = await fetch(joinURL(baseURL, `/users/${users[0].id}`), {
           method,
@@ -889,9 +868,8 @@ export async function declareJSONBodyHttpInterceptorTests(options: RuntimeShared
         const fetchedBody = await response.text();
         expect(fetchedBody).toBe('');
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(1);
-        const [request] = requests;
+        expect(handler.requests).toHaveLength(1);
+        const [request] = handler.requests;
 
         expect(request).toBeInstanceOf(Request);
         expect(request.headers.get('content-type')).toBe('application/json');

--- a/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/bodies/plainText.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/bodies/plainText.ts
@@ -72,8 +72,7 @@ export async function declarePlainTextBodyHttpInterceptorTests(options: RuntimeS
         );
         expect(handler).toBeInstanceOf(Handler);
 
-        let requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
         const response = await fetch(joinURL(baseURL, `/users/${users[0].id}`), {
           method,
@@ -84,9 +83,8 @@ export async function declarePlainTextBodyHttpInterceptorTests(options: RuntimeS
         const fetchedBody = await response.text();
         expect(fetchedBody).toBe('content-response');
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(1);
-        const [request] = requests;
+        expect(handler.requests).toHaveLength(1);
+        const [request] = handler.requests;
 
         expect(request).toBeInstanceOf(Request);
         expect(request.headers.get('content-type')).toBe('text/plain;charset=UTF-8');
@@ -157,8 +155,7 @@ export async function declarePlainTextBodyHttpInterceptorTests(options: RuntimeS
         );
         expect(handler).toBeInstanceOf(Handler);
 
-        let requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
         const response = await fetch(joinURL(baseURL, `/users/${users[0].id}`), {
           method,
@@ -170,9 +167,8 @@ export async function declarePlainTextBodyHttpInterceptorTests(options: RuntimeS
         const fetchedBody = await response.text();
         expect(fetchedBody).toBe('<response>content-response</response>');
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(1);
-        const [request] = requests;
+        expect(handler.requests).toHaveLength(1);
+        const [request] = handler.requests;
 
         expect(request).toBeInstanceOf(Request);
         expect(request.headers.get('content-type')).toBe('application/xml');
@@ -222,8 +218,7 @@ export async function declarePlainTextBodyHttpInterceptorTests(options: RuntimeS
         );
         expect(handler).toBeInstanceOf(Handler);
 
-        let requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
         const response = await fetch(joinURL(baseURL, `/users/${users[0].id}`), {
           method,
@@ -234,9 +229,8 @@ export async function declarePlainTextBodyHttpInterceptorTests(options: RuntimeS
         const fetchedBody = await response.text();
         expect(fetchedBody).toBe('');
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(1);
-        const [request] = requests;
+        expect(handler.requests).toHaveLength(1);
+        const [request] = handler.requests;
 
         expect(request).toBeInstanceOf(Request);
         expect(request.headers.get('content-type')).toBe('text/plain;charset=UTF-8');

--- a/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/bodies/searchParams.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/bodies/searchParams.ts
@@ -89,14 +89,13 @@ export async function declareSearchParamsBodyHttpInterceptorTests(options: Runti
         );
         expect(handler).toBeInstanceOf(Handler);
 
-        let requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
-        const requestSearchParams = new HttpSearchParams<UserSearchParamsSchema>({ tag: 'admin' });
+        const searchParams = new HttpSearchParams<UserSearchParamsSchema>({ tag: 'admin' });
 
         const response = await fetch(joinURL(baseURL, `/users/${users[0].id}`), {
           method,
-          body: requestSearchParams,
+          body: searchParams,
         });
         expect(response.status).toBe(200);
 
@@ -107,15 +106,14 @@ export async function declareSearchParamsBodyHttpInterceptorTests(options: Runti
         const fetchedTag = fetchedSearchParams.get('tag')!;
         expect(fetchedTag).toBe(responseSearchParams.get('tag'));
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(1);
-        const [request] = requests;
+        expect(handler.requests).toHaveLength(1);
+        const [request] = handler.requests;
 
         expect(request).toBeInstanceOf(Request);
         expect(request.headers.get('content-type')).toBe('application/x-www-form-urlencoded;charset=UTF-8');
         expectTypeOf(request.body).toEqualTypeOf<HttpSearchParams<UserSearchParamsSchema>>();
         expect(request.body).toBeInstanceOf(HttpSearchParams);
-        expect(request.body).toEqual(requestSearchParams);
+        expect(request.body).toEqual(searchParams);
         expect(request.body.get('tag')).toEqual('admin');
 
         expect(request.response).toBeInstanceOf(Response);
@@ -186,8 +184,7 @@ export async function declareSearchParamsBodyHttpInterceptorTests(options: Runti
         );
         expect(handler).toBeInstanceOf(Handler);
 
-        let requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
         await usingIgnoredConsole(['error'], async (spies) => {
           const response = await fetch(joinURL(baseURL, `/users/${users[0].id}`), {
@@ -200,9 +197,8 @@ export async function declareSearchParamsBodyHttpInterceptorTests(options: Runti
           expect(spies.error).not.toHaveBeenCalled();
         });
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(1);
-        const [request] = requests;
+        expect(handler.requests).toHaveLength(1);
+        const [request] = handler.requests;
 
         expect(request).toBeInstanceOf(Request);
         expect(request.headers.get('content-type')).toBe('application/x-www-form-urlencoded');
@@ -254,8 +250,7 @@ export async function declareSearchParamsBodyHttpInterceptorTests(options: Runti
         );
         expect(handler).toBeInstanceOf(Handler);
 
-        let requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
         const response = await fetch(joinURL(baseURL, `/users/${users[0].id}`), {
           method,
@@ -266,9 +261,8 @@ export async function declareSearchParamsBodyHttpInterceptorTests(options: Runti
         const fetchedSearchParams = await response.text();
         expect(fetchedSearchParams).toBe('');
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(1);
-        const [request] = requests;
+        expect(handler.requests).toHaveLength(1);
+        const [request] = handler.requests;
 
         expect(request).toBeInstanceOf(Request);
         expect(request.headers.get('content-type')).toBe('application/x-www-form-urlencoded');

--- a/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/clear.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/clear.ts
@@ -60,14 +60,12 @@ export function declareClearHttpInterceptorTests(options: RuntimeSharedHttpInter
         );
         expect(handler).toBeInstanceOf(Handler);
 
-        let requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
         const response = await fetch(joinURL(baseURL, '/users'), { method });
         expect(response.status).toBe(200);
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+        expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
 
         await promiseIfRemote(interceptor.clear(), interceptor);
 
@@ -79,8 +77,7 @@ export function declareClearHttpInterceptorTests(options: RuntimeSharedHttpInter
           await expectFetchError(responsePromise);
         }
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
       });
     });
 
@@ -115,15 +112,13 @@ export function declareClearHttpInterceptorTests(options: RuntimeSharedHttpInter
         );
         expect(handler).toBeInstanceOf(Handler);
 
-        let requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
         const response = await fetch(joinURL(baseURL, '/users'), { method });
         expect(response.status).toBe(200);
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
-        const request = requests[numberOfRequestsIncludingPreflight - 1];
+        expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
+        const request = handler.requests[numberOfRequestsIncludingPreflight - 1];
         expect(request).toBeInstanceOf(Request);
 
         expectTypeOf(request.body).toEqualTypeOf<null>();
@@ -171,15 +166,13 @@ export function declareClearHttpInterceptorTests(options: RuntimeSharedHttpInter
         );
         expect(otherHandler).toBeInstanceOf(Handler);
 
-        let requests = await promiseIfRemote(otherHandler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
         const response = await fetch(joinURL(baseURL, '/users'), { method });
         expect(response.status).toBe(200);
 
-        requests = await promiseIfRemote(otherHandler.requests(), interceptor);
-        expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
-        const request = requests[numberOfRequestsIncludingPreflight - 1];
+        expect(otherHandler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
+        const request = otherHandler.requests[numberOfRequestsIncludingPreflight - 1];
         expect(request).toBeInstanceOf(Request);
 
         expectTypeOf(request.body).toEqualTypeOf<null>();

--- a/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/default.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/default.ts
@@ -25,7 +25,7 @@ export function declareDeclareHttpInterceptorTests(options: RuntimeSharedHttpInt
     baseURL = getBaseURL();
     serverURL = new URL(baseURL.origin);
 
-    expect(store.numberOfRunningLocalInterceptors()).toBe(0);
+    expect(store.numberOfRunningLocalInterceptors).toBe(0);
     expect(store.numberOfRunningRemoteInterceptors(baseURL)).toBe(0);
   });
 
@@ -33,11 +33,11 @@ export function declareDeclareHttpInterceptorTests(options: RuntimeSharedHttpInt
     const worker = getSingletonWorkerByType(store, type, serverURL);
 
     if (worker) {
-      expect(worker.isRunning()).toBe(false);
-      expect(worker.interceptorsWithHandlers()).toHaveLength(0);
+      expect(worker.isRunning).toBe(false);
+      expect(worker.interceptorsWithHandlers).toHaveLength(0);
     }
 
-    expect(store.numberOfRunningLocalInterceptors()).toBe(0);
+    expect(store.numberOfRunningLocalInterceptors).toBe(0);
     expect(store.numberOfRunningRemoteInterceptors(baseURL)).toBe(0);
   });
 
@@ -55,159 +55,159 @@ export function declareDeclareHttpInterceptorTests(options: RuntimeSharedHttpInt
 
   it('should initialize with the correct platform', async () => {
     await usingHttpInterceptor<{}>(getInterceptorOptions(), (interceptor) => {
-      expect(interceptor.platform()).toBe(platform);
+      expect(interceptor.platform).toBe(platform);
 
       const worker = getSingletonWorkerByType(store, type, serverURL);
-      expect(worker!.platform()).toBe(platform);
+      expect(worker!.platform).toBe(platform);
     });
   });
 
   it('should now throw an error if started multiple times', async () => {
     await usingHttpInterceptor<{}>(getInterceptorOptions(), { start: false }, async (interceptor) => {
-      expect(interceptor.isRunning()).toBe(false);
+      expect(interceptor.isRunning).toBe(false);
 
       await interceptor.start();
-      expect(interceptor.isRunning()).toBe(true);
+      expect(interceptor.isRunning).toBe(true);
       await interceptor.start();
-      expect(interceptor.isRunning()).toBe(true);
+      expect(interceptor.isRunning).toBe(true);
 
       await interceptor.stop();
-      expect(interceptor.isRunning()).toBe(false);
+      expect(interceptor.isRunning).toBe(false);
 
       await interceptor.start();
-      expect(interceptor.isRunning()).toBe(true);
+      expect(interceptor.isRunning).toBe(true);
       await interceptor.start();
-      expect(interceptor.isRunning()).toBe(true);
+      expect(interceptor.isRunning).toBe(true);
     });
   });
 
   it('should not throw an error if stopped multiple times', async () => {
     await usingHttpInterceptor<{}>(getInterceptorOptions(), { start: false }, async (interceptor) => {
-      expect(interceptor.isRunning()).toBe(false);
+      expect(interceptor.isRunning).toBe(false);
 
       await interceptor.stop();
-      expect(interceptor.isRunning()).toBe(false);
+      expect(interceptor.isRunning).toBe(false);
       await interceptor.stop();
-      expect(interceptor.isRunning()).toBe(false);
+      expect(interceptor.isRunning).toBe(false);
 
       await interceptor.start();
-      expect(interceptor.isRunning()).toBe(true);
+      expect(interceptor.isRunning).toBe(true);
 
       await interceptor.stop();
-      expect(interceptor.isRunning()).toBe(false);
+      expect(interceptor.isRunning).toBe(false);
       await interceptor.stop();
-      expect(interceptor.isRunning()).toBe(false);
+      expect(interceptor.isRunning).toBe(false);
       await interceptor.stop();
     });
   });
 
   it('should start the shared worker when the first interceptor is started', async () => {
     await usingHttpInterceptor<{}>(getInterceptorOptions(), { start: false }, async (interceptor) => {
-      expect(interceptor.isRunning()).toBe(false);
+      expect(interceptor.isRunning).toBe(false);
 
       await usingHttpInterceptor<{}>(getInterceptorOptions(), { start: false }, async (otherInterceptor) => {
-        expect(otherInterceptor.isRunning()).toBe(false);
+        expect(otherInterceptor.isRunning).toBe(false);
 
         await interceptor.start();
-        expect(interceptor.isRunning()).toBe(true);
+        expect(interceptor.isRunning).toBe(true);
 
         const worker = getSingletonWorkerByType(store, type, serverURL);
         expect(worker).toBeDefined();
-        expect(worker!.isRunning()).toBe(true);
+        expect(worker!.isRunning).toBe(true);
 
         await otherInterceptor.start();
-        expect(otherInterceptor.isRunning()).toBe(true);
+        expect(otherInterceptor.isRunning).toBe(true);
 
-        expect(worker!.isRunning()).toBe(true);
+        expect(worker!.isRunning).toBe(true);
       });
     });
   });
 
   it('should stop the shared worker when the last interceptor is stopped', async () => {
     await usingHttpInterceptor<{}>(getInterceptorOptions(), { start: false }, async (interceptor) => {
-      expect(interceptor.isRunning()).toBe(false);
+      expect(interceptor.isRunning).toBe(false);
 
       await usingHttpInterceptor<{}>(getInterceptorOptions(), { start: false }, async (otherInterceptor) => {
-        expect(otherInterceptor.isRunning()).toBe(false);
+        expect(otherInterceptor.isRunning).toBe(false);
 
         await interceptor.start();
-        expect(interceptor.isRunning()).toBe(true);
+        expect(interceptor.isRunning).toBe(true);
 
         const worker = getSingletonWorkerByType(store, type, serverURL);
         expect(worker).toBeDefined();
-        expect(worker!.isRunning()).toBe(true);
+        expect(worker!.isRunning).toBe(true);
 
         await otherInterceptor.start();
-        expect(otherInterceptor.isRunning()).toBe(true);
+        expect(otherInterceptor.isRunning).toBe(true);
 
-        expect(worker!.isRunning()).toBe(true);
+        expect(worker!.isRunning).toBe(true);
 
         await interceptor.stop();
-        expect(interceptor.isRunning()).toBe(false);
+        expect(interceptor.isRunning).toBe(false);
 
-        expect(worker!.isRunning()).toBe(true);
+        expect(worker!.isRunning).toBe(true);
 
         await otherInterceptor.stop();
-        expect(otherInterceptor.isRunning()).toBe(false);
+        expect(otherInterceptor.isRunning).toBe(false);
 
-        expect(worker!.isRunning()).toBe(false);
+        expect(worker!.isRunning).toBe(false);
       });
     });
   });
 
   it('should support starting interceptors concurrently', async () => {
     await usingHttpInterceptor<{}>(getInterceptorOptions(), { start: false }, async (interceptor) => {
-      expect(interceptor.isRunning()).toBe(false);
+      expect(interceptor.isRunning).toBe(false);
 
       await usingHttpInterceptor<{}>(getInterceptorOptions(), { start: false }, async (otherInterceptor) => {
-        expect(otherInterceptor.isRunning()).toBe(false);
+        expect(otherInterceptor.isRunning).toBe(false);
 
         await Promise.all(
           [interceptor, otherInterceptor].map(async (interceptor) => {
             await interceptor.start();
-            expect(interceptor.isRunning()).toBe(true);
+            expect(interceptor.isRunning).toBe(true);
           }),
         );
 
-        expect(interceptor.isRunning()).toBe(true);
-        expect(otherInterceptor.isRunning()).toBe(true);
+        expect(interceptor.isRunning).toBe(true);
+        expect(otherInterceptor.isRunning).toBe(true);
 
         const worker = getSingletonWorkerByType(store, type, serverURL);
         expect(worker).toBeDefined();
-        expect(worker!.isRunning()).toBe(true);
+        expect(worker!.isRunning).toBe(true);
       });
     });
   });
 
   it('should support stopping interceptors concurrently', async () => {
     await usingHttpInterceptor<{}>(getInterceptorOptions(), async (interceptor) => {
-      expect(interceptor.isRunning()).toBe(true);
+      expect(interceptor.isRunning).toBe(true);
 
       await usingHttpInterceptor<{}>(getInterceptorOptions(), async (otherInterceptor) => {
-        expect(otherInterceptor.isRunning()).toBe(true);
+        expect(otherInterceptor.isRunning).toBe(true);
 
         const worker = getSingletonWorkerByType(store, type, serverURL);
         expect(worker).toBeDefined();
-        expect(worker!.isRunning()).toBe(true);
+        expect(worker!.isRunning).toBe(true);
 
         await Promise.all(
           [interceptor, otherInterceptor].map(async (interceptor) => {
             await interceptor.stop();
-            expect(interceptor.isRunning()).toBe(false);
+            expect(interceptor.isRunning).toBe(false);
           }),
         );
 
-        expect(interceptor.isRunning()).toBe(false);
-        expect(otherInterceptor.isRunning()).toBe(false);
+        expect(interceptor.isRunning).toBe(false);
+        expect(otherInterceptor.isRunning).toBe(false);
 
-        expect(worker!.isRunning()).toBe(false);
+        expect(worker!.isRunning).toBe(false);
       });
     });
   });
 
   it('should throw an error when trying to be cleared if not running', async () => {
     await usingHttpInterceptor<{}>(getInterceptorOptions(), { start: false }, async (interceptor) => {
-      expect(interceptor.isRunning()).toBe(false);
+      expect(interceptor.isRunning).toBe(false);
 
       await expect(async () => {
         await interceptor.clear();

--- a/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/handlers.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/handlers.ts
@@ -65,15 +65,13 @@ export async function declareHandlerHttpInterceptorTests(options: RuntimeSharedH
         );
         expect(handler).toBeInstanceOf(Handler);
 
-        let requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
         const response = await fetch(joinURL(baseURL, '/users'), { method });
         expect(response.status).toBe(200);
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
-        const request = requests[numberOfRequestsIncludingPreflight - 1];
+        expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
+        const request = handler.requests[numberOfRequestsIncludingPreflight - 1];
         expect(request).toBeInstanceOf(Request);
 
         expectTypeOf(request.body).toEqualTypeOf<null>();
@@ -112,16 +110,14 @@ export async function declareHandlerHttpInterceptorTests(options: RuntimeSharedH
         );
         expect(handler).toBeInstanceOf(Handler);
 
-        let requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
         const response = await fetch(joinURL(baseURL, '/users'), { method });
 
         expect(response.status).toBe(200);
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
-        const request = requests[numberOfRequestsIncludingPreflight - 1];
+        expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
+        const request = handler.requests[numberOfRequestsIncludingPreflight - 1];
         expect(request).toBeInstanceOf(Request);
 
         expectTypeOf(request.body).toEqualTypeOf<null>();
@@ -160,8 +156,7 @@ export async function declareHandlerHttpInterceptorTests(options: RuntimeSharedH
         );
         expect(handler).toBeInstanceOf(Handler);
 
-        let requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
         await usingIgnoredConsole(['error', 'warn'], async (spies) => {
           const request = new Request(joinURL(baseURL, '/users'), {
@@ -186,8 +181,7 @@ export async function declareHandlerHttpInterceptorTests(options: RuntimeSharedH
           await verifyUnhandledRequestMessage(errorMessage, { request, platform, type: 'reject' });
         });
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
       });
     });
 
@@ -229,8 +223,7 @@ export async function declareHandlerHttpInterceptorTests(options: RuntimeSharedH
         );
         expect(handler).toBeInstanceOf(Handler);
 
-        let requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
         const response = await fetch(joinURL(baseURL, '/users'), {
           method,
@@ -240,9 +233,8 @@ export async function declareHandlerHttpInterceptorTests(options: RuntimeSharedH
         });
         expect(response.status).toBe(200);
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
-        const request = requests[numberOfRequestsIncludingPreflight - 1];
+        expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
+        const request = handler.requests[numberOfRequestsIncludingPreflight - 1];
         expect(request).toBeInstanceOf(Request);
 
         expectTypeOf(request.headers).toEqualTypeOf<HttpHeaders<UserRequestHeaders>>();
@@ -292,17 +284,15 @@ export async function declareHandlerHttpInterceptorTests(options: RuntimeSharedH
         );
         expect(handler).toBeInstanceOf(Handler);
 
-        let requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
         const searchParams = new HttpSearchParams<UserSearchParams>({ tag: 'admin' });
 
         const response = await fetch(joinURL(baseURL, `/users?${searchParams.toString()}`), { method });
         expect(response.status).toBe(200);
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
-        const request = requests[numberOfRequestsIncludingPreflight - 1];
+        expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
+        const request = handler.requests[numberOfRequestsIncludingPreflight - 1];
         expect(request).toBeInstanceOf(Request);
 
         expectTypeOf(request.searchParams).toEqualTypeOf<HttpSearchParams<UserSearchParams>>();
@@ -339,10 +329,9 @@ export async function declareHandlerHttpInterceptorTests(options: RuntimeSharedH
         const handlerWithoutResponse = await promiseIfRemote(interceptor[lowerMethod]('/users'), interceptor);
         expect(handlerWithoutResponse).toBeInstanceOf(Handler);
 
-        let requestsWithoutResponse = await promiseIfRemote(handlerWithoutResponse.requests(), interceptor);
-        expect(requestsWithoutResponse).toHaveLength(0);
+        expect(handlerWithoutResponse.requests).toHaveLength(0);
 
-        let _requestWithoutResponse = requestsWithoutResponse[numberOfRequestsIncludingPreflight - 1];
+        let _requestWithoutResponse = handlerWithoutResponse.requests[numberOfRequestsIncludingPreflight - 1];
         expectTypeOf<typeof _requestWithoutResponse.body>().toEqualTypeOf<null>();
         expectTypeOf<typeof _requestWithoutResponse.response>().toEqualTypeOf<never>();
 
@@ -354,10 +343,9 @@ export async function declareHandlerHttpInterceptorTests(options: RuntimeSharedH
           await expectFetchError(responsePromise);
         }
 
-        requestsWithoutResponse = await promiseIfRemote(handlerWithoutResponse.requests(), interceptor);
-        expect(requestsWithoutResponse).toHaveLength(0);
+        expect(handlerWithoutResponse.requests).toHaveLength(0);
 
-        _requestWithoutResponse = requestsWithoutResponse[numberOfRequestsIncludingPreflight];
+        _requestWithoutResponse = handlerWithoutResponse.requests[numberOfRequestsIncludingPreflight];
         expectTypeOf<typeof _requestWithoutResponse.body>().toEqualTypeOf<null>();
         expectTypeOf<typeof _requestWithoutResponse.response>().toEqualTypeOf<never>();
 
@@ -372,11 +360,10 @@ export async function declareHandlerHttpInterceptorTests(options: RuntimeSharedH
         const response = await fetch(joinURL(baseURL, '/users'), { method });
         expect(response.status).toBe(200);
 
-        expect(requestsWithoutResponse).toHaveLength(0);
-        const requestsWithResponse = await promiseIfRemote(handlerWithResponse.requests(), interceptor);
-        expect(requestsWithResponse).toHaveLength(numberOfRequestsIncludingPreflight);
+        expect(handlerWithoutResponse.requests).toHaveLength(numberOfRequestsIncludingPreflight);
+        expect(handlerWithResponse.requests).toHaveLength(numberOfRequestsIncludingPreflight);
 
-        const requestWithResponse = requestsWithResponse[numberOfRequestsIncludingPreflight - 1];
+        const requestWithResponse = handlerWithResponse.requests[numberOfRequestsIncludingPreflight - 1];
         expect(requestWithResponse).toBeInstanceOf(Request);
         expect(requestWithResponse.response.status).toBe(200);
 
@@ -418,15 +405,13 @@ export async function declareHandlerHttpInterceptorTests(options: RuntimeSharedH
           interceptor,
         );
 
-        let requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
         const response = await fetch(joinURL(baseURL, '/users'), { method });
         expect(response.status).toBe(200);
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
-        const request = requests[numberOfRequestsIncludingPreflight - 1];
+        expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
+        const request = handler.requests[numberOfRequestsIncludingPreflight - 1];
         expect(request).toBeInstanceOf(Request);
 
         expectTypeOf(request.body).toEqualTypeOf<null>();
@@ -446,18 +431,15 @@ export async function declareHandlerHttpInterceptorTests(options: RuntimeSharedH
           interceptor,
         );
 
-        let otherRequests = await promiseIfRemote(otherHandler.requests(), interceptor);
-        expect(otherRequests).toHaveLength(0);
+        expect(otherHandler.requests).toHaveLength(0);
 
         const otherResponse = await fetch(joinURL(baseURL, '/users'), { method });
         expect(otherResponse.status).toBe(201);
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+        expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
 
-        otherRequests = await promiseIfRemote(otherHandler.requests(), interceptor);
-        expect(otherRequests).toHaveLength(numberOfRequestsIncludingPreflight);
-        const otherRequest = otherRequests[numberOfRequestsIncludingPreflight - 1];
+        expect(otherHandler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
+        const otherRequest = otherHandler.requests[numberOfRequestsIncludingPreflight - 1];
         expect(otherRequest).toBeInstanceOf(Request);
 
         expectTypeOf(otherRequest.body).toEqualTypeOf<null>();
@@ -490,8 +472,7 @@ export async function declareHandlerHttpInterceptorTests(options: RuntimeSharedH
             interceptor,
           );
 
-          const initialRequests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(initialRequests).toHaveLength(0);
+          expect(handler.requests).toHaveLength(0);
 
           const responsePromise = fetch(joinURL(baseURL, '/users'), { method });
 
@@ -530,13 +511,14 @@ export async function declareHandlerHttpInterceptorTests(options: RuntimeSharedH
 
             const error = new DisabledRequestSavingError();
 
-            await expect(async () => {
-              await promiseIfRemote(handler.requests(), interceptor);
-            }).rejects.toThrowError(error);
+            expect(() => {
+              // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+              handler.requests;
+            }).toThrowError(error);
 
             // @ts-expect-error Checking that no intercepted requests are saved.
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            expect(handler._client.interceptedRequests).toHaveLength(0);
+            expect(handler.client._requests).toHaveLength(0);
 
             const numberOfRequests = 5;
 
@@ -545,13 +527,14 @@ export async function declareHandlerHttpInterceptorTests(options: RuntimeSharedH
               expect(response.status).toBe(200);
             }
 
-            await expect(async () => {
-              await promiseIfRemote(handler.requests(), interceptor);
-            }).rejects.toThrowError(error);
+            expect(() => {
+              // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+              handler.requests;
+            }).toThrowError(error);
 
             // @ts-expect-error Checking that no intercepted requests are saved.
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            expect(handler._client.interceptedRequests).toHaveLength(0);
+            expect(handler.client._requests).toHaveLength(0);
           });
         },
       );
@@ -576,8 +559,7 @@ export async function declareHandlerHttpInterceptorTests(options: RuntimeSharedH
             interceptor,
           );
 
-          let requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(0);
+          expect(handler.requests).toHaveLength(0);
 
           const numberOfRequests = 5;
 
@@ -586,8 +568,7 @@ export async function declareHandlerHttpInterceptorTests(options: RuntimeSharedH
             expect(response.status).toBe(200);
           }
 
-          requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(numberOfRequestsIncludingPreflight * numberOfRequests);
+          expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight * numberOfRequests);
         });
       });
     });

--- a/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/lifeCycle.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/lifeCycle.ts
@@ -65,18 +65,16 @@ export function declareLifeCycleHttpInterceptorTests(options: RuntimeSharedHttpI
         );
         expect(handler).toBeInstanceOf(Handler);
 
-        let requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
         const response = await fetch(joinURL(baseURL, '/users'), { method });
         expect(response.status).toBe(200);
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+        expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
 
-        expect(interceptor.isRunning()).toBe(true);
+        expect(interceptor.isRunning).toBe(true);
         await interceptor.stop();
-        expect(interceptor.isRunning()).toBe(false);
+        expect(interceptor.isRunning).toBe(false);
 
         let responsePromise = fetch(joinURL(baseURL, '/users'), {
           method,
@@ -91,11 +89,10 @@ export function declareLifeCycleHttpInterceptorTests(options: RuntimeSharedHttpI
           await expectFetchError(responsePromise, { canBeAborted: true });
         }
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
         await interceptor.start();
-        expect(interceptor.isRunning()).toBe(true);
+        expect(interceptor.isRunning).toBe(true);
 
         responsePromise = fetch(joinURL(baseURL, '/users'), { method });
 
@@ -105,8 +102,7 @@ export function declareLifeCycleHttpInterceptorTests(options: RuntimeSharedHttpI
           await expectFetchError(responsePromise);
         }
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
       });
     });
 
@@ -131,22 +127,20 @@ export function declareLifeCycleHttpInterceptorTests(options: RuntimeSharedHttpI
         );
         expect(handler).toBeInstanceOf(Handler);
 
-        let requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
         const response = await fetch(joinURL(baseURL, '/users'), { method });
         expect(response.status).toBe(200);
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+        expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
 
         await usingHttpInterceptor(interceptorOptions, async (otherInterceptor) => {
-          expect(interceptor.isRunning()).toBe(true);
-          expect(otherInterceptor.isRunning()).toBe(true);
+          expect(interceptor.isRunning).toBe(true);
+          expect(otherInterceptor.isRunning).toBe(true);
 
           await interceptor.stop();
-          expect(interceptor.isRunning()).toBe(false);
-          expect(otherInterceptor.isRunning()).toBe(true);
+          expect(interceptor.isRunning).toBe(false);
+          expect(otherInterceptor.isRunning).toBe(true);
 
           let responsePromise = fetch(joinURL(baseURL, '/users'), {
             method,
@@ -159,12 +153,11 @@ export function declareLifeCycleHttpInterceptorTests(options: RuntimeSharedHttpI
             await expectFetchError(responsePromise, { canBeAborted: true });
           }
 
-          requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(0);
+          expect(handler.requests).toHaveLength(0);
 
           await interceptor.start();
-          expect(interceptor.isRunning()).toBe(true);
-          expect(otherInterceptor.isRunning()).toBe(true);
+          expect(interceptor.isRunning).toBe(true);
+          expect(otherInterceptor.isRunning).toBe(true);
 
           responsePromise = fetch(joinURL(baseURL, '/users'), { method });
 
@@ -174,15 +167,14 @@ export function declareLifeCycleHttpInterceptorTests(options: RuntimeSharedHttpI
             await expectFetchError(responsePromise);
           }
 
-          requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(0);
+          expect(handler.requests).toHaveLength(0);
         });
       });
     });
 
     it(`should throw an error when trying to create a ${method} request handler if not running`, async () => {
       const interceptor = createInternalHttpInterceptor(interceptorOptions);
-      expect(interceptor.isRunning()).toBe(false);
+      expect(interceptor.isRunning).toBe(false);
 
       await expect(async () => {
         await interceptor[lowerMethod]('/');

--- a/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/pathParams.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/pathParams.ts
@@ -75,15 +75,13 @@ export async function declarePathParamsHttpInterceptorTests(options: RuntimeShar
         );
         expect(genericHandler).toBeInstanceOf(Handler);
 
-        let genericRequests = await promiseIfRemote(genericHandler.requests(), interceptor);
-        expect(genericRequests).toHaveLength(0);
+        expect(genericHandler.requests).toHaveLength(0);
 
         const genericResponse = await fetch(joinURL(baseURL, `/users/${users[0].id}`), { method });
         expect(genericResponse.status).toBe(200);
 
-        genericRequests = await promiseIfRemote(genericHandler.requests(), interceptor);
-        expect(genericRequests).toHaveLength(numberOfRequestsIncludingPreflight);
-        const genericRequest = genericRequests[numberOfRequestsIncludingPreflight - 1];
+        expect(genericHandler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
+        const genericRequest = genericHandler.requests[numberOfRequestsIncludingPreflight - 1];
         expect(genericRequest).toBeInstanceOf(Request);
 
         expectTypeOf(genericRequest.pathParams).toEqualTypeOf<{ id: string }>();
@@ -114,15 +112,13 @@ export async function declarePathParamsHttpInterceptorTests(options: RuntimeShar
         );
         expect(specificHandler).toBeInstanceOf(Handler);
 
-        let specificRequests = await promiseIfRemote(specificHandler.requests(), interceptor);
-        expect(specificRequests).toHaveLength(0);
+        expect(specificHandler.requests).toHaveLength(0);
 
         const specificResponse = await fetch(joinURL(baseURL, `/users/${users[0].id}`), { method });
         expect(specificResponse.status).toBe(200);
 
-        specificRequests = await promiseIfRemote(specificHandler.requests(), interceptor);
-        expect(specificRequests).toHaveLength(numberOfRequestsIncludingPreflight);
-        const specificRequest = specificRequests[numberOfRequestsIncludingPreflight - 1];
+        expect(specificHandler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
+        const specificRequest = specificHandler.requests[numberOfRequestsIncludingPreflight - 1];
         expect(specificRequest).toBeInstanceOf(Request);
 
         expectTypeOf(specificRequest.pathParams).toEqualTypeOf<{ id: string }>();

--- a/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/restrictions.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/restrictions.ts
@@ -122,8 +122,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
         );
         expect(handler).toBeInstanceOf(Handler);
 
-        let requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
         const headers = new HttpHeaders<HttpSchema.Headers<RequestHeadersSchema>>({
           'content-language': 'en',
@@ -133,16 +132,14 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
         let response = await fetch(joinURL(baseURL, '/users'), { method, headers });
         expect(response.status).toBe(200);
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(1);
+        expect(handler.requests).toHaveLength(1);
 
         headers.append('accept', 'application/xml');
 
         response = await fetch(joinURL(baseURL, '/users'), { method, headers });
         expect(response.status).toBe(200);
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(2);
+        expect(handler.requests).toHaveLength(2);
 
         headers.delete('accept');
 
@@ -154,8 +151,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
           await expectFetchError(responsePromise);
         }
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(2);
+        expect(handler.requests).toHaveLength(2);
 
         headers.delete('content-language');
 
@@ -167,8 +163,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
           await expectFetchError(responsePromise);
         }
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(2);
+        expect(handler.requests).toHaveLength(2);
 
         headers.set('accept', 'application/json');
         headers.set('content-language', 'pt');
@@ -181,8 +176,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
           await expectFetchError(responsePromise);
         }
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(2);
+        expect(handler.requests).toHaveLength(2);
       });
     });
 
@@ -226,8 +220,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
         );
         expect(handler).toBeInstanceOf(Handler);
 
-        let requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
         const searchParams = new HttpSearchParams<HttpSchema.SearchParams<RequestSearchParamsSchema>>({
           tag: 'admin',
@@ -239,8 +232,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
         });
         expect(response.status).toBe(200);
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+        expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
 
         searchParams.delete('tag');
 
@@ -254,8 +246,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
           await expectFetchError(responsePromise);
         }
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+        expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
       });
     });
   });
@@ -293,8 +284,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
         );
         expect(handler).toBeInstanceOf(Handler);
 
-        let requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
         const response = await fetch(joinURL(baseURL, '/users'), {
           method,
@@ -303,8 +293,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
         });
         expect(response.status).toBe(200);
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(1);
+        expect(handler.requests).toHaveLength(1);
 
         for (const body of [JSON.stringify({ message: 'other' }), JSON.stringify({}), undefined]) {
           const responsePromise = fetch(joinURL(baseURL, '/users'), {
@@ -315,8 +304,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
 
           await expectFetchError(responsePromise);
 
-          requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(1);
+          expect(handler.requests).toHaveLength(1);
         }
       });
     });
@@ -351,8 +339,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
         );
         expect(handler).toBeInstanceOf(Handler);
 
-        let requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
         let response = await fetch(joinURL(baseURL, '/users'), {
           method,
@@ -361,8 +348,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
         });
         expect(response.status).toBe(200);
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(1);
+        expect(handler.requests).toHaveLength(1);
 
         response = await fetch(joinURL(baseURL, '/users'), {
           method,
@@ -371,8 +357,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
         });
         expect(response.status).toBe(200);
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(2);
+        expect(handler.requests).toHaveLength(2);
 
         for (const body of [JSON.stringify({ message: 'other' }), JSON.stringify({}), undefined]) {
           const responsePromise = fetch(joinURL(baseURL, '/users'), {
@@ -383,8 +368,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
 
           await expectFetchError(responsePromise);
 
-          requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(2);
+          expect(handler.requests).toHaveLength(2);
         }
       });
     });
@@ -423,8 +407,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
         );
         expect(handler).toBeInstanceOf(Handler);
 
-        let requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
         const response = await fetch(joinURL(baseURL, '/users'), {
           method,
@@ -432,8 +415,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
         });
         expect(response.status).toBe(200);
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(1);
+        expect(handler.requests).toHaveLength(1);
 
         const differentTagFile = new File(['more-content'], 'tag.txt', { type: 'text/plain' });
 
@@ -458,8 +440,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
 
             await expectFetchError(responsePromise);
 
-            requests = await promiseIfRemote(handler.requests(), interceptor);
-            expect(requests).toHaveLength(1);
+            expect(handler.requests).toHaveLength(1);
 
             if (body && !body.has('tag') && platform === 'browser') {
               expect(spies.error).toHaveBeenCalledTimes(1);
@@ -510,8 +491,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
         );
         expect(handler).toBeInstanceOf(Handler);
 
-        let requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
         let response = await fetch(joinURL(baseURL, '/users'), {
           method,
@@ -519,8 +499,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
         });
         expect(response.status).toBe(200);
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(1);
+        expect(handler.requests).toHaveLength(1);
 
         const differentTagFile = new File(['other'], 'tag.txt', { type: 'text/plain' });
 
@@ -534,8 +513,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
         });
         expect(response.status).toBe(200);
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(2);
+        expect(handler.requests).toHaveLength(2);
 
         const differentFormData = new HttpFormData<HttpSchema.FormData<RequestFormDataSchema>>();
         differentFormData.append('tag', differentTagFile);
@@ -553,8 +531,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
 
             await expectFetchError(responsePromise);
 
-            requests = await promiseIfRemote(handler.requests(), interceptor);
-            expect(requests).toHaveLength(2);
+            expect(handler.requests).toHaveLength(2);
 
             if (body && !body.has('tag') && platform === 'browser') {
               expect(spies.error).toHaveBeenCalledTimes(1);
@@ -604,8 +581,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
         );
         expect(handler).toBeInstanceOf(Handler);
 
-        let requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
         const response = await fetch(joinURL(baseURL, '/users'), {
           method,
@@ -613,8 +589,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
         });
         expect(response.status).toBe(200);
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(1);
+        expect(handler.requests).toHaveLength(1);
 
         for (const body of [
           new HttpSearchParams<SearchParamsSchema>({ tag: 'admin', other: 'other' }),
@@ -629,8 +604,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
 
           await expectFetchError(responsePromise);
 
-          requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(1);
+          expect(handler.requests).toHaveLength(1);
         }
       });
     });
@@ -676,8 +650,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
         );
         expect(handler).toBeInstanceOf(Handler);
 
-        let requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
         let response = await fetch(joinURL(baseURL, '/users'), {
           method,
@@ -685,8 +658,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
         });
         expect(response.status).toBe(200);
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(1);
+        expect(handler.requests).toHaveLength(1);
 
         response = await fetch(joinURL(baseURL, '/users'), {
           method,
@@ -694,8 +666,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
         });
         expect(response.status).toBe(200);
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(2);
+        expect(handler.requests).toHaveLength(2);
 
         for (const body of [
           new HttpSearchParams<SearchParamsSchema>({ tag: 'other' }),
@@ -709,8 +680,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
 
           await expectFetchError(responsePromise);
 
-          requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(2);
+          expect(handler.requests).toHaveLength(2);
         }
       });
     });
@@ -747,8 +717,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
         );
         expect(handler).toBeInstanceOf(Handler);
 
-        let requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
         const response = await fetch(joinURL(baseURL, '/users'), {
           method,
@@ -756,8 +725,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
         });
         expect(response.status).toBe(200);
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(1);
+        expect(handler.requests).toHaveLength(1);
 
         for (const body of ['more-content', 'cont', '']) {
           const responsePromise = fetch(joinURL(baseURL, '/users'), {
@@ -767,8 +735,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
 
           await expectFetchError(responsePromise);
 
-          requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(1);
+          expect(handler.requests).toHaveLength(1);
         }
       });
     });
@@ -805,8 +772,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
         );
         expect(handler).toBeInstanceOf(Handler);
 
-        let requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
         let response = await fetch(joinURL(baseURL, '/users'), {
           method,
@@ -814,8 +780,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
         });
         expect(response.status).toBe(200);
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(1);
+        expect(handler.requests).toHaveLength(1);
 
         response = await fetch(joinURL(baseURL, '/users'), {
           method,
@@ -823,8 +788,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
         });
         expect(response.status).toBe(200);
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(2);
+        expect(handler.requests).toHaveLength(2);
 
         for (const body of ['cont', '']) {
           const responsePromise = fetch(joinURL(baseURL, '/users'), {
@@ -834,8 +798,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
 
           await expectFetchError(responsePromise);
 
-          requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(2);
+          expect(handler.requests).toHaveLength(2);
         }
       });
     });
@@ -875,8 +838,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
         );
         expect(handler).toBeInstanceOf(Handler);
 
-        let requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
         const response = await fetch(joinURL(baseURL, '/users'), {
           method,
@@ -885,8 +847,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
         });
         expect(response.status).toBe(200);
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(1);
+        expect(handler.requests).toHaveLength(1);
 
         for (const body of [
           new File(['more-content'], 'file.bin', { type: 'application/octet-stream' }),
@@ -902,8 +863,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
 
           await expectFetchError(responsePromise);
 
-          requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(1);
+          expect(handler.requests).toHaveLength(1);
         }
       });
     });
@@ -943,8 +903,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
         );
         expect(handler).toBeInstanceOf(Handler);
 
-        let requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
         let response = await fetch(joinURL(baseURL, '/users'), {
           method,
@@ -953,8 +912,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
         });
         expect(response.status).toBe(200);
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(1);
+        expect(handler.requests).toHaveLength(1);
 
         response = await fetch(joinURL(baseURL, '/users'), {
           method,
@@ -963,8 +921,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
         });
         expect(response.status).toBe(200);
 
-        requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(2);
+        expect(handler.requests).toHaveLength(2);
 
         for (const body of [
           new File(['content'], 'file.bin', { type: 'text/plain' }),
@@ -979,8 +936,7 @@ export async function declareRestrictionsHttpInterceptorTests(options: RuntimeSh
 
           await expectFetchError(responsePromise);
 
-          requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(2);
+          expect(handler.requests).toHaveLength(2);
         }
       });
     });

--- a/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/times.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/times.ts
@@ -70,8 +70,7 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
           );
           expect(handler).toBeInstanceOf(Handler);
 
-          let requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(0);
+          expect(handler.requests).toHaveLength(0);
 
           await expectTimesCheckError(
             async () => {
@@ -88,8 +87,7 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
           let response = await fetch(joinURL(baseURL, '/users'), { method });
           expect(response.status).toBe(200);
 
-          requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+          expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
 
           await promiseIfRemote(interceptor.checkTimes(), interceptor);
 
@@ -98,8 +96,7 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
           response = await fetch(joinURL(baseURL, '/users'), { method });
           expect(response.status).toBe(200);
 
-          requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(numberOfRequestsIncludingPreflight * 2);
+          expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight * 2);
 
           await promiseIfRemote(interceptor.checkTimes(), interceptor);
 
@@ -108,8 +105,7 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
           response = await fetch(joinURL(baseURL, '/users'), { method });
           expect(response.status).toBe(200);
 
-          requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(numberOfRequestsIncludingPreflight * 3);
+          expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight * 3);
 
           await promiseIfRemote(interceptor.checkTimes(), interceptor);
         });
@@ -135,8 +131,7 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
           );
           expect(handler).toBeInstanceOf(Handler);
 
-          let requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(0);
+          expect(handler.requests).toHaveLength(0);
 
           await expectTimesCheckError(
             async () => {
@@ -151,8 +146,7 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
           let response = await fetch(joinURL(baseURL, '/users'), { method });
           expect(response.status).toBe(200);
 
-          requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+          expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
 
           await expectTimesCheckError(
             async () => {
@@ -169,8 +163,7 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
           response = await fetch(joinURL(baseURL, '/users'), { method });
           expect(response.status).toBe(200);
 
-          requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(numberOfRequestsIncludingPreflight * 2);
+          expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight * 2);
 
           await promiseIfRemote(interceptor.checkTimes(), interceptor);
 
@@ -179,8 +172,7 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
           response = await fetch(joinURL(baseURL, '/users'), { method });
           expect(response.status).toBe(200);
 
-          requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(numberOfRequestsIncludingPreflight * 3);
+          expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight * 3);
 
           await expectTimesCheckError(
             async () => {
@@ -216,8 +208,7 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
           );
           expect(handler).toBeInstanceOf(Handler);
 
-          let requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(0);
+          expect(handler.requests).toHaveLength(0);
 
           await expectTimesCheckError(
             async () => {
@@ -234,8 +225,7 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
           const response = await fetch(joinURL(baseURL, '/users'), { method });
           expect(response.status).toBe(200);
 
-          requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+          expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
 
           await promiseIfRemote(interceptor.checkTimes(), interceptor);
 
@@ -250,8 +240,7 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
             await expectFetchError(responsePromise);
           }
 
-          requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+          expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
 
           await expectTimesCheckError(
             async () => {
@@ -275,8 +264,7 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
             await expectFetchError(responsePromise);
           }
 
-          requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+          expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
 
           await expectTimesCheckError(
             async () => {
@@ -318,30 +306,26 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
 
           await promiseIfRemote(interceptor.checkTimes(), interceptor);
 
-          let requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(0);
+          expect(handler.requests).toHaveLength(0);
 
           let response = await fetch(joinURL(baseURL, '/users'), { method });
           expect(response.status).toBe(200);
 
-          requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+          expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
 
           await promiseIfRemote(interceptor.checkTimes(), interceptor);
 
           response = await fetch(joinURL(baseURL, '/users'), { method });
           expect(response.status).toBe(200);
 
-          requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(numberOfRequestsIncludingPreflight * 2);
+          expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight * 2);
 
           await promiseIfRemote(interceptor.checkTimes(), interceptor);
 
           response = await fetch(joinURL(baseURL, '/users'), { method });
           expect(response.status).toBe(200);
 
-          requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(numberOfRequestsIncludingPreflight * 3);
+          expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight * 3);
 
           await promiseIfRemote(interceptor.checkTimes(), interceptor);
         });
@@ -367,8 +351,7 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
           );
           expect(handler).toBeInstanceOf(Handler);
 
-          let requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(0);
+          expect(handler.requests).toHaveLength(0);
 
           await expectTimesCheckError(
             async () => {
@@ -386,8 +369,7 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
           let response = await fetch(joinURL(baseURL, '/users'), { method });
           expect(response.status).toBe(200);
 
-          requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+          expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
 
           await expectTimesCheckError(
             async () => {
@@ -407,8 +389,7 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
           response = await fetch(joinURL(baseURL, '/users'), { method });
           expect(response.status).toBe(200);
 
-          requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(numberOfRequestsIncludingPreflight * 2);
+          expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight * 2);
 
           await promiseIfRemote(interceptor.checkTimes(), interceptor);
         });
@@ -443,8 +424,7 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
           response = await fetch(joinURL(baseURL, '/users'), { method });
           expect(response.status).toBe(200);
 
-          const requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(numberOfRequestsIncludingPreflight * 3);
+          expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight * 3);
 
           await promiseIfRemote(interceptor.checkTimes(), interceptor);
         });
@@ -479,8 +459,7 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
           response = await fetch(joinURL(baseURL, '/users'), { method });
           expect(response.status).toBe(200);
 
-          let requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(numberOfRequestsIncludingPreflight * 3);
+          expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight * 3);
 
           await promiseIfRemote(interceptor.checkTimes(), interceptor);
 
@@ -495,8 +474,7 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
             await expectFetchError(responsePromise);
           }
 
-          requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(numberOfRequestsIncludingPreflight * 3);
+          expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight * 3);
 
           await expectTimesCheckError(
             async () => {
@@ -551,8 +529,7 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
           const response = await fetch(joinURL(baseURL, '/users'), { method });
           expect(response.status).toBe(200);
 
-          let requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+          expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
 
           await promiseIfRemote(interceptor.checkTimes(), interceptor);
 
@@ -567,8 +544,7 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
             await expectFetchError(responsePromise);
           }
 
-          requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+          expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
 
           await expectTimesCheckError(
             async () => {
@@ -608,8 +584,7 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
           );
           expect(handler).toBeInstanceOf(Handler);
 
-          let requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(0);
+          expect(handler.requests).toHaveLength(0);
 
           await expectTimesCheckError(
             async () => {
@@ -629,8 +604,7 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
             await expectFetchError(responsePromise);
           }
 
-          requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(0);
+          expect(handler.requests).toHaveLength(0);
 
           const contentLines = [
             'Expected exactly 1 matching request, but got 0.',
@@ -680,8 +654,7 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
           const handler = await promiseIfRemote(interceptor[lowerMethod]('/users').times(1), interceptor);
           expect(handler).toBeInstanceOf(Handler);
 
-          let requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(0);
+          expect(handler.requests).toHaveLength(0);
 
           await expectTimesCheckError(
             async () => {
@@ -698,8 +671,7 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
             await expectFetchError(responsePromise);
           }
 
-          requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(0);
+          expect(handler.requests).toHaveLength(0);
 
           await expectTimesCheckError(
             async () => {
@@ -731,8 +703,7 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
           );
           expect(handler).toBeInstanceOf(Handler);
 
-          let requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(0);
+          expect(handler.requests).toHaveLength(0);
 
           await expectTimesCheckError(
             async () => {
@@ -749,8 +720,7 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
             await expectFetchError(responsePromise);
           }
 
-          requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(0);
+          expect(handler.requests).toHaveLength(0);
 
           await expectTimesCheckError(
             async () => {

--- a/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/types.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/types.ts
@@ -42,7 +42,7 @@ export function declareTypeHttpInterceptorTests(
         };
       };
     }>({ type, baseURL }, async (interceptor) => {
-      const creationHandler = await interceptor.post('/users').respond((request) => {
+      const _creationHandler = await interceptor.post('/users').respond((request) => {
         expectTypeOf(request.body).toEqualTypeOf<User>();
 
         return {
@@ -51,8 +51,7 @@ export function declareTypeHttpInterceptorTests(
         };
       });
 
-      const _creationRequests = await creationHandler.requests();
-      type RequestBody = (typeof _creationRequests)[number]['body'];
+      type RequestBody = (typeof _creationHandler.requests)[number]['body'];
       expectTypeOf<RequestBody>().toEqualTypeOf<User>();
     });
   });
@@ -76,7 +75,7 @@ export function declareTypeHttpInterceptorTests(
         };
       };
     }>({ type, baseURL }, async (interceptor) => {
-      const listHandler = await interceptor.get('/users').respond((request) => {
+      const _listHandler = await interceptor.get('/users').respond((request) => {
         expectTypeOf(request.searchParams).toEqualTypeOf<HttpSearchParams<UserListSearchParams>>();
 
         return {
@@ -85,8 +84,7 @@ export function declareTypeHttpInterceptorTests(
         };
       });
 
-      const _listRequests = await listHandler.requests();
-      type RequestSearchParams = (typeof _listRequests)[number]['searchParams'];
+      type RequestSearchParams = (typeof _listHandler.requests)[number]['searchParams'];
       expectTypeOf<RequestSearchParams>().toEqualTypeOf<HttpSearchParams<UserListSearchParams>>();
     });
   });
@@ -112,7 +110,7 @@ export function declareTypeHttpInterceptorTests(
         };
       };
     }>({ type, baseURL }, async (interceptor) => {
-      const listHandler = await interceptor.get('/users').respond((request) => {
+      const _listHandler = await interceptor.get('/users').respond((request) => {
         expectTypeOf(request.searchParams).toEqualTypeOf<
           HttpSearchParams<HttpSearchParamsSerialized<UserListSearchParams>>
         >();
@@ -123,8 +121,7 @@ export function declareTypeHttpInterceptorTests(
         };
       });
 
-      const _listRequests = await listHandler.requests();
-      type RequestSearchParams = (typeof _listRequests)[number]['searchParams'];
+      type RequestSearchParams = (typeof _listHandler.requests)[number]['searchParams'];
       expectTypeOf<RequestSearchParams>().toEqualTypeOf<
         HttpSearchParams<HttpSearchParamsSerialized<UserListSearchParams>>
       >();
@@ -151,7 +148,7 @@ export function declareTypeHttpInterceptorTests(
         };
       };
     }>({ type, baseURL }, async (interceptor) => {
-      const listHandler = await interceptor.get('/users').respond((request) => {
+      const _listHandler = await interceptor.get('/users').respond((request) => {
         expectTypeOf(request.searchParams).toEqualTypeOf<HttpSearchParams<never>>();
 
         return {
@@ -160,8 +157,7 @@ export function declareTypeHttpInterceptorTests(
         };
       });
 
-      const _listRequests = await listHandler.requests();
-      type RequestSearchParams = (typeof _listRequests)[number]['searchParams'];
+      type RequestSearchParams = (typeof _listHandler.requests)[number]['searchParams'];
       expectTypeOf<RequestSearchParams>().toEqualTypeOf<HttpSearchParams<never>>();
     });
   });
@@ -184,7 +180,7 @@ export function declareTypeHttpInterceptorTests(
         };
       };
     }>({ type, baseURL }, async (interceptor) => {
-      const listHandler = await interceptor.get('/users').respond((request) => {
+      const _listHandler = await interceptor.get('/users').respond((request) => {
         expectTypeOf(request.headers).toEqualTypeOf<HttpHeaders<UserListHeaders>>();
 
         return {
@@ -193,8 +189,7 @@ export function declareTypeHttpInterceptorTests(
         };
       });
 
-      const _listRequests = await listHandler.requests();
-      type RequestHeaders = (typeof _listRequests)[number]['headers'];
+      type RequestHeaders = (typeof _listHandler.requests)[number]['headers'];
       expectTypeOf<RequestHeaders>().toEqualTypeOf<HttpHeaders<UserListHeaders>>();
     });
   });
@@ -219,7 +214,7 @@ export function declareTypeHttpInterceptorTests(
         };
       };
     }>({ type, baseURL }, async (interceptor) => {
-      const listHandler = await interceptor.get('/users').respond((request) => {
+      const _listHandler = await interceptor.get('/users').respond((request) => {
         expectTypeOf(request.headers).toEqualTypeOf<HttpHeaders<HttpHeadersSerialized<UserListHeaders>>>();
 
         return {
@@ -228,8 +223,7 @@ export function declareTypeHttpInterceptorTests(
         };
       });
 
-      const _listRequests = await listHandler.requests();
-      type RequestHeaders = (typeof _listRequests)[number]['headers'];
+      type RequestHeaders = (typeof _listHandler.requests)[number]['headers'];
       expectTypeOf<RequestHeaders>().toEqualTypeOf<HttpHeaders<HttpHeadersSerialized<UserListHeaders>>>();
     });
   });
@@ -251,7 +245,7 @@ export function declareTypeHttpInterceptorTests(
         };
       };
     }>({ type, baseURL }, async (interceptor) => {
-      const listHandler = await interceptor.get('/users').respond((request) => {
+      const _listHandler = await interceptor.get('/users').respond((request) => {
         expectTypeOf(request.headers).toEqualTypeOf<HttpHeaders<UserListHeaders>>();
 
         return {
@@ -260,8 +254,7 @@ export function declareTypeHttpInterceptorTests(
         };
       });
 
-      const _listRequests = await listHandler.requests();
-      type RequestHeaders = (typeof _listRequests)[number]['headers'];
+      type RequestHeaders = (typeof _listHandler.requests)[number]['headers'];
       expectTypeOf<RequestHeaders>().toEqualTypeOf<HttpHeaders<UserListHeaders>>();
     });
   });
@@ -286,7 +279,7 @@ export function declareTypeHttpInterceptorTests(
         };
       };
     }>({ type, baseURL }, async (interceptor) => {
-      const listHandler = await interceptor.get('/users').respond((request) => {
+      const _listHandler = await interceptor.get('/users').respond((request) => {
         expectTypeOf(request.headers).toEqualTypeOf<HttpHeaders<never>>();
 
         return {
@@ -295,8 +288,7 @@ export function declareTypeHttpInterceptorTests(
         };
       });
 
-      const _listRequests = await listHandler.requests();
-      type RequestHeaders = (typeof _listRequests)[number]['headers'];
+      type RequestHeaders = (typeof _listHandler.requests)[number]['headers'];
       expectTypeOf<RequestHeaders>().toEqualTypeOf<HttpHeaders<never>>();
     });
   });
@@ -323,9 +315,8 @@ export function declareTypeHttpInterceptorTests(
         })),
       ]);
 
-      for (const handler of successfulHandlers) {
-        const _successfulRequests = await handler.requests();
-        type SuccessfulResponseBody = (typeof _successfulRequests)[number]['response']['body'];
+      for (const _handler of successfulHandlers) {
+        type SuccessfulResponseBody = (typeof _handler.requests)[number]['response']['body'];
         expectTypeOf<SuccessfulResponseBody>().toEqualTypeOf<User[]>();
       }
 
@@ -340,9 +331,8 @@ export function declareTypeHttpInterceptorTests(
         })),
       ];
 
-      for (const handler of failedHandlers) {
-        const _failedRequests = await handler.requests();
-        type FailedResponseBody = (typeof _failedRequests)[number]['response']['body'];
+      for (const _handler of failedHandlers) {
+        type FailedResponseBody = (typeof _handler.requests)[number]['response']['body'];
         expectTypeOf<FailedResponseBody>().toEqualTypeOf<{ message: string }>();
       }
     });
@@ -368,7 +358,7 @@ export function declareTypeHttpInterceptorTests(
         };
       };
     }>({ type, baseURL }, async (interceptor) => {
-      const handler = await interceptor.get('/users').respond((request) => {
+      const _handler = await interceptor.get('/users').respond((request) => {
         const name = request.searchParams.get('name');
 
         if (!name) {
@@ -389,14 +379,13 @@ export function declareTypeHttpInterceptorTests(
         };
       });
 
-      const _requests = await handler.requests();
-      type ResponseBody = (typeof _requests)[number]['response']['body'];
+      type ResponseBody = (typeof _handler.requests)[number]['response']['body'];
       expectTypeOf<ResponseBody>().toEqualTypeOf<User[] | { message: string } | null>();
 
-      type ResponseHeaders = (typeof _requests)[number]['response']['headers'];
+      type ResponseHeaders = (typeof _handler.requests)[number]['response']['headers'];
       expectTypeOf<ResponseHeaders>().toEqualTypeOf<HttpHeaders<{ 'content-type': string }> | HttpHeaders<never>>();
 
-      type ResponseStatus = (typeof _requests)[number]['response']['status'];
+      type ResponseStatus = (typeof _handler.requests)[number]['response']['status'];
       expectTypeOf<ResponseStatus>().toEqualTypeOf<200 | 400 | 404>();
 
       // @ts-expect-error Each response declaration should match the status code
@@ -471,7 +460,7 @@ export function declareTypeHttpInterceptorTests(
         };
       };
     }>({ type, baseURL }, async (interceptor) => {
-      const handler = await interceptor.get('/users').respond((request) => {
+      const _handler = await interceptor.get('/users').respond((request) => {
         const name = request.searchParams.get('name');
 
         if (!name) {
@@ -504,14 +493,13 @@ export function declareTypeHttpInterceptorTests(
         };
       });
 
-      const _requests = await handler.requests();
-      type ResponseBody = (typeof _requests)[number]['response']['body'];
+      type ResponseBody = (typeof _handler.requests)[number]['response']['body'];
       expectTypeOf<ResponseBody>().toEqualTypeOf<User[] | { message: string } | '2xx' | '4xx' | 'default' | null>();
 
-      type ResponseHeaders = (typeof _requests)[number]['response']['headers'];
+      type ResponseHeaders = (typeof _handler.requests)[number]['response']['headers'];
       expectTypeOf<ResponseHeaders>().toEqualTypeOf<HttpHeaders<{ 'content-type': string }> | HttpHeaders<never>>();
 
-      type ResponseStatus = (typeof _requests)[number]['response']['status'];
+      type ResponseStatus = (typeof _handler.requests)[number]['response']['status'];
       expectTypeOf<ResponseStatus>().toEqualTypeOf<200 | 201 | 204 | 400 | 401 | 404 | 500>();
 
       // @ts-expect-error Each response declaration should match the status code
@@ -574,7 +562,7 @@ export function declareTypeHttpInterceptorTests(
         };
       };
     }>({ type, baseURL }, async (interceptor) => {
-      const listHandler = await interceptor.get('/users').respond({
+      const _listHandler = await interceptor.get('/users').respond({
         status: 200,
         headers: {
           accept: '*/*',
@@ -582,8 +570,7 @@ export function declareTypeHttpInterceptorTests(
         body: users[0],
       });
 
-      const _listRequests = await listHandler.requests();
-      type ResponseHeaders = (typeof _listRequests)[number]['response']['headers'];
+      type ResponseHeaders = (typeof _listHandler.requests)[number]['response']['headers'];
       expectTypeOf<ResponseHeaders>().toEqualTypeOf<HttpHeaders<UserListHeaders>>();
     });
   });
@@ -607,7 +594,7 @@ export function declareTypeHttpInterceptorTests(
         };
       };
     }>({ type, baseURL }, async (interceptor) => {
-      const listHandler = await interceptor.get('/users').respond({
+      const _listHandler = await interceptor.get('/users').respond({
         status: 200,
         headers: {
           accept: '*/*',
@@ -615,8 +602,7 @@ export function declareTypeHttpInterceptorTests(
         body: users[0],
       });
 
-      const _listRequests = await listHandler.requests();
-      type ResponseHeaders = (typeof _listRequests)[number]['response']['headers'];
+      type ResponseHeaders = (typeof _listHandler.requests)[number]['response']['headers'];
       expectTypeOf<ResponseHeaders>().toEqualTypeOf<HttpHeaders<HttpHeadersSerialized<UserListHeaders>>>();
     });
   });
@@ -640,31 +626,30 @@ export function declareTypeHttpInterceptorTests(
         };
       };
     }>({ type, baseURL }, async (interceptor) => {
-      let listHandler = await interceptor.get('/users').respond({
+      let _listHandler = await interceptor.get('/users').respond({
         status: 200,
         body: users[0],
       });
 
-      listHandler = await interceptor.get('/users').respond({
+      _listHandler = await interceptor.get('/users').respond({
         status: 200,
         headers: {},
         body: users[0],
       });
 
-      listHandler = await interceptor.get('/users').respond({
+      _listHandler = await interceptor.get('/users').respond({
         status: 200,
         headers: { 'content-type': undefined },
         body: users[0],
       });
 
-      listHandler = await interceptor.get('/users').respond({
+      _listHandler = await interceptor.get('/users').respond({
         status: 200,
         headers: { 'content-type': 'application/json' },
         body: users[0],
       });
 
-      const _listRequests = await listHandler.requests();
-      type ResponseHeaders = (typeof _listRequests)[number]['response']['headers'];
+      type ResponseHeaders = (typeof _listHandler.requests)[number]['response']['headers'];
       expectTypeOf<ResponseHeaders>().toEqualTypeOf<HttpHeaders<UserListHeaders>>();
     });
   });
@@ -690,40 +675,39 @@ export function declareTypeHttpInterceptorTests(
       };
     }>({ type, baseURL }, async (interceptor) => {
       // @ts-expect-error Headers are required
-      let listHandler = await interceptor.get('/users').respond({
+      let _listHandler = await interceptor.get('/users').respond({
         status: 200,
         body: users[0],
       });
 
-      listHandler = await interceptor.get('/users').respond({
+      _listHandler = await interceptor.get('/users').respond({
         status: 200,
         // @ts-expect-error Providing an accept header is required
         headers: {},
         body: users[0],
       });
 
-      listHandler = await interceptor.get('/users').respond({
+      _listHandler = await interceptor.get('/users').respond({
         status: 200,
         // @ts-expect-error Providing an accept header is required
         headers: { 'content-type': undefined },
         body: users[0],
       });
 
-      listHandler = await interceptor.get('/users').respond({
+      _listHandler = await interceptor.get('/users').respond({
         status: 200,
         // @ts-expect-error Providing an accept header is required
         headers: { 'content-type': 'application/json' },
         body: users[0],
       });
 
-      listHandler = await interceptor.get('/users').respond({
+      _listHandler = await interceptor.get('/users').respond({
         status: 200,
         headers: { 'content-type': 'application/json', accept: '*/*' },
         body: users[0],
       });
 
-      const _listRequests = await listHandler.requests();
-      type ResponseHeaders = (typeof _listRequests)[number]['response']['headers'];
+      type ResponseHeaders = (typeof _listHandler.requests)[number]['response']['headers'];
       expectTypeOf<ResponseHeaders>().toEqualTypeOf<HttpHeaders<UserListHeaders>>();
     });
   });
@@ -749,37 +733,36 @@ export function declareTypeHttpInterceptorTests(
       };
     }>({ type, baseURL }, async (interceptor) => {
       // @ts-expect-error Headers are required
-      let listHandler = await interceptor.get('/users').respond({
+      let _listHandler = await interceptor.get('/users').respond({
         status: 200,
         body: users[0],
       });
 
-      listHandler = await interceptor.get('/users').respond({
+      _listHandler = await interceptor.get('/users').respond({
         status: 200,
         headers: {},
         body: users[0],
       });
 
-      listHandler = await interceptor.get('/users').respond({
+      _listHandler = await interceptor.get('/users').respond({
         status: 200,
         headers: { 'content-type': undefined },
         body: users[0],
       });
 
-      listHandler = await interceptor.get('/users').respond({
+      _listHandler = await interceptor.get('/users').respond({
         status: 200,
         headers: { 'content-type': 'application/json' },
         body: users[0],
       });
 
-      listHandler = await interceptor.get('/users').respond({
+      _listHandler = await interceptor.get('/users').respond({
         status: 200,
         headers: { 'content-type': 'application/json', accept: '*/*' },
         body: users[0],
       });
 
-      const _listRequests = await listHandler.requests();
-      type ResponseHeaders = (typeof _listRequests)[number]['response']['headers'];
+      type ResponseHeaders = (typeof _listHandler.requests)[number]['response']['headers'];
       expectTypeOf<ResponseHeaders>().toEqualTypeOf<HttpHeaders<UserListHeaders>>();
     });
   });
@@ -802,13 +785,12 @@ export function declareTypeHttpInterceptorTests(
         };
       };
     }>({ type, baseURL }, async (interceptor) => {
-      const listHandler = await interceptor.get('/users').respond({
+      const _listHandler = await interceptor.get('/users').respond({
         status: 200,
         body: users[0],
       });
 
-      const _listRequests = await listHandler.requests();
-      type ResponseHeaders = (typeof _listRequests)[number]['response']['headers'];
+      type ResponseHeaders = (typeof _listHandler.requests)[number]['response']['headers'];
       expectTypeOf<ResponseHeaders>().toEqualTypeOf<HttpHeaders<never>>();
     });
   });
@@ -979,7 +961,7 @@ export function declareTypeHttpInterceptorTests(
     }>;
 
     await usingHttpInterceptor<Schema>({ type, baseURL }, async (interceptor) => {
-      const userCreationHandler = await interceptor.post('/users').respond((request) => {
+      const _creationHandler = await interceptor.post('/users').respond((request) => {
         expectTypeOf(request.body).toEqualTypeOf<User>();
 
         return {
@@ -988,15 +970,13 @@ export function declareTypeHttpInterceptorTests(
         };
       });
 
-      const _userCreationRequests = await userCreationHandler.requests();
-
-      type UserCreationRequestBody = (typeof _userCreationRequests)[number]['body'];
+      type UserCreationRequestBody = (typeof _creationHandler.requests)[number]['body'];
       expectTypeOf<UserCreationRequestBody>().toEqualTypeOf<User>();
 
-      type UserCreationResponseBody = (typeof _userCreationRequests)[number]['response']['body'];
+      type UserCreationResponseBody = (typeof _creationHandler.requests)[number]['response']['body'];
       expectTypeOf<UserCreationResponseBody>().toEqualTypeOf<User>();
 
-      const userListHandler = await interceptor.get('/users').respond((request) => {
+      const _listHandler = await interceptor.get('/users').respond((request) => {
         expectTypeOf(request.body).toEqualTypeOf<null>();
         expect(request.body).toBe(null);
 
@@ -1006,15 +986,13 @@ export function declareTypeHttpInterceptorTests(
         };
       });
 
-      const _userListRequests = await userListHandler.requests();
-
-      type UserListRequestBody = (typeof _userListRequests)[number]['body'];
+      type UserListRequestBody = (typeof _listHandler.requests)[number]['body'];
       expectTypeOf<UserListRequestBody>().toEqualTypeOf<null>();
 
-      type UserListResponseBody = (typeof _userListRequests)[number]['response']['body'];
+      type UserListResponseBody = (typeof _listHandler.requests)[number]['response']['body'];
       expectTypeOf<UserListResponseBody>().toEqualTypeOf<User[]>();
 
-      const groupGetHandler = await interceptor.get('/groups/1').respond((request) => {
+      const _getGroupHandler = await interceptor.get('/groups/1').respond((request) => {
         expectTypeOf(request.body).toEqualTypeOf<null>();
         expect(request.body).toBe(null);
 
@@ -1024,14 +1002,12 @@ export function declareTypeHttpInterceptorTests(
         };
       });
 
-      expectTypeOf<HttpRequestHandlerPath<typeof groupGetHandler>>().toEqualTypeOf<'/groups/:groupId'>();
+      expectTypeOf<HttpRequestHandlerPath<typeof _getGroupHandler>>().toEqualTypeOf<'/groups/:groupId'>();
 
-      const _groupGetRequests = await groupGetHandler.requests();
-
-      type GroupGetRequestBody = (typeof _groupGetRequests)[number]['body'];
+      type GroupGetRequestBody = (typeof _getGroupHandler.requests)[number]['body'];
       expectTypeOf<GroupGetRequestBody>().toEqualTypeOf<null>();
 
-      type GroupGetResponseBody = (typeof _groupGetRequests)[number]['response']['body'];
+      type GroupGetResponseBody = (typeof _getGroupHandler.requests)[number]['response']['body'];
       expectTypeOf<GroupGetResponseBody>().toEqualTypeOf<{ users: User[] }>();
     });
   });
@@ -1271,7 +1247,7 @@ export function declareTypeHttpInterceptorTests(
 
     it('should correctly type requests with static paths that conflict with a dynamic path, preferring the former', async () => {
       await usingHttpInterceptor<SchemaWithDynamicPaths>({ type, baseURL }, async (interceptor) => {
-        const getHandler = await interceptor.get('/groups/users').respond((request) => {
+        const _getHandler = await interceptor.get('/groups/users').respond((request) => {
           expectTypeOf(request.pathParams).toEqualTypeOf<{}>();
           expectTypeOf(request.body).toEqualTypeOf<null>();
 
@@ -1281,15 +1257,14 @@ export function declareTypeHttpInterceptorTests(
           };
         });
 
-        expectTypeOf<HttpRequestHandlerPath<typeof getHandler>>().toEqualTypeOf<'/groups/users'>();
+        expectTypeOf<HttpRequestHandlerPath<typeof _getHandler>>().toEqualTypeOf<'/groups/users'>();
 
-        const _getRequests = await getHandler.requests();
-        type GetRequestBody = (typeof _getRequests)[number]['body'];
+        type GetRequestBody = (typeof _getHandler.requests)[number]['body'];
         expectTypeOf<GetRequestBody>().toEqualTypeOf<null>();
-        type GetResponseBody = (typeof _getRequests)[number]['response']['body'];
+        type GetResponseBody = (typeof _getHandler.requests)[number]['response']['body'];
         expectTypeOf<GetResponseBody>().toEqualTypeOf<'path /groups/users'>();
 
-        const otherHandler = await interceptor.get('/groups/1/users/other').respond((request) => {
+        const _otherHandler = await interceptor.get('/groups/1/users/other').respond((request) => {
           expectTypeOf(request.pathParams).toEqualTypeOf<{ groupId: string }>();
           expectTypeOf(request.body).toEqualTypeOf<null>();
 
@@ -1299,19 +1274,18 @@ export function declareTypeHttpInterceptorTests(
           };
         });
 
-        expectTypeOf<HttpRequestHandlerPath<typeof otherHandler>>().toEqualTypeOf<'/groups/:groupId/users/other'>();
+        expectTypeOf<HttpRequestHandlerPath<typeof _otherHandler>>().toEqualTypeOf<'/groups/:groupId/users/other'>();
 
-        const _otherGetRequests = await otherHandler.requests();
-        type OtherGetRequestBody = (typeof _otherGetRequests)[number]['body'];
+        type OtherGetRequestBody = (typeof _otherHandler.requests)[number]['body'];
         expectTypeOf<OtherGetRequestBody>().toEqualTypeOf<null>();
-        type OtherGetResponseBody = (typeof _otherGetRequests)[number]['response']['body'];
+        type OtherGetResponseBody = (typeof _otherHandler.requests)[number]['response']['body'];
         expectTypeOf<OtherGetResponseBody>().toEqualTypeOf<'path /groups/:groupId/users/other'>();
       });
     });
 
     it('should correctly type requests with dynamic paths containing one parameter at the start of the path', async () => {
       await usingHttpInterceptor<SchemaWithDynamicPaths>({ type, baseURL }, async (interceptor) => {
-        const genericGetHandler = await interceptor.get('/:any').respond((request) => {
+        const _genericGetHandler = await interceptor.get('/:any').respond((request) => {
           expectTypeOf(request.pathParams).toEqualTypeOf<{ any: string }>();
           expectTypeOf(request.body).toEqualTypeOf<null>();
 
@@ -1321,15 +1295,14 @@ export function declareTypeHttpInterceptorTests(
           };
         });
 
-        expectTypeOf<HttpRequestHandlerPath<typeof genericGetHandler>>().toEqualTypeOf<'/:any'>();
+        expectTypeOf<HttpRequestHandlerPath<typeof _genericGetHandler>>().toEqualTypeOf<'/:any'>();
 
-        const _genericGetRequests = await genericGetHandler.requests();
-        type GenericRequestBody = (typeof _genericGetRequests)[number]['body'];
+        type GenericRequestBody = (typeof _genericGetHandler.requests)[number]['body'];
         expectTypeOf<GenericRequestBody>().toEqualTypeOf<null>();
-        type GenericResponseBody = (typeof _genericGetRequests)[number]['response']['body'];
+        type GenericResponseBody = (typeof _genericGetHandler.requests)[number]['response']['body'];
         expectTypeOf<GenericResponseBody>().toEqualTypeOf<'path /:any'>();
 
-        const specificGetHandler = await interceptor.get('/1').respond((request) => {
+        const _specificGetHandler = await interceptor.get('/1').respond((request) => {
           expectTypeOf(request.pathParams).toEqualTypeOf<{ any: string }>();
           expectTypeOf(request.body).toEqualTypeOf<null>();
 
@@ -1339,21 +1312,20 @@ export function declareTypeHttpInterceptorTests(
           };
         });
 
-        expectTypeOf<HttpRequestHandlerPath<typeof specificGetHandler>>().toEqualTypeOf<
-          HttpRequestHandlerPath<typeof genericGetHandler>
+        expectTypeOf<HttpRequestHandlerPath<typeof _specificGetHandler>>().toEqualTypeOf<
+          HttpRequestHandlerPath<typeof _genericGetHandler>
         >();
 
-        const _specificGetRequests = await specificGetHandler.requests();
-        type SpecificRequestBody = (typeof _specificGetRequests)[number]['body'];
+        type SpecificRequestBody = (typeof _specificGetHandler.requests)[number]['body'];
         expectTypeOf<SpecificRequestBody>().toEqualTypeOf<null>();
-        type SpecificResponseBody = (typeof _specificGetRequests)[number]['response']['body'];
+        type SpecificResponseBody = (typeof _specificGetHandler.requests)[number]['response']['body'];
         expectTypeOf<SpecificResponseBody>().toEqualTypeOf<GenericResponseBody>();
       });
     });
 
     it('should correctly type requests with dynamic paths containing one parameter in the middle of the path', async () => {
       await usingHttpInterceptor<SchemaWithDynamicPaths>({ type, baseURL }, async (interceptor) => {
-        const genericGetHandler = await interceptor.get('/groups/:groupId/users').respond((request) => {
+        const _genericGetHandler = await interceptor.get('/groups/:groupId/users').respond((request) => {
           expectTypeOf(request.pathParams).toEqualTypeOf<{ groupId: string }>();
           expectTypeOf(request.body).toEqualTypeOf<null>();
 
@@ -1363,15 +1335,14 @@ export function declareTypeHttpInterceptorTests(
           };
         });
 
-        expectTypeOf<HttpRequestHandlerPath<typeof genericGetHandler>>().toEqualTypeOf<'/groups/:groupId/users'>();
+        expectTypeOf<HttpRequestHandlerPath<typeof _genericGetHandler>>().toEqualTypeOf<'/groups/:groupId/users'>();
 
-        const _genericGetRequests = await genericGetHandler.requests();
-        type GenericRequestBody = (typeof _genericGetRequests)[number]['body'];
+        type GenericRequestBody = (typeof _genericGetHandler.requests)[number]['body'];
         expectTypeOf<GenericRequestBody>().toEqualTypeOf<null>();
-        type GenericResponseBody = (typeof _genericGetRequests)[number]['response']['body'];
+        type GenericResponseBody = (typeof _genericGetHandler.requests)[number]['response']['body'];
         expectTypeOf<GenericResponseBody>().toEqualTypeOf<'path /groups/:groupId/users'>();
 
-        const specificGetHandler = await interceptor.get('/groups/1/users').respond((request) => {
+        const _specificGetHandler = await interceptor.get('/groups/1/users').respond((request) => {
           expectTypeOf(request.pathParams).toEqualTypeOf<{ groupId: string }>();
           expectTypeOf(request.body).toEqualTypeOf<null>();
 
@@ -1381,21 +1352,20 @@ export function declareTypeHttpInterceptorTests(
           };
         });
 
-        expectTypeOf<HttpRequestHandlerPath<typeof specificGetHandler>>().toEqualTypeOf<
-          HttpRequestHandlerPath<typeof genericGetHandler>
+        expectTypeOf<HttpRequestHandlerPath<typeof _specificGetHandler>>().toEqualTypeOf<
+          HttpRequestHandlerPath<typeof _genericGetHandler>
         >();
 
-        const _specificGetRequests = await specificGetHandler.requests();
-        type SpecificRequestBody = (typeof _specificGetRequests)[number]['body'];
+        type SpecificRequestBody = (typeof _specificGetHandler.requests)[number]['body'];
         expectTypeOf<SpecificRequestBody>().toEqualTypeOf<null>();
-        type SpecificResponseBody = (typeof _specificGetRequests)[number]['response']['body'];
+        type SpecificResponseBody = (typeof _specificGetHandler.requests)[number]['response']['body'];
         expectTypeOf<SpecificResponseBody>().toEqualTypeOf<GenericResponseBody>();
       });
     });
 
     it('should correctly type requests with dynamic paths containing one parameter at the end of the path', async () => {
       await usingHttpInterceptor<SchemaWithDynamicPaths>({ type, baseURL }, async (interceptor) => {
-        const genericGetHandler = await interceptor.get('/groups/:groupId').respond((request) => {
+        const _genericGetHandler = await interceptor.get('/groups/:groupId').respond((request) => {
           expectTypeOf(request.pathParams).toEqualTypeOf<{ groupId: string }>();
           expectTypeOf(request.body).toEqualTypeOf<null>();
 
@@ -1405,15 +1375,14 @@ export function declareTypeHttpInterceptorTests(
           };
         });
 
-        expectTypeOf<HttpRequestHandlerPath<typeof genericGetHandler>>().toEqualTypeOf<'/groups/:groupId'>();
+        expectTypeOf<HttpRequestHandlerPath<typeof _genericGetHandler>>().toEqualTypeOf<'/groups/:groupId'>();
 
-        const _genericGetRequests = await genericGetHandler.requests();
-        type GenericRequestBody = (typeof _genericGetRequests)[number]['body'];
+        type GenericRequestBody = (typeof _genericGetHandler.requests)[number]['body'];
         expectTypeOf<GenericRequestBody>().toEqualTypeOf<null>();
-        type GenericResponseBody = (typeof _genericGetRequests)[number]['response']['body'];
+        type GenericResponseBody = (typeof _genericGetHandler.requests)[number]['response']['body'];
         expectTypeOf<GenericResponseBody>().toEqualTypeOf<'path /groups/:groupId'>();
 
-        const specificGetHandler = await interceptor.get('/groups/1').respond((request) => {
+        const _specificGetHandler = await interceptor.get('/groups/1').respond((request) => {
           expectTypeOf(request.pathParams).toEqualTypeOf<{ groupId: string }>();
           expectTypeOf(request.body).toEqualTypeOf<null>();
 
@@ -1423,21 +1392,20 @@ export function declareTypeHttpInterceptorTests(
           };
         });
 
-        expectTypeOf<HttpRequestHandlerPath<typeof specificGetHandler>>().toEqualTypeOf<
-          HttpRequestHandlerPath<typeof genericGetHandler>
+        expectTypeOf<HttpRequestHandlerPath<typeof _specificGetHandler>>().toEqualTypeOf<
+          HttpRequestHandlerPath<typeof _genericGetHandler>
         >();
 
-        const _specificGetRequests = await specificGetHandler.requests();
-        type SpecificRequestBody = (typeof _specificGetRequests)[number]['body'];
+        type SpecificRequestBody = (typeof _specificGetHandler.requests)[number]['body'];
         expectTypeOf<SpecificRequestBody>().toEqualTypeOf<null>();
-        type SpecificResponseBody = (typeof _specificGetRequests)[number]['response']['body'];
+        type SpecificResponseBody = (typeof _specificGetHandler.requests)[number]['response']['body'];
         expectTypeOf<SpecificResponseBody>().toEqualTypeOf<GenericResponseBody>();
       });
     });
 
     it('should correctly type requests with dynamic paths containing multiple, non-consecutive parameters', async () => {
       await usingHttpInterceptor<SchemaWithDynamicPaths>({ type, baseURL }, async (interceptor) => {
-        const genericGetHandler = await interceptor.get('/groups/:groupId/users/:userId').respond((request) => {
+        const _genericGetHandler = await interceptor.get('/groups/:groupId/users/:userId').respond((request) => {
           expectTypeOf(request.pathParams).toEqualTypeOf<{ groupId: string; userId: string }>();
           expectTypeOf(request.body).toEqualTypeOf<null>();
 
@@ -1448,16 +1416,15 @@ export function declareTypeHttpInterceptorTests(
         });
 
         expectTypeOf<
-          HttpRequestHandlerPath<typeof genericGetHandler>
+          HttpRequestHandlerPath<typeof _genericGetHandler>
         >().toEqualTypeOf<'/groups/:groupId/users/:userId'>();
 
-        const _genericGetRequests = await genericGetHandler.requests();
-        type GenericRequestBody = (typeof _genericGetRequests)[number]['body'];
+        type GenericRequestBody = (typeof _genericGetHandler.requests)[number]['body'];
         expectTypeOf<GenericRequestBody>().toEqualTypeOf<null>();
-        type GenericResponseBody = (typeof _genericGetRequests)[number]['response']['body'];
+        type GenericResponseBody = (typeof _genericGetHandler.requests)[number]['response']['body'];
         expectTypeOf<GenericResponseBody>().toEqualTypeOf<'path /groups/:groupId/users/:userId'>();
 
-        const specificGetHandler = await interceptor.get('/groups/1/users/2').respond((request) => {
+        const _specificGetHandler = await interceptor.get('/groups/1/users/2').respond((request) => {
           expectTypeOf(request.pathParams).toEqualTypeOf<{ groupId: string; userId: string }>();
           expectTypeOf(request.body).toEqualTypeOf<null>();
 
@@ -1467,21 +1434,20 @@ export function declareTypeHttpInterceptorTests(
           };
         });
 
-        expectTypeOf<HttpRequestHandlerPath<typeof specificGetHandler>>().toEqualTypeOf<
-          HttpRequestHandlerPath<typeof genericGetHandler>
+        expectTypeOf<HttpRequestHandlerPath<typeof _specificGetHandler>>().toEqualTypeOf<
+          HttpRequestHandlerPath<typeof _genericGetHandler>
         >();
 
-        const _specificGetRequests = await specificGetHandler.requests();
-        type SpecificRequestBody = (typeof _specificGetRequests)[number]['body'];
+        type SpecificRequestBody = (typeof _specificGetHandler.requests)[number]['body'];
         expectTypeOf<SpecificRequestBody>().toEqualTypeOf<null>();
-        type SpecificResponseBody = (typeof _specificGetRequests)[number]['response']['body'];
+        type SpecificResponseBody = (typeof _specificGetHandler.requests)[number]['response']['body'];
         expectTypeOf<SpecificResponseBody>().toEqualTypeOf<'path /groups/:groupId/users/:userId'>();
       });
     });
 
     it('should correctly type requests with dynamic paths containing multiple, consecutive parameters', async () => {
       await usingHttpInterceptor<SchemaWithDynamicPaths>({ type, baseURL }, async (interceptor) => {
-        const genericGetHandler = await interceptor
+        const _genericGetHandler = await interceptor
           .get('/groups/:groupId/users/:userId/:otherId')
           .respond((request) => {
             expectTypeOf(request.pathParams).toEqualTypeOf<{ groupId: string; userId: string; otherId: string }>();
@@ -1494,16 +1460,15 @@ export function declareTypeHttpInterceptorTests(
           });
 
         expectTypeOf<
-          HttpRequestHandlerPath<typeof genericGetHandler>
+          HttpRequestHandlerPath<typeof _genericGetHandler>
         >().toEqualTypeOf<'/groups/:groupId/users/:userId/:otherId'>();
 
-        const _genericGetRequests = await genericGetHandler.requests();
-        type GenericRequestBody = (typeof _genericGetRequests)[number]['body'];
+        type GenericRequestBody = (typeof _genericGetHandler.requests)[number]['body'];
         expectTypeOf<GenericRequestBody>().toEqualTypeOf<null>();
-        type GenericResponseBody = (typeof _genericGetRequests)[number]['response']['body'];
+        type GenericResponseBody = (typeof _genericGetHandler.requests)[number]['response']['body'];
         expectTypeOf<GenericResponseBody>().toEqualTypeOf<'path /groups/:groupId/users/:userId/:otherId'>();
 
-        const specificGetHandler = await interceptor.get('/groups/1/users/2/3').respond((request) => {
+        const _specificGetHandler = await interceptor.get('/groups/1/users/2/3').respond((request) => {
           expectTypeOf(request.pathParams).toEqualTypeOf<{ groupId: string; userId: string; otherId: string }>();
           expectTypeOf(request.body).toEqualTypeOf<null>();
 
@@ -1513,21 +1478,20 @@ export function declareTypeHttpInterceptorTests(
           };
         });
 
-        expectTypeOf<HttpRequestHandlerPath<typeof specificGetHandler>>().toEqualTypeOf<
-          HttpRequestHandlerPath<typeof genericGetHandler>
+        expectTypeOf<HttpRequestHandlerPath<typeof _specificGetHandler>>().toEqualTypeOf<
+          HttpRequestHandlerPath<typeof _genericGetHandler>
         >();
 
-        const _specificGetRequests = await specificGetHandler.requests();
-        type SpecificRequestBody = (typeof _specificGetRequests)[number]['body'];
+        type SpecificRequestBody = (typeof _specificGetHandler.requests)[number]['body'];
         expectTypeOf<SpecificRequestBody>().toEqualTypeOf<null>();
-        type SpecificResponseBody = (typeof _specificGetRequests)[number]['response']['body'];
+        type SpecificResponseBody = (typeof _specificGetHandler.requests)[number]['response']['body'];
         expectTypeOf<SpecificResponseBody>().toEqualTypeOf<GenericResponseBody>();
       });
     });
 
     it('should correctly type requests with dynamic paths containing multiple, consecutive parameters ending with static path', async () => {
       await usingHttpInterceptor<SchemaWithDynamicPaths>({ type, baseURL }, async (interceptor) => {
-        const genericGetHandler = await interceptor
+        const _genericGetHandler = await interceptor
           .get('/groups/:groupId/users/:userId/:otherId/suffix')
           .respond((request) => {
             expectTypeOf(request.pathParams).toEqualTypeOf<{ groupId: string; userId: string; otherId: string }>();
@@ -1540,16 +1504,15 @@ export function declareTypeHttpInterceptorTests(
           });
 
         expectTypeOf<
-          HttpRequestHandlerPath<typeof genericGetHandler>
+          HttpRequestHandlerPath<typeof _genericGetHandler>
         >().toEqualTypeOf<'/groups/:groupId/users/:userId/:otherId/suffix'>();
 
-        const _genericGetRequests = await genericGetHandler.requests();
-        type GenericRequestBody = (typeof _genericGetRequests)[number]['body'];
+        type GenericRequestBody = (typeof _genericGetHandler.requests)[number]['body'];
         expectTypeOf<GenericRequestBody>().toEqualTypeOf<null>();
-        type GenericResponseBody = (typeof _genericGetRequests)[number]['response']['body'];
+        type GenericResponseBody = (typeof _genericGetHandler.requests)[number]['response']['body'];
         expectTypeOf<GenericResponseBody>().toEqualTypeOf<'path /groups/:groupId/users/:userId/:otherId/suffix'>();
 
-        const specificGetHandler = await interceptor.get('/groups/1/users/2/3/suffix').respond((request) => {
+        const _specificGetHandler = await interceptor.get('/groups/1/users/2/3/suffix').respond((request) => {
           expectTypeOf(request.pathParams).toEqualTypeOf<{ groupId: string; userId: string; otherId: string }>();
           expectTypeOf(request.body).toEqualTypeOf<null>();
 
@@ -1560,13 +1523,12 @@ export function declareTypeHttpInterceptorTests(
         });
 
         expectTypeOf<
-          HttpRequestHandlerPath<typeof specificGetHandler>
+          HttpRequestHandlerPath<typeof _specificGetHandler>
         >().toEqualTypeOf<'/groups/:groupId/users/:userId/:otherId/suffix'>();
 
-        const _specificGetRequests = await specificGetHandler.requests();
-        type SpecificRequestBody = (typeof _specificGetRequests)[number]['body'];
+        type SpecificRequestBody = (typeof _specificGetHandler.requests)[number]['body'];
         expectTypeOf<SpecificRequestBody>().toEqualTypeOf<null>();
-        type SpecificResponseBody = (typeof _specificGetRequests)[number]['response']['body'];
+        type SpecificResponseBody = (typeof _specificGetHandler.requests)[number]['response']['body'];
         expectTypeOf<SpecificResponseBody>().toEqualTypeOf<GenericResponseBody>();
       });
     });
@@ -1582,48 +1544,46 @@ export function declareTypeHttpInterceptorTests(
           };
         };
       }>({ type, baseURL }, async (interceptor) => {
-        const successfulGenericUserListHandler = await interceptor.get('/groups/:groupId/users').respond({
+        const _successfulGenericListHandler = await interceptor.get('/groups/:groupId/users').respond({
           status: 200,
           body: users,
         });
 
-        const _successfulGenericUserListRequests = await successfulGenericUserListHandler.requests();
-        type SuccessfulGenericResponseBody = (typeof _successfulGenericUserListRequests)[number]['response']['body'];
+        type SuccessfulGenericResponseBody =
+          (typeof _successfulGenericListHandler.requests)[number]['response']['body'];
         expectTypeOf<SuccessfulGenericResponseBody>().toEqualTypeOf<User[]>();
 
-        const failedGenericUserListHandler = await interceptor.get('/groups/:groupId/users').respond({
+        const _failedGenericListHandler = await interceptor.get('/groups/:groupId/users').respond({
           status: 500,
           body: { message: 'Internal server error' },
         });
 
-        const _failedGenericUserListRequests = await failedGenericUserListHandler.requests();
-        type FailedGenericResponseBody = (typeof _failedGenericUserListRequests)[number]['response']['body'];
+        type FailedGenericResponseBody = (typeof _failedGenericListHandler.requests)[number]['response']['body'];
         expectTypeOf<FailedGenericResponseBody>().toEqualTypeOf<{ message: string }>();
 
-        const successfulSpecificUserListHandler = await interceptor.get('/groups/1/users').respond({
+        const _successfulSpecificListHandler = await interceptor.get('/groups/1/users').respond({
           status: 200,
           body: users,
         });
 
         expectTypeOf<
-          HttpRequestHandlerPath<typeof successfulSpecificUserListHandler>
+          HttpRequestHandlerPath<typeof _successfulSpecificListHandler>
         >().toEqualTypeOf<'/groups/:groupId/users'>();
 
-        const _successfulSpecificUserListRequests = await successfulSpecificUserListHandler.requests();
-        type SuccessfulSpecificResponseBody = (typeof _successfulSpecificUserListRequests)[number]['response']['body'];
+        type SuccessfulSpecificResponseBody =
+          (typeof _successfulSpecificListHandler.requests)[number]['response']['body'];
         expectTypeOf<SuccessfulSpecificResponseBody>().toEqualTypeOf<User[]>();
 
-        const failedSpecificUserListHandler = await interceptor.get('/groups/1/users').respond({
+        const _failedSpecificListHandler = await interceptor.get('/groups/1/users').respond({
           status: 500,
           body: { message: 'Internal server error' },
         });
 
         expectTypeOf<
-          HttpRequestHandlerPath<typeof failedSpecificUserListHandler>
+          HttpRequestHandlerPath<typeof _failedSpecificListHandler>
         >().toEqualTypeOf<'/groups/:groupId/users'>();
 
-        const _failedSpecificUserListRequests = await failedSpecificUserListHandler.requests();
-        type FailedSpecificResponseBody = (typeof _failedSpecificUserListRequests)[number]['response']['body'];
+        type FailedSpecificResponseBody = (typeof _failedSpecificListHandler.requests)[number]['response']['body'];
         expectTypeOf<FailedSpecificResponseBody>().toEqualTypeOf<{ message: string }>();
       });
     });

--- a/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/unhandledRequests.factories.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/unhandledRequests.factories.ts
@@ -85,8 +85,7 @@ export async function declareUnhandledRequestFactoriesHttpInterceptorTests(
           );
           expect(handler).toBeInstanceOf(Handler);
 
-          let requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(0);
+          expect(handler.requests).toHaveLength(0);
 
           await usingIgnoredConsole(['warn', 'error'], async (spies) => {
             const searchParams = new HttpSearchParams<{ value: string; name?: string }>({ value: '1' });
@@ -94,8 +93,7 @@ export async function declareUnhandledRequestFactoriesHttpInterceptorTests(
             const response = await fetch(joinURL(baseURL, `/users?${searchParams.toString()}`), { method });
             expect(response.status).toBe(200);
 
-            requests = await promiseIfRemote(handler.requests(), interceptor);
-            expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+            expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
 
             expect(onUnhandledRequest).toHaveBeenCalledTimes(0);
             expect(spies.warn).toHaveBeenCalledTimes(0);
@@ -115,8 +113,7 @@ export async function declareUnhandledRequestFactoriesHttpInterceptorTests(
               await expectFetchError(responsePromise);
             }
 
-            requests = await promiseIfRemote(handler.requests(), interceptor);
-            expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+            expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
 
             expect(onUnhandledRequest).toHaveBeenCalledTimes(numberOfRequestsIncludingPreflight);
             expect(spies.warn).toHaveBeenCalledTimes(0);
@@ -131,8 +128,7 @@ export async function declareUnhandledRequestFactoriesHttpInterceptorTests(
               await expectFetchError(responsePromise);
             }
 
-            requests = await promiseIfRemote(handler.requests(), interceptor);
-            expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+            expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
 
             expect(onUnhandledRequest).toHaveBeenCalledTimes(numberOfRequestsIncludingPreflight * 2);
             expect(spies.warn).toHaveBeenCalledTimes(0);
@@ -171,8 +167,7 @@ export async function declareUnhandledRequestFactoriesHttpInterceptorTests(
           );
           expect(handler).toBeInstanceOf(Handler);
 
-          let requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(0);
+          expect(handler.requests).toHaveLength(0);
 
           await usingIgnoredConsole(['warn', 'error'], async (spies) => {
             const searchParams = new HttpSearchParams<{ value: string; name?: string }>({ value: '1' });
@@ -180,8 +175,7 @@ export async function declareUnhandledRequestFactoriesHttpInterceptorTests(
             const response = await fetch(joinURL(baseURL, `/users?${searchParams.toString()}`), { method });
             expect(response.status).toBe(200);
 
-            requests = await promiseIfRemote(handler.requests(), interceptor);
-            expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+            expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
 
             expect(onUnhandledRequest).toHaveBeenCalledTimes(0);
             expect(spies.warn).toHaveBeenCalledTimes(0);
@@ -201,8 +195,7 @@ export async function declareUnhandledRequestFactoriesHttpInterceptorTests(
               await expectFetchError(responsePromise);
             }
 
-            requests = await promiseIfRemote(handler.requests(), interceptor);
-            expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+            expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
 
             expect(onUnhandledRequest).toHaveBeenCalledTimes(numberOfRequestsIncludingPreflight);
             expect(spies.warn).toHaveBeenCalledTimes(0);
@@ -217,8 +210,7 @@ export async function declareUnhandledRequestFactoriesHttpInterceptorTests(
               await expectFetchError(responsePromise);
             }
 
-            requests = await promiseIfRemote(handler.requests(), interceptor);
-            expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+            expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
 
             expect(onUnhandledRequest).toHaveBeenCalledTimes(numberOfRequestsIncludingPreflight * 2);
             expect(spies.warn).toHaveBeenCalledTimes(0);
@@ -258,8 +250,7 @@ export async function declareUnhandledRequestFactoriesHttpInterceptorTests(
           );
           expect(handler).toBeInstanceOf(Handler);
 
-          let requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(0);
+          expect(handler.requests).toHaveLength(0);
 
           await usingIgnoredConsole(['warn', 'error'], async (spies) => {
             const searchParams = new HttpSearchParams<{ value: string; name?: string }>({ value: '1' });
@@ -267,8 +258,7 @@ export async function declareUnhandledRequestFactoriesHttpInterceptorTests(
             const response = await fetch(joinURL(baseURL, `/users?${searchParams.toString()}`), { method });
             expect(response.status).toBe(200);
 
-            requests = await promiseIfRemote(handler.requests(), interceptor);
-            expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+            expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
 
             expect(onUnhandledRequest).toHaveBeenCalledTimes(0);
             expect(spies.warn).toHaveBeenCalledTimes(0);
@@ -288,8 +278,7 @@ export async function declareUnhandledRequestFactoriesHttpInterceptorTests(
               await expectFetchError(responsePromise);
             }
 
-            requests = await promiseIfRemote(handler.requests(), interceptor);
-            expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+            expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
 
             expect(onUnhandledRequest).toHaveBeenCalledTimes(numberOfRequestsIncludingPreflight);
             expect(spies.warn).toHaveBeenCalledTimes(0);
@@ -304,8 +293,7 @@ export async function declareUnhandledRequestFactoriesHttpInterceptorTests(
               await expectFetchError(responsePromise);
             }
 
-            requests = await promiseIfRemote(handler.requests(), interceptor);
-            expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+            expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
 
             expect(onUnhandledRequest).toHaveBeenCalledTimes(numberOfRequestsIncludingPreflight * 2);
 
@@ -353,8 +341,7 @@ export async function declareUnhandledRequestFactoriesHttpInterceptorTests(
           );
           expect(handler).toBeInstanceOf(Handler);
 
-          let requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(0);
+          expect(handler.requests).toHaveLength(0);
 
           await usingIgnoredConsole(['warn', 'error'], async (spies) => {
             const searchParams = new HttpSearchParams<{
@@ -365,8 +352,7 @@ export async function declareUnhandledRequestFactoriesHttpInterceptorTests(
             const response = await fetch(joinURL(baseURL, `/users?${searchParams.toString()}`), { method });
             expect(response.status).toBe(200);
 
-            requests = await promiseIfRemote(handler.requests(), interceptor);
-            expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+            expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
 
             expect(onUnhandledRequest).toHaveBeenCalledTimes(0);
             expect(spies.warn).toHaveBeenCalledTimes(0);
@@ -386,8 +372,7 @@ export async function declareUnhandledRequestFactoriesHttpInterceptorTests(
               await expectFetchError(responsePromise);
             }
 
-            requests = await promiseIfRemote(handler.requests(), interceptor);
-            expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+            expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
 
             expect(onUnhandledRequest).toHaveBeenCalledTimes(numberOfRequestsIncludingPreflight);
             expect(spies.warn).toHaveBeenCalledTimes(0);
@@ -402,8 +387,7 @@ export async function declareUnhandledRequestFactoriesHttpInterceptorTests(
               await expectFetchError(responsePromise);
             }
 
-            requests = await promiseIfRemote(handler.requests(), interceptor);
-            expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+            expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
 
             expect(onUnhandledRequest).toHaveBeenCalledTimes(numberOfRequestsIncludingPreflight * 2);
 

--- a/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/unhandledRequests.logging.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/unhandledRequests.logging.ts
@@ -3,7 +3,7 @@ import expectFetchError from '@zimic/utils/fetch/expectFetchError';
 import joinURL from '@zimic/utils/url/joinURL';
 import { afterEach, beforeEach, describe, expect, expectTypeOf, it } from 'vitest';
 
-import { httpInterceptor } from '@/http';
+import { httpInterceptor, UnhandledHttpInterceptorRequest } from '@/http';
 import { promiseIfRemote } from '@/http/interceptorWorker/__tests__/utils/promises';
 import LocalHttpRequestHandler from '@/http/requestHandler/LocalHttpRequestHandler';
 import RemoteHttpRequestHandler from '@/http/requestHandler/RemoteHttpRequestHandler';
@@ -15,7 +15,6 @@ import { expectBypassedResponse, expectPreflightResponse } from '@tests/utils/fe
 import { assessPreflightInterference, usingHttpInterceptor } from '@tests/utils/interceptors';
 
 import { HttpInterceptorOptions, UnhandledRequestStrategy } from '../../types/options';
-import { UnhandledHttpInterceptorRequest } from '../../types/requests';
 import {
   RuntimeSharedHttpInterceptorTestsOptions,
   verifyUnhandledRequestMessage,
@@ -157,16 +156,14 @@ export async function declareUnhandledRequestLoggingHttpInterceptorTests(
               );
               expect(handler).toBeInstanceOf(Handler);
 
-              let requests = await promiseIfRemote(handler.requests(), interceptor);
-              expect(requests).toHaveLength(0);
+              expect(handler.requests).toHaveLength(0);
 
               await usingIgnoredConsole(['warn', 'error'], async (spies) => {
                 const response = await fetch(joinURL(baseURL, '/users'), { method });
                 expect(response.status).toBe(200);
 
-                requests = await promiseIfRemote(handler.requests(), interceptor);
-                expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
-                const interceptedRequest = requests[numberOfRequestsIncludingPreflight - 1];
+                expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
+                const interceptedRequest = handler.requests[numberOfRequestsIncludingPreflight - 1];
                 expectTypeOf(interceptedRequest.body).toEqualTypeOf<null>();
                 expect(interceptedRequest.body).toBe(null);
 
@@ -179,8 +176,7 @@ export async function declareUnhandledRequestLoggingHttpInterceptorTests(
                 const responsePromise = fetch(request);
                 await expectBypassedResponse(responsePromise);
 
-                requests = await promiseIfRemote(handler.requests(), interceptor);
-                expect(requests).toHaveLength(0);
+                expect(handler.requests).toHaveLength(0);
 
                 expect(spies.warn).toHaveBeenCalledTimes(numberOfRequestsIncludingPreflight);
                 expect(spies.error).toHaveBeenCalledTimes(0);
@@ -212,8 +208,7 @@ export async function declareUnhandledRequestLoggingHttpInterceptorTests(
               );
               expect(handler).toBeInstanceOf(Handler);
 
-              let requests = await promiseIfRemote(handler.requests(), interceptor);
-              expect(requests).toHaveLength(0);
+              expect(handler.requests).toHaveLength(0);
 
               await usingIgnoredConsole(['warn', 'error'], async (spies) => {
                 const response = await fetch(joinURL(baseURL, '/users'), {
@@ -223,9 +218,8 @@ export async function declareUnhandledRequestLoggingHttpInterceptorTests(
                 });
                 expect(response.status).toBe(200);
 
-                requests = await promiseIfRemote(handler.requests(), interceptor);
-                expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
-                const interceptedRequest = requests[numberOfRequestsIncludingPreflight - 1];
+                expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
+                const interceptedRequest = handler.requests[numberOfRequestsIncludingPreflight - 1];
                 expectTypeOf(interceptedRequest.body).toEqualTypeOf<{ message: string }>();
                 expect(interceptedRequest.body).toEqual({ message: 'ok' });
 
@@ -244,8 +238,7 @@ export async function declareUnhandledRequestLoggingHttpInterceptorTests(
                 const responsePromise = fetch(request);
                 await expectBypassedResponse(responsePromise);
 
-                requests = await promiseIfRemote(handler.requests(), interceptor);
-                expect(requests).toHaveLength(0);
+                expect(handler.requests).toHaveLength(0);
 
                 expect(spies.warn).toHaveBeenCalledTimes(numberOfRequestsIncludingPreflight);
                 expect(spies.error).toHaveBeenCalledTimes(0);
@@ -277,8 +270,7 @@ export async function declareUnhandledRequestLoggingHttpInterceptorTests(
               );
               expect(handler).toBeInstanceOf(Handler);
 
-              let requests = await promiseIfRemote(handler.requests(), interceptor);
-              expect(requests).toHaveLength(0);
+              expect(handler.requests).toHaveLength(0);
 
               await usingIgnoredConsole(['warn', 'error'], async (spies) => {
                 const response = await fetch(joinURL(baseURL, '/users'), {
@@ -287,9 +279,8 @@ export async function declareUnhandledRequestLoggingHttpInterceptorTests(
                 });
                 expect(response.status).toBe(200);
 
-                requests = await promiseIfRemote(handler.requests(), interceptor);
-                expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
-                const interceptedRequest = requests[numberOfRequestsIncludingPreflight - 1];
+                expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
+                const interceptedRequest = handler.requests[numberOfRequestsIncludingPreflight - 1];
                 expectTypeOf(interceptedRequest.body).toEqualTypeOf<null>();
                 expect(interceptedRequest.body).toBe(null);
 
@@ -300,8 +291,7 @@ export async function declareUnhandledRequestLoggingHttpInterceptorTests(
                 const responsePromise = fetch(request);
                 await expectBypassedResponse(responsePromise);
 
-                requests = await promiseIfRemote(handler.requests(), interceptor);
-                expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+                expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
 
                 expect(spies.warn).toHaveBeenCalledTimes(numberOfRequestsIncludingPreflight);
                 expect(spies.error).toHaveBeenCalledTimes(0);
@@ -331,16 +321,14 @@ export async function declareUnhandledRequestLoggingHttpInterceptorTests(
               );
               expect(handler).toBeInstanceOf(Handler);
 
-              let requests = await promiseIfRemote(handler.requests(), interceptor);
-              expect(requests).toHaveLength(0);
+              expect(handler.requests).toHaveLength(0);
 
               await usingIgnoredConsole(['warn', 'error'], async (spies) => {
                 const response = await fetch(joinURL(baseURL, '/users'), { method });
                 expect(response.status).toBe(200);
 
-                requests = await promiseIfRemote(handler.requests(), interceptor);
-                expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
-                const interceptedRequest = requests[numberOfRequestsIncludingPreflight - 1];
+                expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
+                const interceptedRequest = handler.requests[numberOfRequestsIncludingPreflight - 1];
                 expectTypeOf(interceptedRequest.body).toEqualTypeOf<null>();
                 expect(interceptedRequest.body).toBe(null);
 
@@ -351,8 +339,7 @@ export async function declareUnhandledRequestLoggingHttpInterceptorTests(
                 const responsePromise = fetch(request);
                 await expectBypassedResponse(responsePromise);
 
-                requests = await promiseIfRemote(handler.requests(), interceptor);
-                expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+                expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
 
                 expect(spies.warn).toHaveBeenCalledTimes(numberOfRequestsIncludingPreflight);
                 expect(spies.error).toHaveBeenCalledTimes(0);
@@ -382,16 +369,14 @@ export async function declareUnhandledRequestLoggingHttpInterceptorTests(
               );
               expect(handler).toBeInstanceOf(Handler);
 
-              let requests = await promiseIfRemote(handler.requests(), interceptor);
-              expect(requests).toHaveLength(0);
+              expect(handler.requests).toHaveLength(0);
 
               await usingIgnoredConsole(['warn', 'error'], async (spies) => {
                 const response = await fetch(joinURL(baseURL, '/users'), { method });
                 expect(response.status).toBe(200);
 
-                requests = await promiseIfRemote(handler.requests(), interceptor);
-                expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
-                const interceptedRequest = requests[numberOfRequestsIncludingPreflight - 1];
+                expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
+                const interceptedRequest = handler.requests[numberOfRequestsIncludingPreflight - 1];
                 expectTypeOf(interceptedRequest.body).toEqualTypeOf<null>();
                 expect(interceptedRequest.body).toBe(null);
 
@@ -408,8 +393,7 @@ export async function declareUnhandledRequestLoggingHttpInterceptorTests(
                 const responsePromise = fetch(request);
                 await expectBypassedResponse(responsePromise);
 
-                requests = await promiseIfRemote(handler.requests(), interceptor);
-                expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+                expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
 
                 expect(spies.warn).toHaveBeenCalledTimes(numberOfRequestsIncludingPreflight);
                 expect(spies.error).toHaveBeenCalledTimes(0);
@@ -436,16 +420,14 @@ export async function declareUnhandledRequestLoggingHttpInterceptorTests(
             );
             expect(handler).toBeInstanceOf(Handler);
 
-            let requests = await promiseIfRemote(handler.requests(), interceptor);
-            expect(requests).toHaveLength(0);
+            expect(handler.requests).toHaveLength(0);
 
             await usingIgnoredConsole(['warn', 'error'], async (spies) => {
               const response = await fetch(joinURL(baseURL, '/users'), { method });
               expect(response.status).toBe(200);
 
-              requests = await promiseIfRemote(handler.requests(), interceptor);
-              expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
-              const interceptedRequest = requests[numberOfRequestsIncludingPreflight - 1];
+              expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
+              const interceptedRequest = handler.requests[numberOfRequestsIncludingPreflight - 1];
               expectTypeOf(interceptedRequest.body).toEqualTypeOf<null>();
               expect(interceptedRequest.body).toBe(null);
 
@@ -466,8 +448,7 @@ export async function declareUnhandledRequestLoggingHttpInterceptorTests(
                 await expectFetchError(responsePromise);
               }
 
-              requests = await promiseIfRemote(handler.requests(), interceptor);
-              expect(requests).toHaveLength(0);
+              expect(handler.requests).toHaveLength(0);
 
               expect(spies.warn).toHaveBeenCalledTimes(0);
               expect(spies.error).toHaveBeenCalledTimes(numberOfRequestsIncludingPreflight);
@@ -494,8 +475,7 @@ export async function declareUnhandledRequestLoggingHttpInterceptorTests(
               );
               expect(handler).toBeInstanceOf(Handler);
 
-              let requests = await promiseIfRemote(handler.requests(), interceptor);
-              expect(requests).toHaveLength(0);
+              expect(handler.requests).toHaveLength(0);
 
               await usingIgnoredConsole(['warn', 'error'], async (spies) => {
                 const response = await fetch(joinURL(baseURL, '/users'), {
@@ -505,9 +485,8 @@ export async function declareUnhandledRequestLoggingHttpInterceptorTests(
                 });
                 expect(response.status).toBe(200);
 
-                requests = await promiseIfRemote(handler.requests(), interceptor);
-                expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
-                const interceptedRequest = requests[numberOfRequestsIncludingPreflight - 1];
+                expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
+                const interceptedRequest = handler.requests[numberOfRequestsIncludingPreflight - 1];
                 expectTypeOf(interceptedRequest.body).toEqualTypeOf<{ message: string }>();
                 expect(interceptedRequest.body).toEqual({ message: 'ok' });
 
@@ -529,8 +508,7 @@ export async function declareUnhandledRequestLoggingHttpInterceptorTests(
                 const responsePromise = fetch(request);
                 await expectFetchError(responsePromise);
 
-                requests = await promiseIfRemote(handler.requests(), interceptor);
-                expect(requests).toHaveLength(0);
+                expect(handler.requests).toHaveLength(0);
 
                 expect(spies.warn).toHaveBeenCalledTimes(0);
                 expect(spies.error).toHaveBeenCalledTimes(numberOfRequestsIncludingPreflight);
@@ -559,8 +537,7 @@ export async function declareUnhandledRequestLoggingHttpInterceptorTests(
             );
             expect(handler).toBeInstanceOf(Handler);
 
-            let requests = await promiseIfRemote(handler.requests(), interceptor);
-            expect(requests).toHaveLength(0);
+            expect(handler.requests).toHaveLength(0);
 
             await usingIgnoredConsole(['warn', 'error'], async (spies) => {
               const searchParams = new HttpSearchParams({ value: '1' });
@@ -568,9 +545,8 @@ export async function declareUnhandledRequestLoggingHttpInterceptorTests(
               const response = await fetch(joinURL(baseURL, `/users?${searchParams.toString()}`), { method });
               expect(response.status).toBe(200);
 
-              requests = await promiseIfRemote(handler.requests(), interceptor);
-              expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
-              const interceptedRequest = requests[numberOfRequestsIncludingPreflight - 1];
+              expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
+              const interceptedRequest = handler.requests[numberOfRequestsIncludingPreflight - 1];
               expectTypeOf(interceptedRequest.body).toEqualTypeOf<null>();
               expect(interceptedRequest.body).toBe(null);
 
@@ -589,8 +565,7 @@ export async function declareUnhandledRequestLoggingHttpInterceptorTests(
                 await expectFetchError(responsePromise);
               }
 
-              requests = await promiseIfRemote(handler.requests(), interceptor);
-              expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+              expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
 
               expect(spies.warn).toHaveBeenCalledTimes(0);
               expect(spies.error).toHaveBeenCalledTimes(numberOfRequestsIncludingPreflight);
@@ -616,16 +591,14 @@ export async function declareUnhandledRequestLoggingHttpInterceptorTests(
             );
             expect(handler).toBeInstanceOf(Handler);
 
-            let requests = await promiseIfRemote(handler.requests(), interceptor);
-            expect(requests).toHaveLength(0);
+            expect(handler.requests).toHaveLength(0);
 
             await usingIgnoredConsole(['warn', 'error'], async (spies) => {
               const response = await fetch(joinURL(baseURL, '/users'), { method });
               expect(response.status).toBe(200);
 
-              requests = await promiseIfRemote(handler.requests(), interceptor);
-              expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
-              const interceptedRequest = requests[numberOfRequestsIncludingPreflight - 1];
+              expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
+              const interceptedRequest = handler.requests[numberOfRequestsIncludingPreflight - 1];
               expectTypeOf(interceptedRequest.body).toEqualTypeOf<null>();
               expect(interceptedRequest.body).toBe(null);
 
@@ -653,8 +626,7 @@ export async function declareUnhandledRequestLoggingHttpInterceptorTests(
                 await verifyUnhandledRequestMessage(errorMessage, { request, platform, type: 'reject' });
               }
 
-              requests = await promiseIfRemote(handler.requests(), interceptor);
-              expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+              expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
             });
           },
         );
@@ -674,16 +646,14 @@ export async function declareUnhandledRequestLoggingHttpInterceptorTests(
             );
             expect(handler).toBeInstanceOf(Handler);
 
-            let requests = await promiseIfRemote(handler.requests(), interceptor);
-            expect(requests).toHaveLength(0);
+            expect(handler.requests).toHaveLength(0);
 
             await usingIgnoredConsole(['warn', 'error'], async (spies) => {
               const response = await fetch(joinURL(baseURL, '/users'), { method });
               expect(response.status).toBe(200);
 
-              requests = await promiseIfRemote(handler.requests(), interceptor);
-              expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
-              const interceptedRequest = requests[numberOfRequestsIncludingPreflight - 1];
+              expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
+              const interceptedRequest = handler.requests[numberOfRequestsIncludingPreflight - 1];
               expectTypeOf(interceptedRequest.body).toEqualTypeOf<null>();
               expect(interceptedRequest.body).toBe(null);
 
@@ -717,8 +687,7 @@ export async function declareUnhandledRequestLoggingHttpInterceptorTests(
                 await verifyUnhandledRequestMessage(errorMessage, { request, platform, type: 'reject' });
               }
 
-              requests = await promiseIfRemote(handler.requests(), interceptor);
-              expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+              expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
             });
           },
         );
@@ -789,8 +758,7 @@ export async function declareUnhandledRequestLoggingHttpInterceptorTests(
             );
             expect(handler).toBeInstanceOf(Handler);
 
-            let requests = await promiseIfRemote(handler.requests(), interceptor);
-            expect(requests).toHaveLength(0);
+            expect(handler.requests).toHaveLength(0);
 
             await usingIgnoredConsole(['warn', 'error'], async (spies) => {
               const searchParams = new HttpSearchParams({ value: '1' });
@@ -798,8 +766,7 @@ export async function declareUnhandledRequestLoggingHttpInterceptorTests(
               const response = await fetch(joinURL(baseURL, `/users?${searchParams.toString()}`), { method });
               expect(response.status).toBe(200);
 
-              requests = await promiseIfRemote(handler.requests(), interceptor);
-              expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+              expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
 
               expect(spies.warn).toHaveBeenCalledTimes(0);
               expect(spies.error).toHaveBeenCalledTimes(0);
@@ -808,8 +775,7 @@ export async function declareUnhandledRequestLoggingHttpInterceptorTests(
               const responsePromise = fetch(request);
               await expectBypassedResponse(responsePromise);
 
-              requests = await promiseIfRemote(handler.requests(), interceptor);
-              expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+              expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
 
               expect(spies.warn).toHaveBeenCalledTimes(0);
               expect(spies.error).toHaveBeenCalledTimes(0);
@@ -834,8 +800,7 @@ export async function declareUnhandledRequestLoggingHttpInterceptorTests(
           );
           expect(handler).toBeInstanceOf(Handler);
 
-          let requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(0);
+          expect(handler.requests).toHaveLength(0);
 
           await usingIgnoredConsole(['warn', 'error'], async (spies) => {
             const searchParams = new HttpSearchParams({ value: '1' });
@@ -843,8 +808,7 @@ export async function declareUnhandledRequestLoggingHttpInterceptorTests(
             const response = await fetch(joinURL(baseURL, `/users?${searchParams.toString()}`), { method });
             expect(response.status).toBe(200);
 
-            requests = await promiseIfRemote(handler.requests(), interceptor);
-            expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+            expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
 
             expect(spies.warn).toHaveBeenCalledTimes(0);
             expect(spies.error).toHaveBeenCalledTimes(0);
@@ -858,8 +822,7 @@ export async function declareUnhandledRequestLoggingHttpInterceptorTests(
               await expectFetchError(responsePromise);
             }
 
-            requests = await promiseIfRemote(handler.requests(), interceptor);
-            expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+            expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
 
             expect(spies.warn).toHaveBeenCalledTimes(0);
             expect(spies.error).toHaveBeenCalledTimes(0);
@@ -901,8 +864,7 @@ export async function declareUnhandledRequestLoggingHttpInterceptorTests(
           );
           expect(handler).toBeInstanceOf(Handler);
 
-          let requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(0);
+          expect(handler.requests).toHaveLength(0);
 
           await usingIgnoredConsole(['warn', 'error'], async (spies) => {
             const request = new Request(joinURL(baseURL, '/users'), { method });
@@ -918,8 +880,7 @@ export async function declareUnhandledRequestLoggingHttpInterceptorTests(
               await expectFetchError(responsePromise);
             }
 
-            requests = await promiseIfRemote(handler.requests(), interceptor);
-            expect(requests).toHaveLength(0);
+            expect(handler.requests).toHaveLength(0);
 
             expect(spies.warn).toHaveBeenCalledTimes(0);
             expect(spies.error).toHaveBeenCalledTimes(0);
@@ -938,8 +899,7 @@ export async function declareUnhandledRequestLoggingHttpInterceptorTests(
         );
         expect(handler).toBeInstanceOf(Handler);
 
-        let requests = await promiseIfRemote(handler.requests(), interceptor);
-        expect(requests).toHaveLength(0);
+        expect(handler.requests).toHaveLength(0);
 
         await usingIgnoredConsole(['warn', 'error'], async (spies) => {
           const searchParams = new HttpSearchParams({ value: '1' });
@@ -947,8 +907,7 @@ export async function declareUnhandledRequestLoggingHttpInterceptorTests(
           const response = await fetch(joinURL(baseURL, `/users?${searchParams.toString()}`), { method });
           expect(response.status).toBe(200);
 
-          requests = await promiseIfRemote(handler.requests(), interceptor);
-          expect(requests).toHaveLength(numberOfRequestsIncludingPreflight);
+          expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight);
 
           expect(spies.warn).toHaveBeenCalledTimes(0);
           expect(spies.error).toHaveBeenCalledTimes(0);

--- a/packages/zimic-interceptor/src/http/interceptor/errors/NotStartedHttpInterceptorError.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/errors/NotStartedHttpInterceptorError.ts
@@ -3,7 +3,7 @@
  *
  * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-interceptorstart `interceptor.start()` API reference}
  * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-interceptorstop `interceptor.stop()` API reference}
- * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-interceptorisrunning `interceptor.isRunning()` API reference}
+ * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-interceptorisrunning `interceptor.isRunning` API reference}
  */
 class NotStartedHttpInterceptorError extends Error {
   constructor() {

--- a/packages/zimic-interceptor/src/http/interceptor/errors/UnknownHttpInterceptorPlatformError.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/errors/UnknownHttpInterceptorPlatformError.ts
@@ -2,7 +2,7 @@
  * An error thrown when an unknown interceptor platform is detected. Currently, the platforms `node` and `browser` are
  * supported.
  *
- * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-interceptorplatform `interceptor.platform()` API reference}
+ * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-interceptorplatform `interceptor.platform` API reference}
  */
 class UnknownHttpInterceptorPlatformError extends Error {
   /* istanbul ignore next -- @preserve

--- a/packages/zimic-interceptor/src/http/interceptor/types/options.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/types/options.ts
@@ -12,7 +12,7 @@ export type HttpInterceptorType = 'local' | 'remote';
 /**
  * The platform where an HTTP interceptor is running.
  *
- * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-interceptorplatform `interceptor.platform()` API reference}
+ * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-interceptorplatform `interceptor.platform` API reference}
  */
 export type HttpInterceptorPlatform = 'node' | 'browser';
 
@@ -121,9 +121,9 @@ export interface SharedHttpInterceptorOptions {
   /**
    * Whether {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#httprequesthandler request handlers}
    * should save their intercepted requests in memory and make them accessible through
-   * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlerrequests `handler.requests()`}.
+   * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlerrequests `handler.requests`}.
    *
-   * **IMPORTANT**: Saving the intercepted requests will lead to a memory leak if not accompanied by clearing of the
+   * **Important**: Saving the intercepted requests will lead to a memory leak if not accompanied by clearing of the
    * interceptor or disposal of the handlers (i.e. garbage collection). If you plan on accessing those requests, such as
    * to assert them in your tests, set this option to `true` and make sure to regularly clear the interceptor. A common
    * practice is to call

--- a/packages/zimic-interceptor/src/http/interceptor/types/public.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/types/public.ts
@@ -13,22 +13,25 @@ import { HttpInterceptorPlatform } from './options';
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export interface HttpInterceptor<_Schema extends HttpSchema> {
   /**
-   * @returns The base URL used by the interceptor.
-   * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-interceptorbaseurl `interceptor.baseURL()` API reference}
+   * The base URL used by the interceptor.
+   *
+   * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-interceptorbaseurl `interceptor.baseURL` API reference}
    */
-  baseURL: () => string;
+  baseURL: string;
 
   /**
-   * @returns The platform the interceptor is running on.
-   * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-interceptorplatform `interceptor.platform()` API reference}
+   * The platform the interceptor is running on.
+   *
+   * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-interceptorplatform `interceptor.platform` API reference}
    */
-  platform: () => HttpInterceptorPlatform | null;
+  platform: HttpInterceptorPlatform | null;
 
   /**
-   * @returns Whether the interceptor is currently running and ready to use.
-   * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-interceptorisrunning `interceptor.isRunning()` API reference}
+   * Whether the interceptor is currently running and ready to use.
+   *
+   * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-interceptorisrunning `interceptor.isRunning` API reference}
    */
-  isRunning: () => boolean;
+  isRunning: boolean;
 
   /**
    * Starts the interceptor, allowing it to intercept HTTP requests.

--- a/packages/zimic-interceptor/src/http/interceptorWorker/__tests__/HttpinterceptorWorker.browser.test.ts
+++ b/packages/zimic-interceptor/src/http/interceptorWorker/__tests__/HttpinterceptorWorker.browser.test.ts
@@ -27,7 +27,7 @@ describe('HttpInterceptorWorker (browser)', () => {
       ].join('\n'),
     );
 
-    const mswWorker = interceptorWorker.internalWorkerOrCreate() as BrowserHttpWorker;
+    const mswWorker = interceptorWorker.internalWorkerOrCreate as BrowserHttpWorker;
     vi.spyOn(mswWorker, 'start').mockRejectedValueOnce(unavailableMSWWorkerScriptError);
 
     await usingIgnoredConsole(['error'], async (spies) => {
@@ -39,7 +39,7 @@ describe('HttpInterceptorWorker (browser)', () => {
       expect(spies.error).toHaveBeenCalledTimes(0);
     });
 
-    expect(interceptorWorker.platform()).toBe<HttpInterceptorPlatform>('browser');
+    expect(interceptorWorker.platform).toBe<HttpInterceptorPlatform>('browser');
   });
 });
 

--- a/packages/zimic-interceptor/src/http/interceptorWorker/__tests__/shared/default.ts
+++ b/packages/zimic-interceptor/src/http/interceptorWorker/__tests__/shared/default.ts
@@ -43,7 +43,7 @@ export function declareDefaultHttpInterceptorWorkerTests(options: SharedHttpInte
 
   it('should initialize using the correct worker and platform', async () => {
     await usingHttpInterceptorWorker(workerOptions, { start: false }, async (worker) => {
-      expect(worker.platform()).toBe(null);
+      expect(worker.platform).toBe(null);
       expect(worker).toBeInstanceOf(HttpInterceptorWorker);
       expect(worker).toBeInstanceOf(
         workerOptions.type === 'remote' ? RemoteHttpInterceptorWorker : LocalHttpInterceptorWorker,
@@ -51,7 +51,7 @@ export function declareDefaultHttpInterceptorWorkerTests(options: SharedHttpInte
 
       await worker.start();
 
-      expect(worker.platform()).toBe(platform);
+      expect(worker.platform).toBe(platform);
 
       if (worker instanceof LocalHttpInterceptorWorker) {
         expect(worker.hasInternalBrowserWorker()).toBe(platform === 'browser');
@@ -62,73 +62,73 @@ export function declareDefaultHttpInterceptorWorkerTests(options: SharedHttpInte
 
   it('should not throw an error when started multiple times', async () => {
     await usingHttpInterceptorWorker(workerOptions, { start: false }, async (worker) => {
-      expect(worker.isRunning()).toBe(false);
+      expect(worker.isRunning).toBe(false);
       await worker.start();
-      expect(worker.isRunning()).toBe(true);
+      expect(worker.isRunning).toBe(true);
       await worker.start();
-      expect(worker.isRunning()).toBe(true);
+      expect(worker.isRunning).toBe(true);
       await worker.start();
-      expect(worker.isRunning()).toBe(true);
+      expect(worker.isRunning).toBe(true);
     });
   });
 
   it('should not throw an error when started multiple times concurrently', async () => {
     await usingHttpInterceptorWorker(workerOptions, { start: false }, async (worker) => {
-      expect(worker.isRunning()).toBe(false);
+      expect(worker.isRunning).toBe(false);
 
       await Promise.all(
         Array.from({ length: 5 }).map(async () => {
           await worker.start();
-          expect(worker.isRunning()).toBe(true);
+          expect(worker.isRunning).toBe(true);
         }),
       );
 
-      expect(worker.isRunning()).toBe(true);
+      expect(worker.isRunning).toBe(true);
     });
   });
 
   it('should not throw an error when stopped while not running', async () => {
     await usingHttpInterceptorWorker(workerOptions, { start: false }, async (worker) => {
-      expect(worker.isRunning()).toBe(false);
+      expect(worker.isRunning).toBe(false);
       await worker.stop();
-      expect(worker.isRunning()).toBe(false);
+      expect(worker.isRunning).toBe(false);
       await worker.stop();
-      expect(worker.isRunning()).toBe(false);
+      expect(worker.isRunning).toBe(false);
       await worker.stop();
-      expect(worker.isRunning()).toBe(false);
+      expect(worker.isRunning).toBe(false);
     });
   });
 
   it('should not throw an error when stopped multiple times while running', async () => {
     await usingHttpInterceptorWorker(workerOptions, async (worker) => {
-      expect(worker.isRunning()).toBe(true);
+      expect(worker.isRunning).toBe(true);
       await worker.stop();
-      expect(worker.isRunning()).toBe(false);
+      expect(worker.isRunning).toBe(false);
       await worker.stop();
-      expect(worker.isRunning()).toBe(false);
+      expect(worker.isRunning).toBe(false);
       await worker.stop();
-      expect(worker.isRunning()).toBe(false);
+      expect(worker.isRunning).toBe(false);
     });
   });
 
   it('should not throw an error when stopped multiple times concurrently', async () => {
     await usingHttpInterceptorWorker(workerOptions, async (worker) => {
-      expect(worker.isRunning()).toBe(true);
+      expect(worker.isRunning).toBe(true);
 
       await Promise.all(
         Array.from({ length: 5 }).map(async () => {
           await worker.stop();
-          expect(worker.isRunning()).toBe(false);
+          expect(worker.isRunning).toBe(false);
         }),
       );
 
-      expect(worker.isRunning()).toBe(false);
+      expect(worker.isRunning).toBe(false);
     });
   });
 
   it('should throw an error if trying to clear handlers without a running worker', async () => {
     await usingHttpInterceptorWorker(workerOptions, { start: false }, async (worker) => {
-      expect(worker.isRunning()).toBe(false);
+      expect(worker.isRunning).toBe(false);
 
       await expect(async () => {
         await worker.clearHandlers();
@@ -138,12 +138,12 @@ export function declareDefaultHttpInterceptorWorkerTests(options: SharedHttpInte
 
   it('should throw an error if trying to clear interceptor handlers without a running worker', async () => {
     await usingHttpInterceptorWorker(workerOptions, { start: false }, async (worker) => {
-      expect(worker.isRunning()).toBe(false);
+      expect(worker.isRunning).toBe(false);
 
       const interceptor = createDefaultHttpInterceptor();
 
       await expect(async () => {
-        await worker.clearInterceptorHandlers(interceptor.client());
+        await worker.clearInterceptorHandlers(interceptor.client);
       }).rejects.toThrowError(new NotStartedHttpInterceptorError());
     });
   });
@@ -154,15 +154,15 @@ export function declareDefaultHttpInterceptorWorkerTests(options: SharedHttpInte
         expect(rawWorker).toBeInstanceOf(RemoteHttpInterceptorWorker);
 
         const worker = rawWorker as RemoteHttpInterceptorWorker;
-        expect(worker.isRunning()).toBe(true);
-        expect(worker.webSocketClient().isRunning()).toBe(true);
+        expect(worker.isRunning).toBe(true);
+        expect(worker.webSocketClient.isRunning).toBe(true);
 
         // The websocket client automatically stops running if the interceptor server is closed.
         // Let's stop the client manually to simulate that.
-        await worker.webSocketClient().stop();
+        await worker.webSocketClient.stop();
 
-        expect(worker.isRunning()).toBe(true);
-        expect(worker.webSocketClient().isRunning()).toBe(false);
+        expect(worker.isRunning).toBe(true);
+        expect(worker.webSocketClient.isRunning).toBe(false);
 
         const clearPromise = worker.clearHandlers();
         await expect(clearPromise).resolves.not.toThrowError();
@@ -174,19 +174,19 @@ export function declareDefaultHttpInterceptorWorkerTests(options: SharedHttpInte
         expect(rawWorker).toBeInstanceOf(RemoteHttpInterceptorWorker);
 
         const worker = rawWorker as RemoteHttpInterceptorWorker;
-        expect(worker.isRunning()).toBe(true);
-        expect(worker.webSocketClient().isRunning()).toBe(true);
+        expect(worker.isRunning).toBe(true);
+        expect(worker.webSocketClient.isRunning).toBe(true);
 
         // The websocket client automatically stops running if the interceptor server is closed.
         // Let's stop the client manually to simulate that.
-        await worker.webSocketClient().stop();
+        await worker.webSocketClient.stop();
 
-        expect(worker.isRunning()).toBe(true);
-        expect(worker.webSocketClient().isRunning()).toBe(false);
+        expect(worker.isRunning).toBe(true);
+        expect(worker.webSocketClient.isRunning).toBe(false);
 
         const interceptor = createDefaultHttpInterceptor();
 
-        const clearPromise = worker.clearInterceptorHandlers(interceptor.client());
+        const clearPromise = worker.clearInterceptorHandlers(interceptor.client);
         await expect(clearPromise).resolves.not.toThrowError();
       });
     });
@@ -199,10 +199,10 @@ export function declareDefaultHttpInterceptorWorkerTests(options: SharedHttpInte
       const error = new Error('Unknown error');
 
       if (platform === 'browser') {
-        const internalBrowserWorker = interceptorWorker.internalWorkerOrCreate() as BrowserHttpWorker;
+        const internalBrowserWorker = interceptorWorker.internalWorkerOrCreate as BrowserHttpWorker;
         vi.spyOn(internalBrowserWorker, 'start').mockRejectedValueOnce(error);
       } else {
-        const internalNodeWorker = interceptorWorker.internalWorkerOrCreate() as NodeHttpWorker;
+        const internalNodeWorker = interceptorWorker.internalWorkerOrCreate as NodeHttpWorker;
         vi.spyOn(internalNodeWorker, 'listen').mockImplementationOnce(() => {
           throw error;
         });
@@ -220,7 +220,7 @@ export function declareDefaultHttpInterceptorWorkerTests(options: SharedHttpInte
         }
       });
 
-      expect(interceptorWorker.platform()).toBe(platform);
+      expect(interceptorWorker.platform).toBe(platform);
     });
   }
 }

--- a/packages/zimic-interceptor/src/http/interceptorWorker/__tests__/shared/methods.ts
+++ b/packages/zimic-interceptor/src/http/interceptorWorker/__tests__/shared/methods.ts
@@ -97,7 +97,7 @@ export function declareMethodHttpInterceptorWorkerTests(options: SharedHttpInter
       await usingHttpInterceptorWorker(workerOptions, async (worker) => {
         const interceptor = createDefaultHttpInterceptor();
 
-        await promiseIfRemote(worker.use(interceptor.client(), method, baseURL, spiedRequestHandler), worker);
+        await promiseIfRemote(worker.use(interceptor.client, method, baseURL, spiedRequestHandler), worker);
 
         expect(spiedRequestHandler).not.toHaveBeenCalled();
 
@@ -283,7 +283,7 @@ export function declareMethodHttpInterceptorWorkerTests(options: SharedHttpInter
 
       await usingHttpInterceptorWorker(workerOptions, async (worker) => {
         const interceptor = createDefaultHttpInterceptor();
-        await promiseIfRemote(worker.use(interceptor.client(), method, url, spiedRequestHandler), worker);
+        await promiseIfRemote(worker.use(interceptor.client, method, url, spiedRequestHandler), worker);
 
         expect(spiedRequestHandler).not.toHaveBeenCalled();
 
@@ -459,7 +459,7 @@ export function declareMethodHttpInterceptorWorkerTests(options: SharedHttpInter
 
         await usingHttpInterceptorWorker(workerOptions, async (worker) => {
           const interceptor = createDefaultHttpInterceptor();
-          await promiseIfRemote(worker.use(interceptor.client(), method, url, spiedRequestHandler), worker);
+          await promiseIfRemote(worker.use(interceptor.client, method, url, spiedRequestHandler), worker);
 
           expect(spiedRequestHandler).not.toHaveBeenCalled();
 
@@ -496,7 +496,7 @@ export function declareMethodHttpInterceptorWorkerTests(options: SharedHttpInter
           const interceptor = createDefaultHttpInterceptor();
 
           await expect(async () => {
-            await worker.use(interceptor.client(), method, url, spiedRequestHandler);
+            await worker.use(interceptor.client, method, url, spiedRequestHandler);
           }).rejects.toThrowError(new DuplicatedPathParamError(new URL(url), paths.duplicatedParameter));
 
           expect(spiedRequestHandler).not.toHaveBeenCalled();
@@ -523,7 +523,7 @@ export function declareMethodHttpInterceptorWorkerTests(options: SharedHttpInter
         const interceptor = createDefaultHttpInterceptor();
         const emptySpiedRequestHandler = vi.fn(requestHandler).mockImplementation(() => null);
 
-        await promiseIfRemote(worker.use(interceptor.client(), method, baseURL, emptySpiedRequestHandler), worker);
+        await promiseIfRemote(worker.use(interceptor.client, method, baseURL, emptySpiedRequestHandler), worker);
 
         expect(emptySpiedRequestHandler).not.toHaveBeenCalled();
 
@@ -565,7 +565,7 @@ export function declareMethodHttpInterceptorWorkerTests(options: SharedHttpInter
           return requestHandler(context);
         });
 
-        await promiseIfRemote(worker.use(interceptor.client(), method, baseURL, delayedSpiedRequestHandler), worker);
+        await promiseIfRemote(worker.use(interceptor.client, method, baseURL, delayedSpiedRequestHandler), worker);
 
         expect(delayedSpiedRequestHandler).not.toHaveBeenCalled();
 
@@ -592,7 +592,7 @@ export function declareMethodHttpInterceptorWorkerTests(options: SharedHttpInter
       await usingHttpInterceptorWorker(workerOptions, { start: false }, async (worker) => {
         const interceptor = createDefaultHttpInterceptor();
         await expect(async () => {
-          await worker.use(interceptor.client(), method, baseURL, spiedRequestHandler);
+          await worker.use(interceptor.client, method, baseURL, spiedRequestHandler);
         }).rejects.toThrowError(Error);
 
         expect(spiedRequestHandler).not.toHaveBeenCalled();
@@ -617,7 +617,7 @@ export function declareMethodHttpInterceptorWorkerTests(options: SharedHttpInter
     it(`should not intercept ${method} requests after stopped`, async () => {
       await usingHttpInterceptorWorker(workerOptions, async (worker) => {
         const interceptor = createDefaultHttpInterceptor();
-        await promiseIfRemote(worker.use(interceptor.client(), method, baseURL, spiedRequestHandler), worker);
+        await promiseIfRemote(worker.use(interceptor.client, method, baseURL, spiedRequestHandler), worker);
 
         await worker.stop();
 
@@ -641,7 +641,7 @@ export function declareMethodHttpInterceptorWorkerTests(options: SharedHttpInter
     it(`should clear all ${method} handlers after stopped`, async () => {
       await usingHttpInterceptorWorker(workerOptions, async (worker) => {
         const interceptor = createDefaultHttpInterceptor();
-        await promiseIfRemote(worker.use(interceptor.client(), method, baseURL, spiedRequestHandler), worker);
+        await promiseIfRemote(worker.use(interceptor.client, method, baseURL, spiedRequestHandler), worker);
 
         await worker.stop();
         await worker.start();
@@ -666,7 +666,7 @@ export function declareMethodHttpInterceptorWorkerTests(options: SharedHttpInter
     it(`should not intercept ${method} requests having no handler after cleared`, async () => {
       await usingHttpInterceptorWorker(workerOptions, async (worker) => {
         const interceptor = createDefaultHttpInterceptor();
-        await promiseIfRemote(worker.use(interceptor.client(), method, baseURL, spiedRequestHandler), worker);
+        await promiseIfRemote(worker.use(interceptor.client, method, baseURL, spiedRequestHandler), worker);
 
         await promiseIfRemote(worker.clearHandlers(), worker);
 
@@ -682,7 +682,7 @@ export function declareMethodHttpInterceptorWorkerTests(options: SharedHttpInter
 
         expect(spiedRequestHandler).not.toHaveBeenCalled();
 
-        await promiseIfRemote(worker.use(interceptor.client(), method, baseURL, spiedRequestHandler), worker);
+        await promiseIfRemote(worker.use(interceptor.client, method, baseURL, spiedRequestHandler), worker);
 
         expect(spiedRequestHandler).not.toHaveBeenCalled();
 
@@ -711,12 +711,12 @@ export function declareMethodHttpInterceptorWorkerTests(options: SharedHttpInter
         });
 
         const interceptor = createDefaultHttpInterceptor();
-        await promiseIfRemote(worker.use(interceptor.client(), method, baseURL, okSpiedRequestHandler), worker);
+        await promiseIfRemote(worker.use(interceptor.client, method, baseURL, okSpiedRequestHandler), worker);
 
-        let interceptorsWithHandlers = worker.interceptorsWithHandlers();
+        let interceptorsWithHandlers = worker.interceptorsWithHandlers;
 
         expect(interceptorsWithHandlers).toHaveLength(1);
-        expect(interceptorsWithHandlers[0]).toBe(interceptor.client());
+        expect(interceptorsWithHandlers[0]).toBe(interceptor.client);
 
         let response = await fetch(baseURL, { method });
         expect(response.status).toBe(200);
@@ -730,14 +730,14 @@ export function declareMethodHttpInterceptorWorkerTests(options: SharedHttpInter
 
         const otherInterceptor = createDefaultHttpInterceptor();
         await promiseIfRemote(
-          worker.use(otherInterceptor.client(), method, baseURL, noContentSpiedRequestHandler),
+          worker.use(otherInterceptor.client, method, baseURL, noContentSpiedRequestHandler),
           worker,
         );
 
-        interceptorsWithHandlers = worker.interceptorsWithHandlers();
+        interceptorsWithHandlers = worker.interceptorsWithHandlers;
         expect(interceptorsWithHandlers).toHaveLength(2);
-        expect(interceptorsWithHandlers[0]).toBe(interceptor.client());
-        expect(interceptorsWithHandlers[1]).toBe(otherInterceptor.client());
+        expect(interceptorsWithHandlers[0]).toBe(interceptor.client);
+        expect(interceptorsWithHandlers[1]).toBe(otherInterceptor.client);
 
         response = await fetch(baseURL, { method });
         expect(response.status).toBe(204);
@@ -750,11 +750,11 @@ export function declareMethodHttpInterceptorWorkerTests(options: SharedHttpInter
         expect(noContentHandlerContext.request).toBeInstanceOf(Request);
         expect(noContentHandlerContext.request.method).toBe(method);
 
-        await promiseIfRemote(worker.clearInterceptorHandlers(otherInterceptor.client()), worker);
+        await promiseIfRemote(worker.clearInterceptorHandlers(otherInterceptor.client), worker);
 
-        interceptorsWithHandlers = worker.interceptorsWithHandlers();
+        interceptorsWithHandlers = worker.interceptorsWithHandlers;
         expect(interceptorsWithHandlers).toHaveLength(1);
-        expect(interceptorsWithHandlers[0]).toBe(interceptor.client());
+        expect(interceptorsWithHandlers[0]).toBe(interceptor.client);
 
         response = await fetch(baseURL, { method });
         expect(response.status).toBe(200);
@@ -766,9 +766,9 @@ export function declareMethodHttpInterceptorWorkerTests(options: SharedHttpInter
         expect(okHandlerContext.request).toBeInstanceOf(Request);
         expect(okHandlerContext.request.method).toBe(method);
 
-        await promiseIfRemote(worker.clearInterceptorHandlers(interceptor.client()), worker);
+        await promiseIfRemote(worker.clearInterceptorHandlers(interceptor.client), worker);
 
-        interceptorsWithHandlers = worker.interceptorsWithHandlers();
+        interceptorsWithHandlers = worker.interceptorsWithHandlers;
         expect(interceptorsWithHandlers).toHaveLength(0);
 
         const responsePromise = fetch(baseURL, { method });
@@ -791,7 +791,7 @@ export function declareMethodHttpInterceptorWorkerTests(options: SharedHttpInter
         const interceptor = createDefaultHttpInterceptor();
 
         await expect(async () => {
-          await worker.use(interceptor.client(), method, baseURL, spiedRequestHandler);
+          await worker.use(interceptor.client, method, baseURL, spiedRequestHandler);
         }).rejects.toThrowError(NotStartedHttpInterceptorError);
       });
     });
@@ -803,7 +803,7 @@ export function declareMethodHttpInterceptorWorkerTests(options: SharedHttpInter
         const interceptor = createDefaultHttpInterceptor();
 
         await expect(async () => {
-          await worker.use(interceptor.client(), method, invalidURL, spiedRequestHandler);
+          await worker.use(interceptor.client, method, invalidURL, spiedRequestHandler);
         }).rejects.toThrowError(/Invalid URL/);
 
         expect(spiedRequestHandler).not.toHaveBeenCalled();

--- a/packages/zimic-interceptor/src/http/requestHandler/HttpRequestHandlerClient.ts
+++ b/packages/zimic-interceptor/src/http/requestHandler/HttpRequestHandlerClient.ts
@@ -58,8 +58,7 @@ class HttpRequestHandlerClient<
 
   private numberOfMatchedRequests = 0;
   private unmatchedRequestGroups: UnmatchedHttpInterceptorRequestGroup[] = [];
-  private interceptedRequests: InterceptedHttpInterceptorRequest<Path, Default<Schema[Path][Method]>, StatusCode>[] =
-    [];
+  private _requests: InterceptedHttpInterceptorRequest<Path, Default<Schema[Path][Method]>, StatusCode>[] = [];
 
   private createResponseDeclaration?: HttpRequestHandlerResponseDeclarationFactory<
     Path,
@@ -69,18 +68,10 @@ class HttpRequestHandlerClient<
 
   constructor(
     private interceptor: HttpInterceptorClient<Schema>,
-    private _method: Method,
-    private _path: Path,
+    public method: Method,
+    public path: Path,
     private handler: InternalHttpRequestHandler<Schema, Method, Path, StatusCode>,
   ) {}
-
-  method() {
-    return this._method;
-  }
-
-  path() {
-    return this._path;
-  }
 
   with(restriction: HttpRequestHandlerRestriction<Schema, Method, Path>): this {
     this.restrictions.push(restriction);
@@ -100,7 +91,7 @@ class HttpRequestHandlerClient<
 
     newThis.numberOfMatchedRequests = 0;
     newThis.unmatchedRequestGroups.length = 0;
-    newThis.interceptedRequests.length = 0;
+    newThis._requests.length = 0;
 
     this.interceptor.registerRequestHandler(this.handler);
 
@@ -141,7 +132,7 @@ class HttpRequestHandlerClient<
         declarationPointer: this.timesDeclarationPointer,
         unmatchedRequestGroups: this.unmatchedRequestGroups,
         hasRestrictions: this.restrictions.length > 0,
-        hasSavedRequests: this.interceptor.shouldSaveRequests(),
+        hasSavedRequests: this.interceptor.shouldSaveRequests,
       });
     }
   }
@@ -157,7 +148,7 @@ class HttpRequestHandlerClient<
 
     this.numberOfMatchedRequests = 0;
     this.unmatchedRequestGroups.length = 0;
-    this.interceptedRequests.length = 0;
+    this._requests.length = 0;
 
     this.createResponseDeclaration = undefined;
 
@@ -177,7 +168,7 @@ class HttpRequestHandlerClient<
       this.numberOfMatchedRequests++;
     } else {
       const shouldSaveUnmatchedGroup =
-        this.interceptor.shouldSaveRequests() &&
+        this.interceptor.shouldSaveRequests &&
         this.restrictions.length > 0 &&
         this.timesDeclarationPointer !== undefined;
 
@@ -388,7 +379,7 @@ class HttpRequestHandlerClient<
     response: HttpInterceptorResponse<Default<Schema[Path][Method]>, StatusCode>,
   ) {
     const interceptedRequest = this.createInterceptedRequest(request, response);
-    this.interceptedRequests.push(interceptedRequest);
+    this._requests.push(interceptedRequest);
   }
 
   private createInterceptedRequest(
@@ -411,14 +402,12 @@ class HttpRequestHandlerClient<
     return interceptedRequest;
   }
 
-  requests(): readonly InterceptedHttpInterceptorRequest<Path, Default<Schema[Path][Method]>, StatusCode>[] {
-    if (!this.interceptor.shouldSaveRequests()) {
+  get requests(): readonly InterceptedHttpInterceptorRequest<Path, Default<Schema[Path][Method]>, StatusCode>[] {
+    if (!this.interceptor.shouldSaveRequests) {
       throw new DisabledRequestSavingError();
     }
 
-    const interceptedRequestsCopy = [...this.interceptedRequests];
-    Object.freeze(interceptedRequestsCopy);
-    return interceptedRequestsCopy;
+    return this._requests;
   }
 }
 

--- a/packages/zimic-interceptor/src/http/requestHandler/LocalHttpRequestHandler.ts
+++ b/packages/zimic-interceptor/src/http/requestHandler/LocalHttpRequestHandler.ts
@@ -22,26 +22,22 @@ class LocalHttpRequestHandler<
 {
   readonly type = 'local';
 
-  private _client: HttpRequestHandlerClient<Schema, Method, Path, StatusCode>;
+  client: HttpRequestHandlerClient<Schema, Method, Path, StatusCode>;
 
   constructor(interceptor: HttpInterceptorClient<Schema>, method: Method, path: Path) {
-    this._client = new HttpRequestHandlerClient(interceptor, method, path, this);
+    this.client = new HttpRequestHandlerClient(interceptor, method, path, this);
   }
 
-  client() {
-    return this._client;
+  get method() {
+    return this.client.method;
   }
 
-  method() {
-    return this._client.method();
-  }
-
-  path() {
-    return this._client.path();
+  get path() {
+    return this.client.path;
   }
 
   with(restriction: HttpRequestHandlerRestriction<Schema, Method, Path>): this {
-    this._client.with(restriction);
+    this.client.with(restriction);
     return this;
   }
 
@@ -50,45 +46,45 @@ class LocalHttpRequestHandler<
       | HttpRequestHandlerResponseDeclaration<Default<Schema[Path][Method]>, NewStatusCode>
       | HttpRequestHandlerResponseDeclarationFactory<Path, Default<Schema[Path][Method]>, NewStatusCode>,
   ): LocalHttpRequestHandler<Schema, Method, Path, NewStatusCode> {
-    this._client.respond(declaration);
+    this.client.respond(declaration);
 
     const newThis = this as unknown as LocalHttpRequestHandler<Schema, Method, Path, NewStatusCode>;
     return newThis;
   }
 
   times(minNumberOfRequests: number, maxNumberOfRequests?: number): this {
-    this._client.times(minNumberOfRequests, maxNumberOfRequests);
+    this.client.times(minNumberOfRequests, maxNumberOfRequests);
     return this;
   }
 
   checkTimes() {
-    this._client.checkTimes();
+    this.client.checkTimes();
   }
 
   clear(): this {
-    this._client.clear();
+    this.client.clear();
     return this;
   }
 
-  requests(): readonly InterceptedHttpInterceptorRequest<Path, Default<Schema[Path][Method]>, StatusCode>[] {
-    return this._client.requests();
+  get requests(): readonly InterceptedHttpInterceptorRequest<Path, Default<Schema[Path][Method]>, StatusCode>[] {
+    return this.client.requests;
   }
 
   matchesRequest(request: HttpInterceptorRequest<Path, Default<Schema[Path][Method]>>): Promise<boolean> {
-    return this._client.matchesRequest(request);
+    return this.client.matchesRequest(request);
   }
 
   async applyResponseDeclaration(
     request: HttpInterceptorRequest<Path, Default<Schema[Path][Method]>>,
   ): Promise<HttpRequestHandlerResponseDeclaration<Default<Schema[Path][Method]>, StatusCode>> {
-    return this._client.applyResponseDeclaration(request);
+    return this.client.applyResponseDeclaration(request);
   }
 
   saveInterceptedRequest(
     request: HttpInterceptorRequest<Path, Default<Schema[Path][Method]>>,
     response: HttpInterceptorResponse<Default<Schema[Path][Method]>, StatusCode>,
   ) {
-    this._client.saveInterceptedRequest(request, response);
+    this.client.saveInterceptedRequest(request, response);
   }
 }
 

--- a/packages/zimic-interceptor/src/http/requestHandler/__tests__/shared/restrictions.ts
+++ b/packages/zimic-interceptor/src/http/requestHandler/__tests__/shared/restrictions.ts
@@ -34,10 +34,10 @@ export function declareRestrictionHttpRequestHandlerTests(
     baseURL = await getBaseURL(type);
 
     interceptor = createInternalHttpInterceptor<Schema>({ type, baseURL });
-    interceptorClient = interceptor.client() as SharedHttpInterceptorClient<Schema>;
+    interceptorClient = interceptor.client as SharedHttpInterceptorClient<Schema>;
 
     await interceptor.start();
-    expect(interceptor.platform()).toBe(platform);
+    expect(interceptor.platform).toBe(platform);
   });
 
   afterAll(async () => {

--- a/packages/zimic-interceptor/src/http/requestHandler/__tests__/shared/times.ts
+++ b/packages/zimic-interceptor/src/http/requestHandler/__tests__/shared/times.ts
@@ -38,10 +38,10 @@ export function declareTimesHttpRequestHandlerTests(
     baseURL = await getBaseURL(type);
 
     interceptor = createInternalHttpInterceptor<Schema>({ type, baseURL });
-    interceptorClient = interceptor.client() as SharedHttpInterceptorClient<Schema>;
+    interceptorClient = interceptor.client as SharedHttpInterceptorClient<Schema>;
 
     await interceptor.start();
-    expect(interceptor.platform()).toBe(platform);
+    expect(interceptor.platform).toBe(platform);
   });
 
   afterAll(async () => {
@@ -351,7 +351,7 @@ export function declareTimesHttpRequestHandlerTests(
     describe('Restrictions', () => {
       it('should not include the requests unmatched due to restrictions if not saving requests', async () => {
         const interceptor = createInternalHttpInterceptor<Schema>({ type, baseURL, saveRequests: false });
-        const interceptorClient = interceptor.client() as SharedHttpInterceptorClient<Schema>;
+        const interceptorClient = interceptor.client as SharedHttpInterceptorClient<Schema>;
 
         const handler = new Handler<Schema, 'POST', '/users'>(interceptorClient, 'POST', '/users')
           .with((request) => typeof request.body === 'number')

--- a/packages/zimic-interceptor/src/http/requestHandler/types/public.ts
+++ b/packages/zimic-interceptor/src/http/requestHandler/types/public.ts
@@ -30,17 +30,19 @@ export interface HttpRequestHandler<
   Path extends HttpSchemaPath<Schema, Method>,
 > {
   /**
-   * @returns The method that matches this handler.
-   * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlermethod `handler.method()` API reference}
+   * The method that matches this handler.
+   *
+   * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlermethod `handler.method` API reference}
    */
-  method: () => Method;
+  method: Method;
 
   /**
-   * @returns The path that matches this handler. The base URL of the interceptor is not included, but it is used when
-   *   matching requests.
-   * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlerpath `handler.path()` API reference}
+   * The path that matches this handler. The base URL of the interceptor is not included, but it is used when matching
+   * requests.
+   *
+   * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlerpath `handler.path` API reference}
    */
-  path: () => Path;
+  path: Path;
 }
 
 export interface InternalHttpRequestHandler<
@@ -49,7 +51,7 @@ export interface InternalHttpRequestHandler<
   Path extends HttpSchemaPath<Schema, Method>,
   StatusCode extends HttpStatusCode = never,
 > extends HttpRequestHandler<Schema, Method, Path> {
-  client: () => HttpRequestHandlerClient<Schema, Method, Path, StatusCode>;
+  client: HttpRequestHandlerClient<Schema, Method, Path, StatusCode>;
 }
 
 /**
@@ -118,7 +120,7 @@ export interface LocalHttpRequestHandler<
    * intercepted request in the
    * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-interceptormethodpath `interceptor.<method>(path)` API reference}.
    *
-   * **IMPORTANT**: To make sure that all expected requests were made, use
+   * **Important**: To make sure that all expected requests were made, use
    * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-interceptorchecktimes `interceptor.checkTimes()`}
    * or {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlertimes `handler.times()`}.
    * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-interceptorchecktimes `interceptor.checkTimes()`}
@@ -170,18 +172,17 @@ export interface LocalHttpRequestHandler<
   clear: () => this;
 
   /**
-   * Returns the intercepted requests that matched this handler, along with the responses returned to each of them. This
-   * is useful for testing that the correct requests were made by your application.
+   * The intercepted requests that matched this handler, along with the responses returned to each of them. This is
+   * useful for testing that the correct requests were made by your application.
    *
-   * **IMPORTANT**: This method can only be used if `saveRequests` was set to `true` when creating the interceptor. See
+   * **Important**: This method can only be used if `saveRequests` was set to `true` when creating the interceptor. See
    * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#saving-requests Saving intercepted requests}
    * for more information.
    *
-   * @returns The intercepted requests.
    * @throws {DisabledRequestSavingError} If the interceptor was not created with `saveRequests: true`.
-   * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlerrequests `handler.requests()` API reference}
+   * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlerrequests `handler.requests` API reference}
    */
-  requests: () => readonly InterceptedHttpInterceptorRequest<Path, Default<Schema[Path][Method]>, StatusCode>[];
+  requests: readonly InterceptedHttpInterceptorRequest<Path, Default<Schema[Path][Method]>, StatusCode>[];
 }
 
 /**
@@ -249,7 +250,7 @@ export interface SyncedRemoteHttpRequestHandler<
    * intercepted request in the
    * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-interceptormethodpath `interceptor.<method>(path)` API reference}.
    *
-   * **IMPORTANT**: To make sure that all expected requests were made, use
+   * **Important**: To make sure that all expected requests were made, use
    * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-interceptorchecktimes `interceptor.checkTimes()`}
    * or
    * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlerchecktimes `handler.checkTimes()`}.
@@ -306,20 +307,17 @@ export interface SyncedRemoteHttpRequestHandler<
   clear: () => PendingRemoteHttpRequestHandler<Schema, Method, Path, StatusCode>;
 
   /**
-   * Returns the intercepted requests that matched this handler, along with the responses returned to each of them. This
-   * is useful for testing that the correct requests were made by your application.
+   * The intercepted requests that matched this handler, along with the responses returned to each of them. This is
+   * useful for testing that the correct requests were made by your application.
    *
-   * **IMPORTANT**: This method can only be used if `saveRequests` was set to `true` when creating the interceptor. See
+   * **Important**: This method can only be used if `saveRequests` was set to `true` when creating the interceptor. See
    * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#saving-requests Saving intercepted requests}
    * for more information.
    *
-   * @returns The intercepted requests.
    * @throws {DisabledRequestSavingError} If the interceptor was not created with `saveRequests: true`.
-   * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlerrequests `handler.requests()` API reference}
+   * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlerrequests `handler.requests` API reference}
    */
-  requests: () => Promise<
-    readonly InterceptedHttpInterceptorRequest<Path, Default<Schema[Path][Method]>, StatusCode>[]
-  >;
+  requests: readonly InterceptedHttpInterceptorRequest<Path, Default<Schema[Path][Method]>, StatusCode>[];
 }
 
 /**

--- a/packages/zimic-interceptor/src/server/InterceptorServer.ts
+++ b/packages/zimic-interceptor/src/server/InterceptorServer.ts
@@ -34,12 +34,12 @@ interface HttpHandler {
 }
 
 class InterceptorServer implements PublicInterceptorServer {
-  private _httpServer?: HttpServer;
-  private _webSocketServer?: WebSocketServer<InterceptorServerWebSocketSchema>;
+  private httpServer?: HttpServer;
+  private webSocketServer?: WebSocketServer<InterceptorServerWebSocketSchema>;
 
-  private _hostname: string;
-  private _port?: number;
-  private _logUnhandledRequests: boolean;
+  hostname: string;
+  port: number | undefined;
+  logUnhandledRequests: boolean;
 
   private httpHandlerGroups: {
     [Method in HttpMethod]: HttpHandler[];
@@ -56,87 +56,71 @@ class InterceptorServer implements PublicInterceptorServer {
   private knownWorkerSockets = new Set<Socket>();
 
   constructor(options: InterceptorServerOptions) {
-    this._hostname = options.hostname ?? 'localhost';
-    this._port = options.port;
-    this._logUnhandledRequests = options.logUnhandledRequests ?? DEFAULT_LOG_UNHANDLED_REQUESTS;
+    this.hostname = options.hostname ?? 'localhost';
+    this.port = options.port;
+    this.logUnhandledRequests = options.logUnhandledRequests ?? DEFAULT_LOG_UNHANDLED_REQUESTS;
   }
 
-  hostname() {
-    return this._hostname;
-  }
-
-  port() {
-    return this._port;
-  }
-
-  logUnhandledRequests() {
-    return this._logUnhandledRequests;
-  }
-
-  httpURL() {
-    if (this._port === undefined) {
+  get httpURL() {
+    if (this.port === undefined) {
       return undefined;
     }
-    return `http://${this._hostname}:${this._port}`;
+    return `http://${this.hostname}:${this.port}`;
   }
 
-  isRunning() {
-    return !!this._httpServer?.listening && !!this._webSocketServer?.isRunning();
+  get isRunning() {
+    return !!this.httpServer?.listening && !!this.webSocketServer?.isRunning;
   }
 
-  private httpServer() {
+  private get httpServerOrThrow(): HttpServer {
     /* istanbul ignore if -- @preserve
      * The HTTP server is initialized before using this method in normal conditions. */
-    if (!this._httpServer) {
+    if (!this.httpServer) {
       throw new NotStartedInterceptorServerError();
     }
-    return this._httpServer;
+    return this.httpServer;
   }
 
-  private webSocketServer() {
+  private get webSocketServerOrThrow(): WebSocketServer<InterceptorServerWebSocketSchema> {
     /* istanbul ignore if -- @preserve
      * The web socket server is initialized before using this method in normal conditions. */
-    if (!this._webSocketServer) {
+    if (!this.webSocketServer) {
       throw new NotStartedInterceptorServerError();
     }
-    return this._webSocketServer;
+    return this.webSocketServer;
   }
 
   async start() {
-    if (this.isRunning()) {
+    if (this.isRunning) {
       return;
     }
 
-    this._httpServer = createServer({
+    this.httpServer = createServer({
       keepAlive: true,
       joinDuplicateHeaders: true,
     });
     await this.startHttpServer();
 
-    this._webSocketServer = new WebSocketServer({
-      httpServer: this._httpServer,
+    this.webSocketServer = new WebSocketServer({
+      httpServer: this.httpServer,
     });
     this.startWebSocketServer();
   }
 
   private async startHttpServer() {
-    const httpServer = this.httpServer();
-
-    await startHttpServer(httpServer, {
-      hostname: this._hostname,
-      port: this._port,
+    await startHttpServer(this.httpServerOrThrow, {
+      hostname: this.hostname,
+      port: this.port,
     });
-    this._port = getHttpServerPort(httpServer);
+    this.port = getHttpServerPort(this.httpServerOrThrow);
 
-    httpServer.on('request', this.handleHttpRequest);
+    this.httpServerOrThrow.on('request', this.handleHttpRequest);
   }
 
   private startWebSocketServer() {
-    const webSocketServer = this.webSocketServer();
-
-    webSocketServer.start();
-    webSocketServer.onEvent('interceptors/workers/use/commit', this.commitWorker);
-    webSocketServer.onEvent('interceptors/workers/use/reset', this.resetWorker);
+    this.webSocketServerOrThrow.start();
+    this.webSocketServerOrThrow.onEvent('interceptors/workers/use/commit', this.commitWorker);
+    this.webSocketServerOrThrow.onEvent('interceptors/workers/use/reset', this.resetWorker);
   }
 
   private commitWorker = (
@@ -161,7 +145,7 @@ class InterceptorServer implements PublicInterceptorServer {
     if (isWorkerNoLongerCommitted) {
       // When a worker is no longer committed, we should abort all requests that were using it.
       // This ensures that we only wait for responses from committed worker sockets.
-      this.webSocketServer().abortSocketMessages([socket]);
+      this.webSocketServerOrThrow.abortSocketMessages([socket]);
     } else {
       for (const handler of handlersToResetTo) {
         this.registerHttpHandler(handler, socket);
@@ -209,32 +193,28 @@ class InterceptorServer implements PublicInterceptorServer {
     }
   }
 
-  stop = async () => {
-    if (!this.isRunning()) {
+  async stop() {
+    if (!this.isRunning) {
       return;
     }
 
     await this.stopWebSocketServer();
     await this.stopHttpServer();
-  };
+  }
 
   private async stopHttpServer() {
-    const httpServer = this.httpServer();
-
-    await stopHttpServer(httpServer);
-    httpServer.removeAllListeners();
-
-    this._httpServer = undefined;
+    await stopHttpServer(this.httpServerOrThrow);
+    this.httpServerOrThrow.removeAllListeners();
+    this.httpServer = undefined;
   }
 
   private async stopWebSocketServer() {
-    const webSocketServer = this.webSocketServer();
+    this.webSocketServerOrThrow.offEvent('interceptors/workers/use/commit', this.commitWorker);
+    this.webSocketServerOrThrow.offEvent('interceptors/workers/use/reset', this.resetWorker);
 
-    webSocketServer.offEvent('interceptors/workers/use/commit', this.commitWorker);
-    webSocketServer.offEvent('interceptors/workers/use/reset', this.resetWorker);
-    await webSocketServer.stop();
+    await this.webSocketServerOrThrow.stop();
 
-    this._webSocketServer = undefined;
+    this.webSocketServer = undefined;
   }
 
   private handleHttpRequest = async (nodeRequest: IncomingMessage, nodeResponse: ServerResponse) => {
@@ -278,7 +258,6 @@ class InterceptorServer implements PublicInterceptorServer {
   };
 
   private async createResponseForRequest(request: SerializedHttpRequest) {
-    const webSocketServer = this.webSocketServer();
     const methodHandlers = this.httpHandlerGroups[request.method as HttpMethod];
 
     const requestURL = excludeURLParams(new URL(request.url)).toString();
@@ -295,7 +274,7 @@ class InterceptorServer implements PublicInterceptorServer {
 
       matchedSomeInterceptor = true;
 
-      const { response: serializedResponse } = await webSocketServer.request(
+      const { response: serializedResponse } = await this.webSocketServerOrThrow.request(
         'interceptors/responses/create',
         { handlerId: handler.id, request },
         { sockets: [handler.socket] },
@@ -329,13 +308,11 @@ class InterceptorServer implements PublicInterceptorServer {
   }
 
   private async logUnhandledRequestIfNecessary(request: HttpRequest, serializedRequest: SerializedHttpRequest) {
-    const webSocketServer = this.webSocketServer();
-
     const handler = this.findHttpHandlerByRequestBaseURL(request);
 
     if (handler) {
       try {
-        const { wasLogged: wasRequestLoggedByRemoteInterceptor } = await webSocketServer.request(
+        const { wasLogged: wasRequestLoggedByRemoteInterceptor } = await this.webSocketServerOrThrow.request(
           'interceptors/responses/unhandled',
           { request: serializedRequest },
           { sockets: [handler.socket] },
@@ -357,7 +334,7 @@ class InterceptorServer implements PublicInterceptorServer {
       }
     }
 
-    if (!this._logUnhandledRequests) {
+    if (!this.logUnhandledRequests) {
       return;
     }
 

--- a/packages/zimic-interceptor/src/server/__tests__/InterceptorServer.node.test.ts
+++ b/packages/zimic-interceptor/src/server/__tests__/InterceptorServer.node.test.ts
@@ -17,74 +17,74 @@ describe('Interceptor server', () => {
   it('should start correctly with a defined port', async () => {
     server = createInternalInterceptorServer({ hostname: 'localhost', port: 8080 });
 
-    expect(server.isRunning()).toBe(false);
-    expect(server.hostname()).toBe('localhost');
-    expect(server.port()).toBe(8080);
-    expect(server.httpURL()).toBe('http://localhost:8080');
+    expect(server.isRunning).toBe(false);
+    expect(server.hostname).toBe('localhost');
+    expect(server.port).toBe(8080);
+    expect(server.httpURL).toBe('http://localhost:8080');
 
     await server.start();
 
-    expect(server.isRunning()).toBe(true);
-    expect(server.hostname()).toBe('localhost');
-    expect(server.port()).toBe(8080);
-    expect(server.httpURL()).toBe('http://localhost:8080');
+    expect(server.isRunning).toBe(true);
+    expect(server.hostname).toBe('localhost');
+    expect(server.port).toBe(8080);
+    expect(server.httpURL).toBe('http://localhost:8080');
   });
 
   it('should start correctly with an undefined port', async () => {
     server = createInternalInterceptorServer({ hostname: 'localhost' });
 
-    expect(server.isRunning()).toBe(false);
-    expect(server.hostname()).toBe('localhost');
-    expect(server.port()).toBe(undefined);
-    expect(server.httpURL()).toBe(undefined);
+    expect(server.isRunning).toBe(false);
+    expect(server.hostname).toBe('localhost');
+    expect(server.port).toBe(undefined);
+    expect(server.httpURL).toBe(undefined);
 
     await server.start();
 
-    expect(server.isRunning()).toBe(true);
-    expect(server.hostname()).toBe('localhost');
-    expect(server.port()).toEqual(expect.any(Number));
-    expect(server.httpURL()).toBe(`http://localhost:${server.port()}`);
+    expect(server.isRunning).toBe(true);
+    expect(server.hostname).toBe('localhost');
+    expect(server.port).toEqual(expect.any(Number));
+    expect(server.httpURL).toBe(`http://localhost:${server.port}`);
   });
 
   it('should not throw an error is started multiple times', async () => {
     server = createInternalInterceptorServer({ hostname: 'localhost' });
 
-    expect(server.isRunning()).toBe(false);
+    expect(server.isRunning).toBe(false);
 
     await server.start();
-    expect(server.isRunning()).toBe(true);
+    expect(server.isRunning).toBe(true);
 
     await server.start();
-    expect(server.isRunning()).toBe(true);
+    expect(server.isRunning).toBe(true);
 
     await server.start();
-    expect(server.isRunning()).toBe(true);
+    expect(server.isRunning).toBe(true);
   });
 
   it('should not throw an error if stopped multiple times', async () => {
     server = createInternalInterceptorServer({ hostname: 'localhost' });
 
-    expect(server.isRunning()).toBe(false);
+    expect(server.isRunning).toBe(false);
 
     await server.start();
-    expect(server.isRunning()).toBe(true);
+    expect(server.isRunning).toBe(true);
 
     await server.stop();
-    expect(server.isRunning()).toBe(false);
+    expect(server.isRunning).toBe(false);
 
     await server.stop();
-    expect(server.isRunning()).toBe(false);
+    expect(server.isRunning).toBe(false);
 
     await server.stop();
-    expect(server.isRunning()).toBe(false);
+    expect(server.isRunning).toBe(false);
   });
 
   it('should use the default values for optional parameters if not provided', () => {
     server = createInternalInterceptorServer();
 
-    expect(server.hostname()).toBe('localhost');
-    expect(server.port()).toBe(undefined);
-    expect(server.logUnhandledRequests()).toBe(true);
-    expect(server.httpURL()).toBe(undefined);
+    expect(server.hostname).toBe('localhost');
+    expect(server.port).toBe(undefined);
+    expect(server.logUnhandledRequests).toBe(true);
+    expect(server.httpURL).toBe(undefined);
   });
 });

--- a/packages/zimic-interceptor/src/server/types/public.ts
+++ b/packages/zimic-interceptor/src/server/types/public.ts
@@ -6,35 +6,40 @@
  */
 export interface InterceptorServer {
   /**
-   * @returns The hostname of the server.
+   * The hostname of the server.
+   *
    * @see {@link https://github.com/zimicjs/zimic/wiki/cli‐zimic‐server#zimic-server `zimic-interceptor server` API reference}
    */
-  hostname: () => string;
+  hostname: string;
 
   /**
-   * @returns The port of the server.
+   * The port of the server.
+   *
    * @see {@link https://github.com/zimicjs/zimic/wiki/cli‐zimic‐server#zimic-server `zimic-interceptor server` API reference}
    */
-  port: () => number | undefined;
+  port: number | undefined;
 
   /**
+   * Whether to log warnings about unhandled requests to the console.
+   *
    * @default true
-   * @returns Whether to log warnings about unhandled requests to the console.
    * @see {@link https://github.com/zimicjs/zimic/wiki/cli‐zimic‐server#zimic-server `zimic-interceptor server` API reference}
    */
-  logUnhandledRequests: () => boolean;
+  logUnhandledRequests: boolean;
 
   /**
-   * @returns The HTTP URL of the server.
+   * The HTTP URL of the server.
+   *
    * @see {@link https://github.com/zimicjs/zimic/wiki/cli‐zimic‐server#zimic-server `zimic-interceptor server` API reference}
    */
-  httpURL: () => string | undefined;
+  httpURL: string | undefined;
 
   /**
-   * @returns Whether the server is running.
+   * Whether the server is running.
+   *
    * @see {@link https://github.com/zimicjs/zimic/wiki/cli‐zimic‐server#zimic-server `zimic-interceptor server` API reference}
    */
-  isRunning: () => boolean;
+  isRunning: boolean;
 
   /**
    * Starts the server.

--- a/packages/zimic-interceptor/src/webSocket/WebSocketClient.ts
+++ b/packages/zimic-interceptor/src/webSocket/WebSocketClient.ts
@@ -27,7 +27,7 @@ class WebSocketClient<Schema extends WebSocket.ServiceSchema> extends WebSocketH
     validateURLProtocol(this.url, SUPPORTED_WEB_SOCKET_PROTOCOLS);
   }
 
-  isRunning() {
+  get isRunning() {
     return this.socket !== undefined && this.socket.readyState === this.socket.OPEN;
   }
 

--- a/packages/zimic-interceptor/src/webSocket/WebSocketHandler.ts
+++ b/packages/zimic-interceptor/src/webSocket/WebSocketHandler.ts
@@ -18,8 +18,8 @@ import { WebSocket } from './types';
 abstract class WebSocketHandler<Schema extends WebSocket.ServiceSchema> {
   private sockets = new Set<ClientSocket>();
 
-  private _socketTimeout: number;
-  private _messageTimeout: number;
+  socketTimeout: number;
+  messageTimeout: number;
 
   private channelListeners: {
     [Channel in WebSocket.ServiceChannel<Schema>]?: {
@@ -33,22 +33,14 @@ abstract class WebSocketHandler<Schema extends WebSocket.ServiceSchema> {
   };
 
   protected constructor(options: { socketTimeout?: number; messageTimeout?: number }) {
-    this._socketTimeout = options.socketTimeout ?? DEFAULT_WEB_SOCKET_LIFECYCLE_TIMEOUT;
-    this._messageTimeout = options.messageTimeout ?? DEFAULT_WEB_SOCKET_MESSAGE_TIMEOUT;
+    this.socketTimeout = options.socketTimeout ?? DEFAULT_WEB_SOCKET_LIFECYCLE_TIMEOUT;
+    this.messageTimeout = options.messageTimeout ?? DEFAULT_WEB_SOCKET_MESSAGE_TIMEOUT;
   }
 
-  abstract isRunning(): boolean;
-
-  socketTimeout() {
-    return this._socketTimeout;
-  }
-
-  messageTimeout() {
-    return this._messageTimeout;
-  }
+  abstract isRunning: boolean;
 
   protected async registerSocket(socket: ClientSocket) {
-    const openPromise = waitForOpenClientSocket(socket, { timeout: this._socketTimeout });
+    const openPromise = waitForOpenClientSocket(socket, { timeout: this.socketTimeout });
 
     const handleSocketMessage = async (rawMessage: ClientSocket.MessageEvent) => {
       await this.handleSocketMessage(socket, rawMessage);
@@ -173,7 +165,7 @@ abstract class WebSocketHandler<Schema extends WebSocket.ServiceSchema> {
 
   protected async closeClientSockets(sockets: Collection<ClientSocket> = this.sockets) {
     const closingPromises = Array.from(sockets, async (socket) => {
-      await closeClientSocket(socket, { timeout: this._socketTimeout });
+      await closeClientSocket(socket, { timeout: this.socketTimeout });
     });
     await Promise.all(closingPromises);
   }
@@ -232,9 +224,9 @@ abstract class WebSocketHandler<Schema extends WebSocket.ServiceSchema> {
         this.offReply(channel, replyListener); // eslint-disable-line @typescript-eslint/no-use-before-define
         this.offAbortSocketMessages(sockets, abortListener); // eslint-disable-line @typescript-eslint/no-use-before-define
 
-        const timeoutError = new WebSocketMessageTimeoutError(this._messageTimeout);
+        const timeoutError = new WebSocketMessageTimeoutError(this.messageTimeout);
         reject(timeoutError);
-      }, this._messageTimeout);
+      }, this.messageTimeout);
 
       const abortListener = this.onAbortSocketMessages(sockets, (error) => {
         clearTimeout(replyTimeout);
@@ -274,7 +266,7 @@ abstract class WebSocketHandler<Schema extends WebSocket.ServiceSchema> {
     const reply = await this.createReplyMessage(request, replyData);
 
     // If this handler received a request and was stopped before responding, discard any pending replies.
-    if (this.isRunning()) {
+    if (this.isRunning) {
       this.sendMessage(reply, options.sockets);
     }
   }
@@ -298,7 +290,7 @@ abstract class WebSocketHandler<Schema extends WebSocket.ServiceSchema> {
     message: WebSocket.ServiceMessage<Schema, Channel>,
     sockets: Collection<ClientSocket> = this.sockets,
   ) {
-    if (!this.isRunning()) {
+    if (!this.isRunning) {
       throw new NotStartedWebSocketHandlerError();
     }
 

--- a/packages/zimic-interceptor/src/webSocket/WebSocketServer.ts
+++ b/packages/zimic-interceptor/src/webSocket/WebSocketServer.ts
@@ -27,12 +27,12 @@ class WebSocketServer<Schema extends WebSocket.ServiceSchema> extends WebSocketH
     this.httpServer = options.httpServer;
   }
 
-  isRunning() {
+  get isRunning() {
     return this.webSocketServer !== undefined;
   }
 
   start() {
-    if (this.isRunning()) {
+    if (this.isRunning) {
       return;
     }
 
@@ -54,7 +54,7 @@ class WebSocketServer<Schema extends WebSocket.ServiceSchema> extends WebSocketH
   }
 
   async stop() {
-    if (!this.webSocketServer || !this.isRunning()) {
+    if (!this.webSocketServer || !this.isRunning) {
       return;
     }
 
@@ -62,7 +62,7 @@ class WebSocketServer<Schema extends WebSocket.ServiceSchema> extends WebSocketH
     super.abortSocketMessages();
     await super.closeClientSockets();
 
-    await closeServerSocket(this.webSocketServer, { timeout: this.socketTimeout() });
+    await closeServerSocket(this.webSocketServer, { timeout: this.socketTimeout });
     this.webSocketServer.removeAllListeners();
     this.webSocketServer = undefined;
   }

--- a/packages/zimic-interceptor/src/webSocket/__tests__/WebSocketClient.node.test.ts
+++ b/packages/zimic-interceptor/src/webSocket/__tests__/WebSocketClient.node.test.ts
@@ -64,47 +64,47 @@ describe('Web socket client', async () => {
     it('should support being started', async () => {
       client = new WebSocketClient({ url: `ws://localhost:${port}` });
 
-      expect(client.isRunning()).toBe(false);
+      expect(client.isRunning).toBe(false);
 
       await client.start();
 
-      expect(client.isRunning()).toBe(true);
+      expect(client.isRunning).toBe(true);
     });
 
     it('should not throw an error if being started multiple times', async () => {
       client = new WebSocketClient({ url: `ws://localhost:${port}` });
 
-      expect(client.isRunning()).toBe(false);
+      expect(client.isRunning).toBe(false);
 
       await client.start();
       await client.start();
       await client.start();
 
-      expect(client.isRunning()).toBe(true);
+      expect(client.isRunning).toBe(true);
     });
 
     it('should support being stopped', async () => {
       client = new WebSocketClient({ url: `ws://localhost:${port}` });
 
       await client.start();
-      expect(client.isRunning()).toBe(true);
+      expect(client.isRunning).toBe(true);
 
       await client.stop();
 
-      expect(client.isRunning()).toBe(false);
+      expect(client.isRunning).toBe(false);
     });
 
     it('should not throw an error if being stopped multiple times', async () => {
       client = new WebSocketClient({ url: `ws://localhost:${port}` });
 
       await client.start();
-      expect(client.isRunning()).toBe(true);
+      expect(client.isRunning).toBe(true);
 
       await client.stop();
       await client.stop();
       await client.stop();
 
-      expect(client.isRunning()).toBe(false);
+      expect(client.isRunning).toBe(false);
     });
 
     it('should throw an error if the client socket open timeout is reached', async () => {
@@ -113,7 +113,7 @@ describe('Web socket client', async () => {
       try {
         const socketTimeout = 100;
         client = new WebSocketClient({ url: `ws://localhost:${port}`, socketTimeout });
-        expect(client.socketTimeout()).toBe(socketTimeout);
+        expect(client.socketTimeout).toBe(socketTimeout);
 
         await expect(client.start()).rejects.toThrowError(new WebSocketOpenTimeoutError(socketTimeout));
       } finally {
@@ -127,7 +127,7 @@ describe('Web socket client', async () => {
       try {
         const socketTimeout = 100;
         client = new WebSocketClient({ url: `ws://localhost:${port}`, socketTimeout });
-        expect(client.socketTimeout()).toBe(socketTimeout);
+        expect(client.socketTimeout).toBe(socketTimeout);
         await client.start();
 
         await expect(client.stop()).rejects.toThrowError(new WebSocketCloseTimeoutError(socketTimeout));
@@ -256,7 +256,7 @@ describe('Web socket client', async () => {
     it('should throw an error if a reply request timeout is reached', async () => {
       const messageTimeout = 100;
       client = new WebSocketClient({ url: `ws://localhost:${port}`, messageTimeout });
-      expect(client.messageTimeout()).toBe(messageTimeout);
+      expect(client.messageTimeout).toBe(messageTimeout);
       await client.start();
 
       type RequestMessage = WebSocket.ServiceEventMessage<Schema, 'with-reply'>;

--- a/packages/zimic-interceptor/src/webSocket/__tests__/WebSocketServer.node.test.ts
+++ b/packages/zimic-interceptor/src/webSocket/__tests__/WebSocketServer.node.test.ts
@@ -69,44 +69,44 @@ describe('Web socket server', async () => {
   describe('Lifecycle', () => {
     it('should support being started', () => {
       server = new WebSocketServer({ httpServer });
-      expect(server.isRunning()).toBe(false);
+      expect(server.isRunning).toBe(false);
 
       server.start();
 
-      expect(server.isRunning()).toBe(true);
+      expect(server.isRunning).toBe(true);
     });
 
     it('should not throw an error if being started multiple times', () => {
       server = new WebSocketServer({ httpServer });
-      expect(server.isRunning()).toBe(false);
+      expect(server.isRunning).toBe(false);
 
       server.start();
       server.start();
       server.start();
 
-      expect(server.isRunning()).toBe(true);
+      expect(server.isRunning).toBe(true);
     });
 
     it('should support being stopped', async () => {
       server = new WebSocketServer({ httpServer });
       server.start();
-      expect(server.isRunning()).toBe(true);
+      expect(server.isRunning).toBe(true);
 
       await server.stop();
 
-      expect(server.isRunning()).toBe(false);
+      expect(server.isRunning).toBe(false);
     });
 
     it('should not throw an error if being stopped multiple times', async () => {
       server = new WebSocketServer({ httpServer });
       server.start();
-      expect(server.isRunning()).toBe(true);
+      expect(server.isRunning).toBe(true);
 
       await server.stop();
       await server.stop();
       await server.stop();
 
-      expect(server.isRunning()).toBe(false);
+      expect(server.isRunning).toBe(false);
     });
 
     it('should throw an error if the server socket close timeout is reached', async () => {
@@ -115,7 +115,7 @@ describe('Web socket server', async () => {
       try {
         const socketTimeout = 100;
         server = new WebSocketServer({ httpServer, socketTimeout });
-        expect(server.socketTimeout()).toBe(socketTimeout);
+        expect(server.socketTimeout).toBe(socketTimeout);
         server.start();
 
         await expect(server.stop()).rejects.toThrowError(new WebSocketCloseTimeoutError(socketTimeout));
@@ -127,7 +127,7 @@ describe('Web socket server', async () => {
     it('should terminate connected clients before stopping', async () => {
       server = new WebSocketServer({ httpServer });
       server.start();
-      expect(server.isRunning()).toBe(true);
+      expect(server.isRunning).toBe(true);
 
       rawClient = new ClientSocket(`ws://localhost:${port}`);
       await waitForOpenClientSocket(rawClient);
@@ -135,7 +135,7 @@ describe('Web socket server', async () => {
       expect(rawClient.readyState).toBe(rawClient.OPEN);
 
       await server.stop();
-      expect(server.isRunning()).toBe(false);
+      expect(server.isRunning).toBe(false);
 
       await waitFor(() => {
         expect(rawClient!.readyState).toBe(rawClient!.CLOSED);
@@ -149,7 +149,7 @@ describe('Web socket server', async () => {
       try {
         const socketTimeout = 100;
         server = new WebSocketServer({ httpServer, socketTimeout });
-        expect(server.socketTimeout()).toBe(socketTimeout);
+        expect(server.socketTimeout).toBe(socketTimeout);
         server.start();
 
         await usingIgnoredConsole(['error'], async (spies) => {
@@ -172,7 +172,7 @@ describe('Web socket server', async () => {
       try {
         const socketTimeout = 100;
         server = new WebSocketServer({ httpServer, socketTimeout });
-        expect(server.socketTimeout()).toBe(socketTimeout);
+        expect(server.socketTimeout).toBe(socketTimeout);
         server.start();
 
         rawClient = new ClientSocket(`ws://localhost:${port}`);
@@ -289,7 +289,7 @@ describe('Web socket server', async () => {
     it('should throw an error if the reply request timeout is reached', async () => {
       const messageTimeout = 100;
       server = new WebSocketServer({ httpServer, messageTimeout });
-      expect(server.messageTimeout()).toBe(messageTimeout);
+      expect(server.messageTimeout).toBe(messageTimeout);
       server.start();
 
       rawClient = new ClientSocket(`ws://localhost:${port}`);

--- a/packages/zimic-interceptor/tests/utils/interceptors.ts
+++ b/packages/zimic-interceptor/tests/utils/interceptors.ts
@@ -43,13 +43,11 @@ export async function getNodeBaseURL(type: HttpInterceptorType, server: Intercep
     return new URL(`http://localhost:${GLOBAL_FALLBACK_SERVER_PORT}`);
   }
 
-  const hostname = server.hostname();
-  const port = server.port()!;
-  expect(port).not.toBe(null);
+  expect(server.port).not.toBe(null);
 
   const crypto = await importCrypto();
   const pathPrefix = `path-${crypto.randomUUID()}`;
-  const baseURL = joinURL(`http://${hostname}:${port}`, pathPrefix);
+  const baseURL = joinURL(`http://${server.hostname}:${server.port}`, pathPrefix);
   return new URL(baseURL);
 }
 
@@ -142,7 +140,7 @@ export async function usingHttpInterceptorWorker(
 }
 
 export function getSingletonWorkerByType(store: HttpInterceptorStore, type: HttpInterceptorType, serverURL: URL) {
-  return type === 'local' ? store.localWorker() : store.remoteWorker(serverURL);
+  return type === 'local' ? store.localWorker : store.remoteWorker(serverURL);
 }
 
 export function assessPreflightInterference(resources: {

--- a/packages/zimic-utils/src/error/expectToThrow.ts
+++ b/packages/zimic-utils/src/error/expectToThrow.ts
@@ -8,10 +8,8 @@ export class ExpectedToThrowError extends Error {
 
 async function expectToThrow<ExpectedError extends Error = Error>(
   promiseOrCallback: Promise<unknown> | (() => PossiblePromise<unknown>),
-  options: { is: (error: unknown) => error is ExpectedError },
+  isExpectedError: (error: unknown) => error is ExpectedError,
 ): Promise<ExpectedError> {
-  const { is: isExpectedError } = options;
-
   try {
     if (promiseOrCallback instanceof Promise) {
       await promiseOrCallback;


### PR DESCRIPTION
### Refactoring
- [interceptor] Changed getter methods to getter properties, as a way to simplify the Zimic API.

#### `HttpInterceptor`

| Previously                | Now                     |
| ------------------------- | ----------------------- |
| `interceptor.baseURL()`   | `interceptor.baseURL`   |
| `interceptor.platform()`  | `interceptor.platform`  |
| `interceptor.isRunning()` | `interceptor.isRunning` |

#### `HttpRequestHandler`

| Previously           | Now                |
| -------------------- | ------------------ |
| `handler.method()`   | `handler.method`   |
| `handler.path()`     | `handler.path`     |
| `handler.requests()` | `handler.requests` |

#### `InterceptorServer`

| Previously                      | Now                           |
| ------------------------------- | ----------------------------- |
| `server.hostname()`             | `server.hostname`             |
| `server.port()`                 | `server.port`                 |
| `server.logUnhandledRequests()` | `server.logUnhandledRequests` |
| `server.httpURL()`              | `server.httpURL`              |
| `server.isRunning()`            | `server.isRunning`            |

> [!IMPORTANT]
>
> For remote interceptors, `await handler.requests()` was the way to access the intercepted requests. Now, you can access the requests in both local and remote interceptors by using `handler.requests`, without needing to await.

Part of #490.