### PR TITLE
feat(interceptor): `NODE_ENV === 'test'` as default `saveRequests` (#348)

### DIFF
--- a/packages/zimic-interceptor/package.json
+++ b/packages/zimic-interceptor/package.json
@@ -82,7 +82,7 @@
     "style": "prettier --log-level warn --ignore-unknown --no-error-on-unmatched-pattern --cache",
     "style:check": "pnpm style --check",
     "style:format": "pnpm style --write",
-    "test": "dotenv -v NODE_ENV=test -- vitest",
+    "test": "dotenv -v NODE_ENV=test -v FORCE_COLOR=1 -- vitest",
     "test:turbo": "dotenv -v CI=true -- pnpm run test run --coverage",
     "types:check": "tsc --noEmit",
     "deps:install-playwright": "playwright install chromium",

--- a/packages/zimic-interceptor/src/http/interceptor/types/public.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/types/public.ts
@@ -29,7 +29,7 @@ export interface HttpInterceptor<_Schema extends HttpSchema> {
    * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-interceptorclear `interceptor.clear()`}
    * after each test.
    *
-   * @default false
+   * @default process.env.NODE_ENV === 'test'
    * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#saving-requests Saving intercepted requests}
    * @see {@link https://github.com/zimicjs/zimic/wiki/guides‐testing‐interceptor Testing}
    */

--- a/packages/zimic-interceptor/vitest.config.mts
+++ b/packages/zimic-interceptor/vitest.config.mts
@@ -36,7 +36,6 @@ export default defineConfig({
         '**/tsup.config.*',
       ],
     },
-    env: { FORCE_COLOR: '1' },
   },
   define: {
     'process.env.SERVER_ACCESS_CONTROL_MAX_AGE': "'0'",


### PR DESCRIPTION
### Features
- Updated the default interceptor `saveRequests` from `false` to `process.env.NODE_ENV === 'test'`. If `process.env` is not available, the default is still false.

This implementation will be paired with https://github.com/zimicjs/zimic/issues/349 shortly, warn users if `saveRequests` is `true` and no regular `interceptor.clear()` calls are made.

Closes #348,