### PR TITLE
chore(ci): create only tag if pre-release

### DIFF
--- a/.github/actions/zimic-release-docs/action.yaml
+++ b/.github/actions/zimic-release-docs/action.yaml
@@ -8,8 +8,8 @@ inputs:
   project-name:
     description: The project name to release
     required: true
-  wiki-ssh-key:
-    description: The SSH key to push to the wiki repository
+  wiki-token:
+    description: The token to push to the wiki repository
     required: true
   commit-user-name:
     description: Commit user name
@@ -26,7 +26,7 @@ runs:
       with:
         repository: zimicjs/zimic.wiki
         path: zimic.wiki
-        ssh-key: ${{ inputs.wiki-ssh-key }}
+        token: ${{ inputs.wiki-token }}
 
     - name: Sync wiki content
       working-directory: zimic

--- a/.github/actions/zimic-release-github/action.yaml
+++ b/.github/actions/zimic-release-github/action.yaml
@@ -1,0 +1,45 @@
+name: Zimic Release GitHub
+description: Zimic Release GitHub
+
+inputs:
+  token:
+    description: GitHub token
+    required: true
+  project-name:
+    description: The project name to release
+    required: true
+  version:
+    description: The version value to release
+    required: true
+  commit:
+    description: The commit SHA to release
+    required: true
+  pre-release-id:
+    description: The pre-release ID to release
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Create GitHub release
+      uses: ncipollo/release-action@v1
+      if: ${{ inputs.pre-release-id == 'none' }}
+      with:
+        name: '${{ inputs.project-name }}: ${{ inputs.version }}'
+        tag: '${{ inputs.project-name }}@${{ inputs.version }}'
+        commit: ${{ inputs.commit }}
+        token: ${{ inputs.token }}
+        makeLatest: true
+        prerelease: false
+        generateReleaseNotes: true
+        draft: true
+
+    - name: Create GitHub tag
+      if: ${{ inputs.pre-release-id != 'none' }}
+      shell: bash
+      run: |
+        git checkout ${{ inputs.commit }}
+
+        tag=${{ inputs.project-name }}@${{ inputs.version }}
+        git tag "$tag"
+        git push origin "$tag"

--- a/.github/workflows/release-zimic-fetch-package.yaml
+++ b/.github/workflows/release-zimic-fetch-package.yaml
@@ -4,6 +4,9 @@ on:
   release:
     types:
       - published
+  push:
+    tags:
+      - '@zimic/fetch@*'
 
 concurrency:
   group: release-zimic-fetch-${{ github.ref_name }}

--- a/.github/workflows/release-zimic-fetch-package.yaml
+++ b/.github/workflows/release-zimic-fetch-package.yaml
@@ -95,7 +95,7 @@ jobs:
         with:
           ref-name: ${{ github.ref_name }}
           project-name: '@zimic/fetch'
-          wiki-ssh-key: ${{ secrets.RELEASE_GITHUB_PUSH_KEY }}
+          wiki-token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
           commit-user-name: ${{ vars.RELEASE_COMMIT_USER_NAME }}
           commit-user-email: ${{ vars.RELEASE_COMMIT_USER_EMAIL }}
 

--- a/.github/workflows/release-zimic-fetch-to-github.yaml
+++ b/.github/workflows/release-zimic-fetch-to-github.yaml
@@ -84,7 +84,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ssh-key: ${{ secrets.RELEASE_GITHUB_PUSH_KEY }}
+          token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
 
       - name: Set up Zimic
         uses: ./.github/actions/zimic-setup
@@ -103,14 +103,11 @@ jobs:
           commit-user-name: ${{ vars.RELEASE_COMMIT_USER_NAME }}
           commit-user-email: ${{ vars.RELEASE_COMMIT_USER_EMAIL }}
 
-      - name: Create GitHub release
-        uses: ncipollo/release-action@v1
+      - name: Release to GitHub
+        uses: ./.github/actions/zimic-release-github
         with:
-          name: '@zimic/fetch: ${{ steps.bump-version.outputs.value }}'
-          tag: '@zimic/fetch@${{ steps.bump-version.outputs.value }}'
-          commit: ${{ steps.bump-version.outputs.commit-sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          makeLatest: ${{ needs.pre-release-to-github.outputs.pre-release-id == 'none' }}
-          prerelease: ${{ needs.pre-release-to-github.outputs.pre-release-id != 'node' }}
-          generateReleaseNotes: true
-          draft: true
+          project-name: '@zimic/fetch'
+          version: ${{ steps.bump-version.outputs.value }}
+          commit: ${{ steps.bump-version.outputs.commit-sha }}
+          pre-release-id: ${{ needs.pre-release-to-github.outputs.pre-release-id }}

--- a/.github/workflows/release-zimic-http-package.yaml
+++ b/.github/workflows/release-zimic-http-package.yaml
@@ -4,6 +4,9 @@ on:
   release:
     types:
       - published
+  push:
+    tags:
+      - '@zimic/http@*'
 
 concurrency:
   group: release-zimic-http-${{ github.ref_name }}

--- a/.github/workflows/release-zimic-http-package.yaml
+++ b/.github/workflows/release-zimic-http-package.yaml
@@ -95,7 +95,7 @@ jobs:
         with:
           ref-name: ${{ github.ref_name }}
           project-name: '@zimic/http'
-          wiki-ssh-key: ${{ secrets.RELEASE_GITHUB_PUSH_KEY }}
+          wiki-token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
           commit-user-name: ${{ vars.RELEASE_COMMIT_USER_NAME }}
           commit-user-email: ${{ vars.RELEASE_COMMIT_USER_EMAIL }}
 

--- a/.github/workflows/release-zimic-http-to-github.yaml
+++ b/.github/workflows/release-zimic-http-to-github.yaml
@@ -84,7 +84,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ssh-key: ${{ secrets.RELEASE_GITHUB_PUSH_KEY }}
+          token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
 
       - name: Set up Zimic
         uses: ./.github/actions/zimic-setup
@@ -103,14 +103,11 @@ jobs:
           commit-user-name: ${{ vars.RELEASE_COMMIT_USER_NAME }}
           commit-user-email: ${{ vars.RELEASE_COMMIT_USER_EMAIL }}
 
-      - name: Create GitHub release
-        uses: ncipollo/release-action@v1
+      - name: Release to GitHub
+        uses: ./.github/actions/zimic-release-github
         with:
-          name: '@zimic/http: ${{ steps.bump-version.outputs.value }}'
-          tag: '@zimic/http@${{ steps.bump-version.outputs.value }}'
-          commit: ${{ steps.bump-version.outputs.commit-sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          makeLatest: ${{ needs.pre-release-to-github.outputs.pre-release-id == 'none' }}
-          prerelease: ${{ needs.pre-release-to-github.outputs.pre-release-id != 'node' }}
-          generateReleaseNotes: true
-          draft: true
+          project-name: '@zimic/http'
+          version: ${{ steps.bump-version.outputs.value }}
+          commit: ${{ steps.bump-version.outputs.commit-sha }}
+          pre-release-id: ${{ needs.pre-release-to-github.outputs.pre-release-id }}

--- a/.github/workflows/release-zimic-interceptor-package.yaml
+++ b/.github/workflows/release-zimic-interceptor-package.yaml
@@ -97,7 +97,7 @@ jobs:
         with:
           ref-name: ${{ github.ref_name }}
           project-name: '@zimic/interceptor'
-          wiki-ssh-key: ${{ secrets.RELEASE_GITHUB_PUSH_KEY }}
+          wiki-token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
           commit-user-name: ${{ vars.RELEASE_COMMIT_USER_NAME }}
           commit-user-email: ${{ vars.RELEASE_COMMIT_USER_EMAIL }}
 

--- a/.github/workflows/release-zimic-interceptor-package.yaml
+++ b/.github/workflows/release-zimic-interceptor-package.yaml
@@ -4,6 +4,9 @@ on:
   release:
     types:
       - published
+  push:
+    tags:
+      - '@zimic/interceptor@*'
 
 concurrency:
   group: release-zimic-interceptor-${{ github.ref_name }}

--- a/.github/workflows/release-zimic-interceptor-to-github.yaml
+++ b/.github/workflows/release-zimic-interceptor-to-github.yaml
@@ -84,7 +84,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ssh-key: ${{ secrets.RELEASE_GITHUB_PUSH_KEY }}
+          token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
 
       - name: Set up Zimic
         uses: ./.github/actions/zimic-setup
@@ -103,14 +103,12 @@ jobs:
           commit-user-name: ${{ vars.RELEASE_COMMIT_USER_NAME }}
           commit-user-email: ${{ vars.RELEASE_COMMIT_USER_EMAIL }}
 
-      - name: Create GitHub release
-        uses: ncipollo/release-action@v1
+      - name: Release to GitHub
+        id: release
+        uses: ./.github/actions/zimic-release-github
         with:
-          name: '@zimic/interceptor: ${{ steps.bump-version.outputs.value }}'
-          tag: '@zimic/interceptor@${{ steps.bump-version.outputs.value }}'
-          commit: ${{ steps.bump-version.outputs.commit-sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          makeLatest: ${{ needs.pre-release-to-github.outputs.pre-release-id == 'none' }}
-          prerelease: ${{ needs.pre-release-to-github.outputs.pre-release-id != 'node' }}
-          generateReleaseNotes: true
-          draft: true
+          project-name: '@zimic/interceptor'
+          version: ${{ steps.bump-version.outputs.value }}
+          commit: ${{ steps.bump-version.outputs.commit-sha }}
+          pre-release-id: ${{ needs.pre-release-to-github.outputs.pre-release-id }}


### PR DESCRIPTION
### Chore
- [ci] Changed the GitHub release workflows to create only a tag (without release) if it is as pre-release. The purpose is to keep our [Releases page](https://github.com/zimicjs/zimic/releases) cleaner.