### PR TITLE
feat(interceptor): show warning when safe number of saved requests is exceeded (#349)

### DIFF
--- a/apps/zimic-test-client/tests/fetch/FetchClient.test.ts
+++ b/apps/zimic-test-client/tests/fetch/FetchClient.test.ts
@@ -28,7 +28,6 @@ describe('Fetch client', async () => {
   const authInterceptor = createHttpInterceptor<AuthServiceSchema>({
     type: 'local',
     baseURL: authFetch.defaults.baseURL,
-    saveRequests: true,
   });
 
   const notificationFetch = createFetch<NotificationServiceSchema>({
@@ -38,7 +37,6 @@ describe('Fetch client', async () => {
   const notificationInterceptor = createHttpInterceptor<NotificationServiceSchema>({
     type: 'local',
     baseURL: notificationFetch.defaults.baseURL,
-    saveRequests: true,
   });
 
   const interceptors = [authInterceptor, notificationInterceptor];

--- a/apps/zimic-test-client/tests/interceptor/thirdParty/shared/httpInterceptor.ts
+++ b/apps/zimic-test-client/tests/interceptor/thirdParty/shared/httpInterceptor.ts
@@ -37,13 +37,13 @@ async function declareHttpInterceptorTests(options: ClientTestOptionsByWorkerTyp
   const authInterceptor = createHttpInterceptor<AuthServiceSchema>({
     type,
     baseURL: getAuthBaseURL(type, crypto),
-    saveRequests: true,
+    requestSaving: { enabled: true },
   });
 
   const notificationInterceptor = createHttpInterceptor<NotificationServiceSchema>({
     type,
     baseURL: getNotificationsBaseURL(type, crypto),
-    saveRequests: true,
+    requestSaving: { enabled: true },
   });
 
   const interceptors = [authInterceptor, notificationInterceptor];

--- a/docs/wiki/api‐zimic‐interceptor‐http.md
+++ b/docs/wiki/api‐zimic‐interceptor‐http.md
@@ -269,7 +269,7 @@ import { createHttpInterceptor } from '@zimic/interceptor/http';
 const interceptor = createHttpInterceptor<Schema>({
   type: 'local',
   baseURL: 'http://localhost:3000',
-  saveRequests: true,
+  requestSaving: { enabled: true },
 });
 
 // Recommended: Clear the interceptor after each test.
@@ -287,7 +287,7 @@ import { createHttpInterceptor } from '@zimic/interceptor/http';
 const interceptor = createHttpInterceptor<Schema>({
   type: 'remote',
   baseURL: 'http://localhost:3000',
-  saveRequests: true,
+  requestSaving: { enabled: true },
 });
 
 // Recommended: Clear the interceptor after each test.
@@ -504,7 +504,7 @@ including a stack trace to the [`handler.times()`](#http-handlertimes) that was 
 
 > [!TIP]
 >
-> When [`saveRequests: true`](#createhttpinterceptoroptions) is enabled in your interceptor, the `TimesCheckError`
+> When [`requestSaving.enabled`](#createhttpinterceptoroptions) is true in your interceptor, the `TimesCheckError`
 > errors will also list each unmatched request with diff of the expected and received data. This is useful for debugging
 > requests that did not match a handler with [restrictions](#http-handlerwithrestriction).
 

--- a/docs/wiki/api‐zimic‐interceptor‐http.md
+++ b/docs/wiki/api‐zimic‐interceptor‐http.md
@@ -247,15 +247,15 @@ const interceptor = createHttpInterceptor<Schema>({
 The `requestSaving` option configures if the intercepted requests are saved and how they are handled. It supports the
 following properties:
 
-| Property    | Description                                                                                                                                                                                                                                                                                                                                                                                                        | Default                           |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------- |
-| `enabled`   | Whether [request handlers](#httprequesthandler) should save their intercepted requests in memory and make them accessible through `handler.requests`. If you are using [interceptor.checkTimes()](#http-interceptorchecktimes) or [handler.checkTimes()](#http-handlerchecktimes) during tests, consider enabling this option to get more detailed information in `TimesCheckError` errors.                        | `process.env.NODE_ENV === 'test'` |
-| `safeLimit` | The safe number of requests to save in memory before logging warnings in the console. If `requestSaving.enabled` is true and the interceptor is not regularly cleared with [`interceptor.clear()`](#http-interceptorclear), the requests may accumulate in memory and cause performance issues. This option does not limit the number of requests saved in memory, but it logs warnings when the limit is reached. | `1000`                            |
+| Property    | Description                                                                                                                                                                                                                                                                                                                                                                                             | Default                           |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------- |
+| `enabled`   | Whether [request handlers](#httprequesthandler) should save their intercepted requests in memory and make them accessible through [`handler.requests`](#http-handlerrequests). If you are using [interceptor.checkTimes()](#http-interceptorchecktimes) or [handler.checkTimes()](#http-handlerchecktimes), consider enabling this option to get more detailed information in `TimesCheckError` errors. | `process.env.NODE_ENV === 'test'` |
+| `safeLimit` | The safe number of requests to save in memory before logging warnings in the console. If `requestSaving.enabled` is true and the interceptor is not regularly cleared with [`interceptor.clear()`](#http-interceptorclear), the requests may accumulate in memory and cause performance issues. This option does not limit the number of saved requests, only when to log warnings.                     | `1000`                            |
 
 > [!IMPORTANT]
 >
-> If `requestSaving.enabled` is true, make sure to regularly clear the interceptor to avoid that the requests accumulate
-> in memory. A common practice is to call [`interceptor.clear()`](#http-interceptorclear) after each test.
+> If `requestSaving.enabled` is `true`, make sure to regularly clear the interceptor to avoid requests accumulating in
+> memory. A common practice is to call [`interceptor.clear()`](#http-interceptorclear) after each test.
 >
 > See [Testing](guides‐testing‐interceptor) for an example of how to manage the lifecycle of interceptors in your tests.
 
@@ -486,7 +486,7 @@ including a stack trace to the [`handler.times()`](#http-handlertimes) that was 
 
 > [!TIP]
 >
-> When [`requestSaving.enabled`](#saving-requests) is true in your interceptor, the `TimesCheckError` errors will also
+> When [`requestSaving.enabled`](#saving-requests) is `true` in your interceptor, the `TimesCheckError` errors will also
 > list each unmatched request with diff of the expected and received data. This is useful for debugging requests that
 > did not match a handler with [restrictions](#http-handlerwithrestriction).
 

--- a/docs/wiki/getting‐started‐interceptor.md
+++ b/docs/wiki/getting‐started‐interceptor.md
@@ -207,7 +207,7 @@ use remote interceptors.
     const interceptor = createHttpInterceptor<Schema>({
       type: 'local',
       baseURL: 'http://localhost:3000',
-      saveRequests: true, // Allow access to `handler.requests`
+      requestSaving: { enabled: true },
     });
     ```
 
@@ -220,7 +220,7 @@ use remote interceptors.
       type: 'remote',
       // The interceptor server is at http://localhost:4000
       baseURL: 'http://localhost:4000/my-service',
-      saveRequests: true, // Allow access to `handler.requests`
+      requestSaving: { enabled: true },
     });
     ```
 

--- a/docs/wiki/getting‐started‐interceptor.md
+++ b/docs/wiki/getting‐started‐interceptor.md
@@ -207,7 +207,6 @@ use remote interceptors.
     const interceptor = createHttpInterceptor<Schema>({
       type: 'local',
       baseURL: 'http://localhost:3000',
-      requestSaving: { enabled: true },
     });
     ```
 
@@ -220,7 +219,6 @@ use remote interceptors.
       type: 'remote',
       // The interceptor server is at http://localhost:4000
       baseURL: 'http://localhost:4000/my-service',
-      requestSaving: { enabled: true },
     });
     ```
 

--- a/examples/with-jest-jsdom/tests/interceptors/github.ts
+++ b/examples/with-jest-jsdom/tests/interceptors/github.ts
@@ -5,7 +5,6 @@ import { GITHUB_API_BASE_URL, GitHubSchema } from '../../src/clients/github';
 const githubInterceptor = createHttpInterceptor<GitHubSchema>({
   type: 'local',
   baseURL: GITHUB_API_BASE_URL,
-  saveRequests: true,
 });
 
 export default githubInterceptor;

--- a/examples/with-jest-node/tests/interceptors/github.ts
+++ b/examples/with-jest-node/tests/interceptors/github.ts
@@ -5,7 +5,6 @@ import { GITHUB_API_BASE_URL, GitHubSchema } from '../../src/clients/github';
 const githubInterceptor = createHttpInterceptor<GitHubSchema>({
   type: 'local',
   baseURL: GITHUB_API_BASE_URL,
-  saveRequests: true,
 });
 
 export default githubInterceptor;

--- a/examples/with-openapi-typegen/tests/interceptors/github.ts
+++ b/examples/with-openapi-typegen/tests/interceptors/github.ts
@@ -6,7 +6,6 @@ import { GitHubSchema } from '../../src/clients/github/typegen/generated';
 const githubInterceptor = createHttpInterceptor<GitHubSchema>({
   type: 'local',
   baseURL: GITHUB_API_BASE_URL,
-  saveRequests: true,
 });
 
 export default githubInterceptor;

--- a/examples/with-vitest-node/tests/interceptors/github.ts
+++ b/examples/with-vitest-node/tests/interceptors/github.ts
@@ -5,7 +5,6 @@ import { GITHUB_API_BASE_URL, GitHubSchema } from '../../src/clients/github';
 const githubInterceptor = createHttpInterceptor<GitHubSchema>({
   type: 'local',
   baseURL: GITHUB_API_BASE_URL,
-  saveRequests: true,
 });
 
 export default githubInterceptor;

--- a/packages/zimic-fetch/tests/utils/interceptors.ts
+++ b/packages/zimic-fetch/tests/utils/interceptors.ts
@@ -44,7 +44,7 @@ export async function usingHttpInterceptor<Schema extends HttpSchema>(
   const interceptor = createHttpInterceptor<Schema>({
     ...interceptorOptions,
     onUnhandledRequest: { action: 'reject', log: false },
-    saveRequests: true,
+    requestSaving: { enabled: true },
   });
 
   await interceptor.start();

--- a/packages/zimic-fetch/tests/utils/interceptors.ts
+++ b/packages/zimic-fetch/tests/utils/interceptors.ts
@@ -41,11 +41,7 @@ export async function usingHttpInterceptor<Schema extends HttpSchema>(
   interceptorOptions: HttpInterceptorOptions,
   callback: UsingInterceptorCallback<Schema>,
 ): Promise<void> {
-  const interceptor = createHttpInterceptor<Schema>({
-    ...interceptorOptions,
-    onUnhandledRequest: { action: 'reject', log: false },
-    requestSaving: { enabled: true },
-  });
+  const interceptor = createHttpInterceptor<Schema>(interceptorOptions);
 
   await interceptor.start();
 

--- a/packages/zimic-http/src/cli/typegen/__tests__/openapi.node.test.ts
+++ b/packages/zimic-http/src/cli/typegen/__tests__/openapi.node.test.ts
@@ -86,7 +86,7 @@ describe('Type generation (OpenAPI)', () => {
   }>({
     type: 'local',
     baseURL: 'http://localhost:3000',
-    saveRequests: true,
+    requestSaving: { enabled: true },
   });
 
   beforeAll(async () => {

--- a/packages/zimic-http/src/cli/typegen/__tests__/openapi.node.test.ts
+++ b/packages/zimic-http/src/cli/typegen/__tests__/openapi.node.test.ts
@@ -86,7 +86,6 @@ describe('Type generation (OpenAPI)', () => {
   }>({
     type: 'local',
     baseURL: 'http://localhost:3000',
-    requestSaving: { enabled: true },
   });
 
   beforeAll(async () => {

--- a/packages/zimic-interceptor/README.md
+++ b/packages/zimic-interceptor/README.md
@@ -149,7 +149,7 @@ Check our [getting started guide](https://github.com/zimicjs/zimic/wiki/gettingâ
     const interceptor = createHttpInterceptor<Schema>({
       type: 'local',
       baseURL: 'http://localhost:3000',
-      saveRequests: true, // Allow access to `handler.requests`
+      requestSaving: { enabled: true },
     });
     ```
 

--- a/packages/zimic-interceptor/README.md
+++ b/packages/zimic-interceptor/README.md
@@ -149,7 +149,6 @@ Check our [getting started guide](https://github.com/zimicjs/zimic/wiki/gettingâ
     const interceptor = createHttpInterceptor<Schema>({
       type: 'local',
       baseURL: 'http://localhost:3000',
-      requestSaving: { enabled: true },
     });
     ```
 

--- a/packages/zimic-interceptor/src/http/interceptor/HttpInterceptorClient.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/HttpInterceptorClient.ts
@@ -41,7 +41,7 @@ class HttpInterceptorClient<
   private store: HttpInterceptorStore;
 
   private _baseURL!: URL;
-  private _saveRequests: HttpInterceptorRequestSaving;
+  private _requestSaving: HttpInterceptorRequestSaving;
 
   onUnhandledRequest?: HandlerConstructor extends typeof LocalHttpRequestHandler
     ? UnhandledRequestStrategy.Local
@@ -76,7 +76,7 @@ class HttpInterceptorClient<
 
     this.baseURL = options.baseURL;
 
-    this._saveRequests = {
+    this._requestSaving = {
       enabled: options.requestSaving?.enabled ?? (isServerSide() ? process.env.NODE_ENV === 'test' : false),
       safeLimit: options.requestSaving?.safeLimit ?? DEFAULT_SAVE_REQUESTS_SAFE_LIMIT,
     };
@@ -112,11 +112,11 @@ class HttpInterceptorClient<
   }
 
   get requestSaving() {
-    return this._saveRequests;
+    return this._requestSaving;
   }
 
   set requestSaving(requestSaving: HttpInterceptorRequestSaving) {
-    this._saveRequests = requestSaving;
+    this._requestSaving = requestSaving;
   }
 
   get platform() {

--- a/packages/zimic-interceptor/src/http/interceptor/HttpInterceptorClient.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/HttpInterceptorClient.ts
@@ -23,6 +23,7 @@ import RemoteHttpRequestHandler from '../requestHandler/RemoteHttpRequestHandler
 import { HttpRequestHandler, InternalHttpRequestHandler } from '../requestHandler/types/public';
 import { HttpInterceptorRequest } from '../requestHandler/types/requests';
 import NotRunningHttpInterceptorError from './errors/NotRunningHttpInterceptorError';
+import RequestSavingSafeLimitExceededError from './errors/RequestSavingSafeLimitExceededError';
 import RunningHttpInterceptorError from './errors/RunningHttpInterceptorError';
 import HttpInterceptorStore from './HttpInterceptorStore';
 import { UnhandledRequestStrategy } from './types/options';
@@ -41,7 +42,9 @@ class HttpInterceptorClient<
   private store: HttpInterceptorStore;
 
   private _baseURL!: URL;
-  private _requestSaving: HttpInterceptorRequestSaving;
+
+  requestSaving: HttpInterceptorRequestSaving;
+  private numberOfSavedRequests = 0;
 
   onUnhandledRequest?: HandlerConstructor extends typeof LocalHttpRequestHandler
     ? UnhandledRequestStrategy.Local
@@ -76,7 +79,7 @@ class HttpInterceptorClient<
 
     this.baseURL = options.baseURL;
 
-    this._requestSaving = {
+    this.requestSaving = {
       enabled: options.requestSaving?.enabled ?? (isServerSide() ? process.env.NODE_ENV === 'test' : false),
       safeLimit: options.requestSaving?.safeLimit ?? DEFAULT_REQUEST_SAVING_SAFE_LIMIT,
     };
@@ -109,14 +112,6 @@ class HttpInterceptorClient<
       return this.baseURL.origin;
     }
     return this.baseURL.href;
-  }
-
-  get requestSaving() {
-    return this._requestSaving;
-  }
-
-  set requestSaving(requestSaving: HttpInterceptorRequestSaving) {
-    this._requestSaving = requestSaving;
   }
 
   get platform() {
@@ -268,6 +263,17 @@ class HttpInterceptorClient<
     }
 
     return response;
+  }
+
+  incrementNumberOfSavedRequests(increment: number) {
+    this.numberOfSavedRequests = Math.max(this.numberOfSavedRequests + increment, 0);
+
+    const exceedsSafeLimit = this.numberOfSavedRequests > this.requestSaving.safeLimit;
+
+    if (increment > 0 && exceedsSafeLimit) {
+      const error = new RequestSavingSafeLimitExceededError(this.numberOfSavedRequests, this.requestSaving.safeLimit);
+      console.warn(error);
+    }
   }
 
   private async findMatchedHandler<

--- a/packages/zimic-interceptor/src/http/interceptor/HttpInterceptorClient.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/HttpInterceptorClient.ts
@@ -31,7 +31,7 @@ import { HttpInterceptorRequestContext } from './types/requests';
 
 export const SUPPORTED_BASE_URL_PROTOCOLS = Object.freeze(['http', 'https']);
 
-export const DEFAULT_SAVE_REQUESTS_SAFE_LIMIT = 1000;
+export const DEFAULT_REQUEST_SAVING_SAFE_LIMIT = 1000;
 
 class HttpInterceptorClient<
   Schema extends HttpSchema,
@@ -78,7 +78,7 @@ class HttpInterceptorClient<
 
     this._requestSaving = {
       enabled: options.requestSaving?.enabled ?? (isServerSide() ? process.env.NODE_ENV === 'test' : false),
-      safeLimit: options.requestSaving?.safeLimit ?? DEFAULT_SAVE_REQUESTS_SAFE_LIMIT,
+      safeLimit: options.requestSaving?.safeLimit ?? DEFAULT_REQUEST_SAVING_SAFE_LIMIT,
     };
 
     this.onUnhandledRequest = options.onUnhandledRequest satisfies

--- a/packages/zimic-interceptor/src/http/interceptor/LocalHttpInterceptor.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/LocalHttpInterceptor.ts
@@ -4,8 +4,8 @@ import LocalHttpRequestHandler from '../requestHandler/LocalHttpRequestHandler';
 import HttpInterceptorClient from './HttpInterceptorClient';
 import HttpInterceptorStore from './HttpInterceptorStore';
 import { SyncHttpInterceptorMethodHandler } from './types/handlers';
-import { LocalHttpInterceptorOptions } from './types/options';
-import { LocalHttpInterceptor as PublicLocalHttpInterceptor } from './types/public';
+import { LocalHttpInterceptorOptions, UnhandledRequestStrategy } from './types/options';
+import { HttpInterceptorRequestSaving, LocalHttpInterceptor as PublicLocalHttpInterceptor } from './types/public';
 
 class LocalHttpInterceptor<Schema extends HttpSchema> implements PublicLocalHttpInterceptor<Schema> {
   private store = new HttpInterceptorStore();
@@ -23,7 +23,7 @@ class LocalHttpInterceptor<Schema extends HttpSchema> implements PublicLocalHttp
       baseURL,
       Handler: LocalHttpRequestHandler,
       onUnhandledRequest: options.onUnhandledRequest,
-      saveRequests: options.saveRequests,
+      requestSaving: options.requestSaving,
     });
   }
 
@@ -39,19 +39,19 @@ class LocalHttpInterceptor<Schema extends HttpSchema> implements PublicLocalHttp
     this.client.baseURL = new URL(baseURL);
   }
 
-  get saveRequests() {
-    return this.client.saveRequests;
+  get requestSaving() {
+    return this.client.requestSaving;
   }
 
-  set saveRequests(saveRequests: NonNullable<LocalHttpInterceptorOptions['saveRequests']>) {
-    this.client.saveRequests = saveRequests;
+  set requestSaving(requestSaving: HttpInterceptorRequestSaving) {
+    this.client.requestSaving = requestSaving;
   }
 
   get onUnhandledRequest() {
     return this.client.onUnhandledRequest;
   }
 
-  set onUnhandledRequest(onUnhandledRequest: LocalHttpInterceptorOptions['onUnhandledRequest']) {
+  set onUnhandledRequest(onUnhandledRequest: UnhandledRequestStrategy.Local | undefined) {
     this.client.onUnhandledRequest = onUnhandledRequest;
   }
 

--- a/packages/zimic-interceptor/src/http/interceptor/RemoteHttpInterceptor.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/RemoteHttpInterceptor.ts
@@ -4,8 +4,8 @@ import RemoteHttpRequestHandler from '../requestHandler/RemoteHttpRequestHandler
 import HttpInterceptorClient from './HttpInterceptorClient';
 import HttpInterceptorStore from './HttpInterceptorStore';
 import { AsyncHttpInterceptorMethodHandler } from './types/handlers';
-import { RemoteHttpInterceptorOptions } from './types/options';
-import { RemoteHttpInterceptor as PublicRemoteHttpInterceptor } from './types/public';
+import { RemoteHttpInterceptorOptions, UnhandledRequestStrategy } from './types/options';
+import { HttpInterceptorRequestSaving, RemoteHttpInterceptor as PublicRemoteHttpInterceptor } from './types/public';
 
 class RemoteHttpInterceptor<Schema extends HttpSchema> implements PublicRemoteHttpInterceptor<Schema> {
   private store = new HttpInterceptorStore();
@@ -24,7 +24,7 @@ class RemoteHttpInterceptor<Schema extends HttpSchema> implements PublicRemoteHt
       baseURL,
       Handler: RemoteHttpRequestHandler,
       onUnhandledRequest: options.onUnhandledRequest,
-      saveRequests: options.saveRequests,
+      requestSaving: options.requestSaving,
     });
   }
 
@@ -40,19 +40,19 @@ class RemoteHttpInterceptor<Schema extends HttpSchema> implements PublicRemoteHt
     this.client.baseURL = new URL(baseURL);
   }
 
-  get saveRequests() {
-    return this.client.saveRequests;
+  get requestSaving() {
+    return this.client.requestSaving;
   }
 
-  set saveRequests(saveRequests: NonNullable<RemoteHttpInterceptorOptions['saveRequests']>) {
-    this.client.saveRequests = saveRequests;
+  set requestSaving(requestSaving: HttpInterceptorRequestSaving) {
+    this.client.requestSaving = requestSaving;
   }
 
   get onUnhandledRequest() {
     return this.client.onUnhandledRequest;
   }
 
-  set onUnhandledRequest(onUnhandledRequest: RemoteHttpInterceptorOptions['onUnhandledRequest']) {
+  set onUnhandledRequest(onUnhandledRequest: UnhandledRequestStrategy.Remote | undefined) {
     this.client.onUnhandledRequest = onUnhandledRequest;
   }
 

--- a/packages/zimic-interceptor/src/http/interceptor/__tests__/HttpInterceptor.requestSaving.browser.test.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/__tests__/HttpInterceptor.requestSaving.browser.test.ts
@@ -1,0 +1,21 @@
+import { beforeAll, describe } from 'vitest';
+
+import { getBrowserBaseURL } from '@tests/utils/interceptors';
+
+import testMatrix from './shared/matrix';
+import { declareRequestSavingHttpInterceptorTests } from './shared/requestSaving';
+
+describe.each(testMatrix)('HttpInterceptor (browser, $type) > Request saving', ({ type }) => {
+  let baseURL: string;
+
+  beforeAll(async () => {
+    baseURL = await getBrowserBaseURL(type);
+  });
+
+  declareRequestSavingHttpInterceptorTests({
+    platform: 'browser',
+    type,
+    getBaseURL: () => baseURL,
+    getInterceptorOptions: () => ({ type, baseURL }),
+  });
+});

--- a/packages/zimic-interceptor/src/http/interceptor/__tests__/HttpInterceptor.requestSaving.node.test.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/__tests__/HttpInterceptor.requestSaving.node.test.ts
@@ -1,0 +1,33 @@
+import { afterAll, beforeAll, describe } from 'vitest';
+
+import { getNodeBaseURL } from '@tests/utils/interceptors';
+import { createInternalInterceptorServer } from '@tests/utils/interceptorServers';
+
+import testMatrix from './shared/matrix';
+import { declareRequestSavingHttpInterceptorTests } from './shared/requestSaving';
+
+describe.each(testMatrix)('HttpInterceptor (node, $type) > Request saving', ({ type }) => {
+  const server = createInternalInterceptorServer({ logUnhandledRequests: false });
+
+  let baseURL: string;
+
+  beforeAll(async () => {
+    if (type === 'remote') {
+      await server.start();
+    }
+    baseURL = await getNodeBaseURL(type, server);
+  });
+
+  afterAll(async () => {
+    if (type === 'remote') {
+      await server.stop();
+    }
+  });
+
+  declareRequestSavingHttpInterceptorTests({
+    platform: 'node',
+    type,
+    getBaseURL: () => baseURL,
+    getInterceptorOptions: () => ({ type, baseURL }),
+  });
+});

--- a/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/handlers.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/handlers.ts
@@ -1,15 +1,13 @@
 import { HttpHeaders, HttpSearchParams, HTTP_METHODS, HttpSchema } from '@zimic/http';
 import expectFetchError from '@zimic/utils/fetch/expectFetchError';
 import joinURL from '@zimic/utils/url/joinURL';
-import { beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
+import { beforeEach, describe, expect, expectTypeOf, it } from 'vitest';
 
 import { promiseIfRemote } from '@/http/interceptorWorker/__tests__/utils/promises';
-import DisabledRequestSavingError from '@/http/requestHandler/errors/DisabledRequestSavingError';
 import LocalHttpRequestHandler from '@/http/requestHandler/LocalHttpRequestHandler';
 import RemoteHttpRequestHandler from '@/http/requestHandler/RemoteHttpRequestHandler';
 import { AccessControlHeaders, DEFAULT_ACCESS_CONTROL_HEADERS } from '@/server/constants';
 import { importCrypto } from '@/utils/crypto';
-import { isClientSide } from '@/utils/environment';
 import { usingIgnoredConsole } from '@tests/utils/console';
 import { expectPreflightResponse } from '@tests/utils/fetch';
 import { assessPreflightInterference, usingHttpInterceptor } from '@tests/utils/interceptors';
@@ -34,79 +32,6 @@ export async function declareHandlerHttpInterceptorTests(options: RuntimeSharedH
   beforeEach(() => {
     baseURL = getBaseURL();
     interceptorOptions = getInterceptorOptions();
-  });
-
-  describe('Request saving', () => {
-    it.each([{ NODE_ENV: 'development' }, { NODE_ENV: 'test' }, { NODE_ENV: 'production' }])(
-      'should have the correct default save requests strategy if none is provided (NODE_ENV: %s)',
-      async (environment) => {
-        vi.spyOn(process, 'env', 'get').mockReturnValue(environment);
-        expect(process.env).toEqual(environment);
-
-        await usingHttpInterceptor<{
-          '/users': { GET: MethodSchema };
-        }>({ ...interceptorOptions, requestSaving: undefined }, async (interceptor) => {
-          const defaultSaveRequests = interceptor.requestSaving.enabled;
-
-          if (isClientSide()) {
-            expect(defaultSaveRequests).toBe(false);
-          } else {
-            expect(defaultSaveRequests).toBe(environment.NODE_ENV === 'test');
-          }
-
-          const handler = await promiseIfRemote(
-            interceptor.get('/users').respond({
-              status: 200,
-              headers: DEFAULT_ACCESS_CONTROL_HEADERS,
-            }),
-            interceptor,
-          );
-
-          const numberOfRequests = 5;
-
-          if (defaultSaveRequests) {
-            expect(handler.requests).toHaveLength(0);
-
-            for (let index = 0; index < numberOfRequests; index++) {
-              const response = await fetch(joinURL(baseURL, '/users'), { method: 'GET' });
-              expect(response.status).toBe(200);
-            }
-
-            expect(handler.requests).toHaveLength(numberOfRequests);
-          } else {
-            const error = new DisabledRequestSavingError();
-
-            expect(() => {
-              // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-              handler.requests;
-            }).toThrowError(error);
-
-            // @ts-expect-error Checking that no intercepted requests are saved.
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            expect(handler.client._requests).toHaveLength(0);
-
-            const numberOfRequests = 5;
-
-            for (let index = 0; index < numberOfRequests; index++) {
-              const response = await fetch(joinURL(baseURL, '/users'), { method: 'GET' });
-              expect(response.status).toBe(200);
-            }
-
-            expect(() => {
-              // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-              handler.requests;
-            }).toThrowError(error);
-
-            // @ts-expect-error Checking that no intercepted requests are saved.
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            expect(handler.client._requests).toHaveLength(0);
-          }
-
-          interceptor.requestSaving.enabled = !defaultSaveRequests;
-          expect(interceptor.requestSaving.enabled).toBe(!defaultSaveRequests);
-        });
-      },
-    );
   });
 
   describe.each(HTTP_METHODS)('Method (%s)', (method) => {
@@ -559,155 +484,5 @@ export async function declareHandlerHttpInterceptorTests(options: RuntimeSharedH
         });
       });
     }
-
-    describe('Request saving', () => {
-      it(`should not save intercepted ${method} requests if disabled`, async () => {
-        await usingHttpInterceptor<{
-          '/users': {
-            GET: MethodSchema;
-            POST: MethodSchema;
-            PUT: MethodSchema;
-            PATCH: MethodSchema;
-            DELETE: MethodSchema;
-            HEAD: MethodSchema;
-            OPTIONS: MethodSchema;
-          };
-        }>({ ...interceptorOptions, requestSaving: { enabled: false } }, async (interceptor) => {
-          const handler = await promiseIfRemote(
-            interceptor[lowerMethod]('/users').respond({
-              status: 200,
-              headers: DEFAULT_ACCESS_CONTROL_HEADERS,
-            }),
-            interceptor,
-          );
-
-          const error = new DisabledRequestSavingError();
-
-          expect(() => {
-            // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-            handler.requests;
-          }).toThrowError(error);
-
-          // @ts-expect-error Checking that no intercepted requests are saved.
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          expect(handler.client._requests).toHaveLength(0);
-
-          const numberOfRequests = 5;
-
-          for (let index = 0; index < numberOfRequests; index++) {
-            const response = await fetch(joinURL(baseURL, '/users'), { method });
-            expect(response.status).toBe(200);
-          }
-
-          expect(() => {
-            // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-            handler.requests;
-          }).toThrowError(error);
-
-          // @ts-expect-error Checking that no intercepted requests are saved.
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          expect(handler.client._requests).toHaveLength(0);
-        });
-      });
-
-      it(`should save intercepted ${method} requests if enabled`, async () => {
-        await usingHttpInterceptor<{
-          '/users': {
-            GET: MethodSchema;
-            POST: MethodSchema;
-            PUT: MethodSchema;
-            PATCH: MethodSchema;
-            DELETE: MethodSchema;
-            HEAD: MethodSchema;
-            OPTIONS: MethodSchema;
-          };
-        }>({ ...interceptorOptions, requestSaving: { enabled: true } }, async (interceptor) => {
-          const handler = await promiseIfRemote(
-            interceptor[lowerMethod]('/users').respond({
-              status: 200,
-              headers: DEFAULT_ACCESS_CONTROL_HEADERS,
-            }),
-            interceptor,
-          );
-
-          expect(handler.requests).toHaveLength(0);
-
-          const numberOfRequests = 5;
-
-          for (let index = 0; index < numberOfRequests; index++) {
-            const response = await fetch(joinURL(baseURL, '/users'), { method });
-            expect(response.status).toBe(200);
-          }
-
-          expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight * numberOfRequests);
-        });
-      });
-
-      it(`should support changing the save requests strategy after created for ${method} requests`, async () => {
-        await usingHttpInterceptor<{
-          '/users': {
-            GET: MethodSchema;
-            POST: MethodSchema;
-            PUT: MethodSchema;
-            PATCH: MethodSchema;
-            DELETE: MethodSchema;
-            HEAD: MethodSchema;
-            OPTIONS: MethodSchema;
-          };
-        }>({ ...interceptorOptions, requestSaving: { enabled: true } }, async (interceptor) => {
-          const handler = await promiseIfRemote(
-            interceptor[lowerMethod]('/users').respond({
-              status: 200,
-              headers: DEFAULT_ACCESS_CONTROL_HEADERS,
-            }),
-            interceptor,
-          );
-
-          expect(interceptor.requestSaving.enabled).toBe(true);
-          interceptor.requestSaving.enabled = false;
-          expect(interceptor.requestSaving.enabled).toBe(false);
-
-          const error = new DisabledRequestSavingError();
-
-          expect(() => {
-            // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-            handler.requests;
-          }).toThrowError(error);
-
-          // @ts-expect-error Checking that no intercepted requests are saved.
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          expect(handler.client._requests).toHaveLength(0);
-
-          const numberOfRequests = 5;
-
-          for (let index = 0; index < numberOfRequests; index++) {
-            const response = await fetch(joinURL(baseURL, '/users'), { method });
-            expect(response.status).toBe(200);
-          }
-
-          expect(() => {
-            // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-            handler.requests;
-          }).toThrowError(error);
-
-          // @ts-expect-error Checking that no intercepted requests are saved.
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          expect(handler.client._requests).toHaveLength(0);
-
-          expect(interceptor.requestSaving.enabled).toBe(false);
-          interceptor.requestSaving.enabled = true;
-          expect(interceptor.requestSaving.enabled).toBe(true);
-
-          expect(handler.requests).toHaveLength(0);
-
-          for (let index = 0; index < numberOfRequests; index++) {
-            const response = await fetch(joinURL(baseURL, '/users'), { method });
-            expect(response.status).toBe(200);
-          }
-
-          expect(handler.requests).toHaveLength(numberOfRequestsIncludingPreflight * numberOfRequests);
-        });
-      });
-    });
   });
 }

--- a/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/handlers.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/handlers.ts
@@ -45,8 +45,8 @@ export async function declareHandlerHttpInterceptorTests(options: RuntimeSharedH
 
         await usingHttpInterceptor<{
           '/users': { GET: MethodSchema };
-        }>({ ...interceptorOptions, saveRequests: undefined }, async (interceptor) => {
-          const defaultSaveRequests = interceptor.saveRequests;
+        }>({ ...interceptorOptions, requestSaving: undefined }, async (interceptor) => {
+          const defaultSaveRequests = interceptor.requestSaving.enabled;
 
           if (isClientSide()) {
             expect(defaultSaveRequests).toBe(false);
@@ -102,8 +102,8 @@ export async function declareHandlerHttpInterceptorTests(options: RuntimeSharedH
             expect(handler.client._requests).toHaveLength(0);
           }
 
-          interceptor.saveRequests = !defaultSaveRequests;
-          expect(interceptor.saveRequests).toBe(!defaultSaveRequests);
+          interceptor.requestSaving.enabled = !defaultSaveRequests;
+          expect(interceptor.requestSaving.enabled).toBe(!defaultSaveRequests);
         });
       },
     );
@@ -572,7 +572,7 @@ export async function declareHandlerHttpInterceptorTests(options: RuntimeSharedH
             HEAD: MethodSchema;
             OPTIONS: MethodSchema;
           };
-        }>({ ...interceptorOptions, saveRequests: false }, async (interceptor) => {
+        }>({ ...interceptorOptions, requestSaving: { enabled: false } }, async (interceptor) => {
           const handler = await promiseIfRemote(
             interceptor[lowerMethod]('/users').respond({
               status: 200,
@@ -621,7 +621,7 @@ export async function declareHandlerHttpInterceptorTests(options: RuntimeSharedH
             HEAD: MethodSchema;
             OPTIONS: MethodSchema;
           };
-        }>({ ...interceptorOptions, saveRequests: true }, async (interceptor) => {
+        }>({ ...interceptorOptions, requestSaving: { enabled: true } }, async (interceptor) => {
           const handler = await promiseIfRemote(
             interceptor[lowerMethod]('/users').respond({
               status: 200,
@@ -654,7 +654,7 @@ export async function declareHandlerHttpInterceptorTests(options: RuntimeSharedH
             HEAD: MethodSchema;
             OPTIONS: MethodSchema;
           };
-        }>({ ...interceptorOptions, saveRequests: true }, async (interceptor) => {
+        }>({ ...interceptorOptions, requestSaving: { enabled: true } }, async (interceptor) => {
           const handler = await promiseIfRemote(
             interceptor[lowerMethod]('/users').respond({
               status: 200,
@@ -663,9 +663,9 @@ export async function declareHandlerHttpInterceptorTests(options: RuntimeSharedH
             interceptor,
           );
 
-          expect(interceptor.saveRequests).toBe(true);
-          interceptor.saveRequests = false;
-          expect(interceptor.saveRequests).toBe(false);
+          expect(interceptor.requestSaving.enabled).toBe(true);
+          interceptor.requestSaving.enabled = false;
+          expect(interceptor.requestSaving.enabled).toBe(false);
 
           const error = new DisabledRequestSavingError();
 
@@ -694,9 +694,9 @@ export async function declareHandlerHttpInterceptorTests(options: RuntimeSharedH
           // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           expect(handler.client._requests).toHaveLength(0);
 
-          expect(interceptor.saveRequests).toBe(false);
-          interceptor.saveRequests = true;
-          expect(interceptor.saveRequests).toBe(true);
+          expect(interceptor.requestSaving.enabled).toBe(false);
+          interceptor.requestSaving.enabled = true;
+          expect(interceptor.requestSaving.enabled).toBe(true);
 
           expect(handler.requests).toHaveLength(0);
 

--- a/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/requestSaving.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/requestSaving.ts
@@ -4,10 +4,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { promiseIfRemote } from '@/http/interceptorWorker/__tests__/utils/promises';
 import DisabledRequestSavingError from '@/http/requestHandler/errors/DisabledRequestSavingError';
-import { AccessControlHeaders, DEFAULT_ACCESS_CONTROL_HEADERS } from '@/server/constants';
 import { isClientSide } from '@/utils/environment';
+import { usingIgnoredConsole } from '@tests/utils/console';
 import { usingHttpInterceptor } from '@tests/utils/interceptors';
 
+import RequestSavingSafeLimitExceededError from '../../errors/RequestSavingSafeLimitExceededError';
 import { DEFAULT_REQUEST_SAVING_SAFE_LIMIT } from '../../HttpInterceptorClient';
 import { HttpInterceptorOptions } from '../../types/options';
 import { HttpInterceptorRequestSaving } from '../../types/public';
@@ -20,7 +21,7 @@ export function declareRequestSavingHttpInterceptorTests(options: RuntimeSharedH
   let interceptorOptions: HttpInterceptorOptions;
 
   type MethodSchema = HttpSchema.Method<{
-    response: { 200: { headers: AccessControlHeaders } };
+    response: { 200: {} };
   }>;
 
   beforeEach(() => {
@@ -30,7 +31,7 @@ export function declareRequestSavingHttpInterceptorTests(options: RuntimeSharedH
 
   describe('Enabled', () => {
     it.each([{ NODE_ENV: 'development' }, { NODE_ENV: 'test' }, { NODE_ENV: 'production' }])(
-      'should have the correct default save requests strategy if none is provided (NODE_ENV: %s)',
+      'should have the correct default request saving configuration if none is provided (NODE_ENV: %s)',
       async (environment) => {
         vi.spyOn(process, 'env', 'get').mockReturnValue(environment);
         expect(process.env).toEqual(environment);
@@ -41,18 +42,18 @@ export function declareRequestSavingHttpInterceptorTests(options: RuntimeSharedH
           const defaultRequestSaving = interceptor.requestSaving;
 
           if (isClientSide()) {
-            expect(defaultRequestSaving.enabled).toBe(false);
+            expect(defaultRequestSaving).toEqual<HttpInterceptorRequestSaving>({
+              enabled: false,
+              safeLimit: DEFAULT_REQUEST_SAVING_SAFE_LIMIT,
+            });
           } else {
-            expect(defaultRequestSaving.enabled).toBe(environment.NODE_ENV === 'test');
+            expect(defaultRequestSaving).toEqual<HttpInterceptorRequestSaving>({
+              enabled: environment.NODE_ENV === 'test',
+              safeLimit: DEFAULT_REQUEST_SAVING_SAFE_LIMIT,
+            });
           }
 
-          const handler = await promiseIfRemote(
-            interceptor.get('/users').respond({
-              status: 200,
-              headers: DEFAULT_ACCESS_CONTROL_HEADERS,
-            }),
-            interceptor,
-          );
+          const handler = await promiseIfRemote(interceptor.get('/users').respond({ status: 200 }), interceptor);
 
           const numberOfRequests = 5;
 
@@ -97,19 +98,37 @@ export function declareRequestSavingHttpInterceptorTests(options: RuntimeSharedH
       },
     );
 
+    it('should save intercepted requests if enabled', async () => {
+      await usingHttpInterceptor<{
+        '/users': {
+          GET: MethodSchema;
+        };
+      }>({ ...interceptorOptions, requestSaving: { enabled: true } }, async (interceptor) => {
+        expect(interceptor.requestSaving.enabled).toBe(true);
+
+        const handler = await promiseIfRemote(interceptor.get('/users').respond({ status: 200 }), interceptor);
+        expect(handler.requests).toHaveLength(0);
+
+        const numberOfRequests = 5;
+
+        for (let index = 0; index < numberOfRequests; index++) {
+          const response = await fetch(joinURL(baseURL, '/users'), { method: 'GET' });
+          expect(response.status).toBe(200);
+        }
+
+        expect(handler.requests).toHaveLength(numberOfRequests);
+      });
+    });
+
     it('should not save intercepted requests if disabled', async () => {
       await usingHttpInterceptor<{
         '/users': {
           GET: MethodSchema;
         };
       }>({ ...interceptorOptions, requestSaving: { enabled: false } }, async (interceptor) => {
-        const handler = await promiseIfRemote(
-          interceptor.get('/users').respond({
-            status: 200,
-            headers: DEFAULT_ACCESS_CONTROL_HEADERS,
-          }),
-          interceptor,
-        );
+        expect(interceptor.requestSaving.enabled).toBe(false);
+
+        const handler = await promiseIfRemote(interceptor.get('/users').respond({ status: 200 }), interceptor);
 
         const error = new DisabledRequestSavingError();
 
@@ -139,31 +158,278 @@ export function declareRequestSavingHttpInterceptorTests(options: RuntimeSharedH
         expect(handler.client._requests).toHaveLength(0);
       });
     });
+  });
 
-    it('should save intercepted requests if enabled', async () => {
+  describe('Safe limit', () => {
+    const safeLimit = 5;
+
+    it('should not show a warning if requests are not being saved, even if the safe limit would be exceeded if so', async () => {
       await usingHttpInterceptor<{
         '/users': {
           GET: MethodSchema;
         };
-      }>({ ...interceptorOptions, requestSaving: { enabled: true } }, async (interceptor) => {
-        const handler = await promiseIfRemote(
-          interceptor.get('/users').respond({
-            status: 200,
-            headers: DEFAULT_ACCESS_CONTROL_HEADERS,
-          }),
-          interceptor,
-        );
+      }>({ ...interceptorOptions, requestSaving: { enabled: false, safeLimit } }, async (interceptor) => {
+        expect(interceptor.requestSaving.enabled).toBe(false);
+        expect(interceptor.requestSaving.safeLimit).toBe(safeLimit);
 
+        const handler = await promiseIfRemote(interceptor.get('/users').respond({ status: 200 }), interceptor);
+
+        await usingIgnoredConsole(['warn'], async (spies) => {
+          const numberOfRequests = safeLimit * 2;
+          expect(numberOfRequests).toBeGreaterThan(safeLimit);
+
+          for (let index = 0; index < numberOfRequests; index++) {
+            const response = await fetch(joinURL(baseURL, '/users'), { method: 'GET' });
+            expect(response.status).toBe(200);
+          }
+
+          const error = new DisabledRequestSavingError();
+
+          expect(() => {
+            // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+            handler.requests;
+          }).toThrowError(error);
+
+          // @ts-expect-error Checking that no intercepted requests are saved.
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+          expect(handler.client._requests).toHaveLength(0);
+
+          expect(spies.warn).toHaveBeenCalledTimes(0);
+        });
+      });
+    });
+
+    it('should not show a warning if the number of saved requests is below the safe limit', async () => {
+      await usingHttpInterceptor<{
+        '/users': {
+          GET: MethodSchema;
+        };
+      }>({ ...interceptorOptions, requestSaving: { enabled: true, safeLimit } }, async (interceptor) => {
+        expect(interceptor.requestSaving.enabled).toBe(true);
+        expect(interceptor.requestSaving.safeLimit).toBe(safeLimit);
+
+        const handler = await promiseIfRemote(interceptor.get('/users').respond({ status: 200 }), interceptor);
         expect(handler.requests).toHaveLength(0);
 
-        const numberOfRequests = 5;
+        await usingIgnoredConsole(['warn'], async (spies) => {
+          const numberOfRequests = safeLimit - 1;
+          expect(numberOfRequests).toBeLessThan(safeLimit);
 
-        for (let index = 0; index < numberOfRequests; index++) {
-          const response = await fetch(joinURL(baseURL, '/users'), { method: 'GET' });
-          expect(response.status).toBe(200);
-        }
+          for (let index = 0; index < numberOfRequests; index++) {
+            const response = await fetch(joinURL(baseURL, '/users'), { method: 'GET' });
+            expect(response.status).toBe(200);
+          }
 
-        expect(handler.requests).toHaveLength(numberOfRequests);
+          expect(handler.requests).toHaveLength(numberOfRequests);
+
+          expect(spies.warn).toHaveBeenCalledTimes(0);
+        });
+      });
+    });
+
+    it('should not show a warning if the number of saved requests reaches the safe limit', async () => {
+      await usingHttpInterceptor<{
+        '/users': {
+          GET: MethodSchema;
+        };
+      }>({ ...interceptorOptions, requestSaving: { enabled: true, safeLimit } }, async (interceptor) => {
+        expect(interceptor.requestSaving.enabled).toBe(true);
+        expect(interceptor.requestSaving.safeLimit).toBe(safeLimit);
+
+        const handler = await promiseIfRemote(interceptor.get('/users').respond({ status: 200 }), interceptor);
+        expect(handler.requests).toHaveLength(0);
+
+        await usingIgnoredConsole(['warn'], async (spies) => {
+          const numberOfRequests = safeLimit;
+          expect(numberOfRequests).toBe(safeLimit);
+
+          for (let index = 0; index < numberOfRequests; index++) {
+            const response = await fetch(joinURL(baseURL, '/users'), { method: 'GET' });
+            expect(response.status).toBe(200);
+          }
+
+          expect(handler.requests).toHaveLength(numberOfRequests);
+
+          expect(spies.warn).toHaveBeenCalledTimes(0);
+        });
+      });
+    });
+
+    it('should show a warning if the number of saved requests exceeds the safe limit', async () => {
+      await usingHttpInterceptor<{
+        '/users': {
+          GET: MethodSchema;
+        };
+      }>({ ...interceptorOptions, requestSaving: { enabled: true, safeLimit } }, async (interceptor) => {
+        expect(interceptor.requestSaving.enabled).toBe(true);
+        expect(interceptor.requestSaving.safeLimit).toBe(safeLimit);
+
+        const handler = await promiseIfRemote(interceptor.get('/users').respond({ status: 200 }), interceptor);
+        expect(handler.requests).toHaveLength(0);
+
+        await usingIgnoredConsole(['warn'], async (spies) => {
+          const numberOfRequests = safeLimit * 2;
+          expect(numberOfRequests).toBeGreaterThan(safeLimit);
+
+          for (let index = 0; index < numberOfRequests; index++) {
+            const response = await fetch(joinURL(baseURL, '/users'), { method: 'GET' });
+            expect(response.status).toBe(200);
+          }
+
+          expect(handler.requests).toHaveLength(numberOfRequests);
+
+          const numberOfExceedingRequests = numberOfRequests - safeLimit;
+          expect(spies.warn).toHaveBeenCalledTimes(numberOfExceedingRequests);
+
+          for (const [index, call] of spies.warn.mock.calls.entries()) {
+            const numberOfSavedRequestsAtCall = safeLimit + index + 1;
+            const error = new RequestSavingSafeLimitExceededError(numberOfSavedRequestsAtCall, safeLimit);
+            expect(call).toEqual([error]);
+          }
+        });
+      });
+    });
+
+    it('should show a warning if the number of saved requests exceeds the safe limit, considering the sum of all handlers', async () => {
+      await usingHttpInterceptor<{
+        '/users': {
+          GET: MethodSchema;
+        };
+        '/users/others': {
+          GET: MethodSchema;
+        };
+      }>({ ...interceptorOptions, requestSaving: { enabled: true, safeLimit } }, async (interceptor) => {
+        expect(interceptor.requestSaving.enabled).toBe(true);
+        expect(interceptor.requestSaving.safeLimit).toBe(safeLimit);
+
+        const handler = await promiseIfRemote(interceptor.get('/users').respond({ status: 200 }), interceptor);
+        expect(handler.requests).toHaveLength(0);
+
+        const otherHandler = await promiseIfRemote(
+          interceptor.get('/users/others').respond({ status: 200 }),
+          interceptor,
+        );
+        expect(otherHandler.requests).toHaveLength(0);
+
+        await usingIgnoredConsole(['warn'], async (spies) => {
+          const numberOfRequestsPerHandler = safeLimit - 1;
+          expect(numberOfRequestsPerHandler).toBeLessThan(safeLimit);
+
+          const numberOfRequests = numberOfRequestsPerHandler * 2;
+          expect(numberOfRequests).toBeGreaterThan(safeLimit);
+
+          for (let index = 0; index < numberOfRequestsPerHandler; index++) {
+            const response = await fetch(joinURL(baseURL, '/users'), { method: 'GET' });
+            expect(response.status).toBe(200);
+
+            const otherResponse = await fetch(joinURL(baseURL, '/users/others'), { method: 'GET' });
+            expect(otherResponse.status).toBe(200);
+          }
+
+          expect(handler.requests).toHaveLength(numberOfRequestsPerHandler);
+          expect(otherHandler.requests).toHaveLength(numberOfRequestsPerHandler);
+
+          const numberOfExceedingRequests = numberOfRequests - safeLimit;
+          expect(spies.warn).toHaveBeenCalledTimes(numberOfExceedingRequests);
+
+          for (const [index, call] of spies.warn.mock.calls.entries()) {
+            const numberOfSavedRequestsAtCall = safeLimit + index + 1;
+            const error = new RequestSavingSafeLimitExceededError(numberOfSavedRequestsAtCall, safeLimit);
+            expect(call).toEqual([error]);
+          }
+        });
+      });
+    });
+
+    it('should not show a warning if the number of saved requests does not exceed the safe limit due to interceptor clearing', async () => {
+      await usingHttpInterceptor<{
+        '/users': {
+          GET: MethodSchema;
+        };
+      }>({ ...interceptorOptions, requestSaving: { enabled: true, safeLimit } }, async (interceptor) => {
+        expect(interceptor.requestSaving.enabled).toBe(true);
+        expect(interceptor.requestSaving.safeLimit).toBe(safeLimit);
+
+        const handler = await promiseIfRemote(interceptor.get('/users'), interceptor);
+        expect(handler.requests).toHaveLength(0);
+
+        await usingIgnoredConsole(['warn'], async (spies) => {
+          const numberOfRequests = safeLimit * 2;
+          expect(numberOfRequests).toBeGreaterThan(safeLimit);
+
+          for (let index = 0; index < numberOfRequests; index++) {
+            await promiseIfRemote(interceptor.clear(), interceptor);
+            await promiseIfRemote(handler.respond({ status: 200 }), interceptor);
+
+            const response = await fetch(joinURL(baseURL, '/users'), { method: 'GET' });
+            expect(response.status).toBe(200);
+          }
+
+          expect(handler.requests).toHaveLength(1);
+
+          expect(spies.warn).toHaveBeenCalledTimes(0);
+        });
+      });
+    });
+
+    it('should not show a warning if the number of saved requests does not exceed the safe limit due to handler clearing', async () => {
+      await usingHttpInterceptor<{
+        '/users': {
+          GET: MethodSchema;
+        };
+      }>({ ...interceptorOptions, requestSaving: { enabled: true, safeLimit } }, async (interceptor) => {
+        expect(interceptor.requestSaving.enabled).toBe(true);
+        expect(interceptor.requestSaving.safeLimit).toBe(safeLimit);
+
+        const handler = await promiseIfRemote(interceptor.get('/users'), interceptor);
+        expect(handler.requests).toHaveLength(0);
+
+        await usingIgnoredConsole(['warn'], async (spies) => {
+          const numberOfRequests = safeLimit * 2;
+          expect(numberOfRequests).toBeGreaterThan(safeLimit);
+
+          for (let index = 0; index < numberOfRequests; index++) {
+            await promiseIfRemote(handler.clear(), handler);
+            await promiseIfRemote(handler.respond({ status: 200 }), interceptor);
+
+            const response = await fetch(joinURL(baseURL, '/users'), { method: 'GET' });
+            expect(response.status).toBe(200);
+          }
+
+          expect(handler.requests).toHaveLength(1);
+
+          expect(spies.warn).toHaveBeenCalledTimes(0);
+        });
+      });
+    });
+
+    it('should not show a warning if the number of saved requests does not exceed the safe limit due to new response declarations', async () => {
+      await usingHttpInterceptor<{
+        '/users': {
+          GET: MethodSchema;
+        };
+      }>({ ...interceptorOptions, requestSaving: { enabled: true, safeLimit } }, async (interceptor) => {
+        expect(interceptor.requestSaving.enabled).toBe(true);
+        expect(interceptor.requestSaving.safeLimit).toBe(safeLimit);
+
+        const handler = await promiseIfRemote(interceptor.get('/users'), interceptor);
+        expect(handler.requests).toHaveLength(0);
+
+        await usingIgnoredConsole(['warn'], async (spies) => {
+          const numberOfRequests = safeLimit * 2;
+          expect(numberOfRequests).toBeGreaterThan(safeLimit);
+
+          for (let index = 0; index < numberOfRequests; index++) {
+            await promiseIfRemote(handler.respond({ status: 200 }), interceptor);
+
+            const response = await fetch(joinURL(baseURL, '/users'), { method: 'GET' });
+            expect(response.status).toBe(200);
+          }
+
+          expect(handler.requests).toHaveLength(1);
+
+          expect(spies.warn).toHaveBeenCalledTimes(0);
+        });
       });
     });
   });
@@ -180,13 +446,7 @@ export function declareRequestSavingHttpInterceptorTests(options: RuntimeSharedH
         OPTIONS: MethodSchema;
       };
     }>({ ...interceptorOptions, requestSaving: { enabled: true } }, async (interceptor) => {
-      const handler = await promiseIfRemote(
-        interceptor.get('/users').respond({
-          status: 200,
-          headers: DEFAULT_ACCESS_CONTROL_HEADERS,
-        }),
-        interceptor,
-      );
+      const handler = await promiseIfRemote(interceptor.get('/users').respond({ status: 200 }), interceptor);
 
       expect(interceptor.requestSaving).toEqual<HttpInterceptorRequestSaving>({
         enabled: true,

--- a/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/requestSaving.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/requestSaving.ts
@@ -1,0 +1,262 @@
+import { HttpSchema } from '@zimic/http';
+import joinURL from '@zimic/utils/url/joinURL';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { promiseIfRemote } from '@/http/interceptorWorker/__tests__/utils/promises';
+import DisabledRequestSavingError from '@/http/requestHandler/errors/DisabledRequestSavingError';
+import { AccessControlHeaders, DEFAULT_ACCESS_CONTROL_HEADERS } from '@/server/constants';
+import { isClientSide } from '@/utils/environment';
+import { usingHttpInterceptor } from '@tests/utils/interceptors';
+
+import { DEFAULT_REQUEST_SAVING_SAFE_LIMIT } from '../../HttpInterceptorClient';
+import { HttpInterceptorOptions } from '../../types/options';
+import { HttpInterceptorRequestSaving } from '../../types/public';
+import { RuntimeSharedHttpInterceptorTestsOptions } from './utils';
+
+export function declareRequestSavingHttpInterceptorTests(options: RuntimeSharedHttpInterceptorTestsOptions) {
+  const { getBaseURL, getInterceptorOptions } = options;
+
+  let baseURL: string;
+  let interceptorOptions: HttpInterceptorOptions;
+
+  type MethodSchema = HttpSchema.Method<{
+    response: { 200: { headers: AccessControlHeaders } };
+  }>;
+
+  beforeEach(() => {
+    baseURL = getBaseURL();
+    interceptorOptions = getInterceptorOptions();
+  });
+
+  describe('Enabled', () => {
+    it.each([{ NODE_ENV: 'development' }, { NODE_ENV: 'test' }, { NODE_ENV: 'production' }])(
+      'should have the correct default save requests strategy if none is provided (NODE_ENV: %s)',
+      async (environment) => {
+        vi.spyOn(process, 'env', 'get').mockReturnValue(environment);
+        expect(process.env).toEqual(environment);
+
+        await usingHttpInterceptor<{
+          '/users': { GET: MethodSchema };
+        }>({ ...interceptorOptions, requestSaving: undefined }, async (interceptor) => {
+          const defaultRequestSaving = interceptor.requestSaving;
+
+          if (isClientSide()) {
+            expect(defaultRequestSaving.enabled).toBe(false);
+          } else {
+            expect(defaultRequestSaving.enabled).toBe(environment.NODE_ENV === 'test');
+          }
+
+          const handler = await promiseIfRemote(
+            interceptor.get('/users').respond({
+              status: 200,
+              headers: DEFAULT_ACCESS_CONTROL_HEADERS,
+            }),
+            interceptor,
+          );
+
+          const numberOfRequests = 5;
+
+          if (defaultRequestSaving.enabled) {
+            expect(handler.requests).toHaveLength(0);
+
+            for (let index = 0; index < numberOfRequests; index++) {
+              const response = await fetch(joinURL(baseURL, '/users'), { method: 'GET' });
+              expect(response.status).toBe(200);
+            }
+
+            expect(handler.requests).toHaveLength(numberOfRequests);
+          } else {
+            const error = new DisabledRequestSavingError();
+
+            expect(() => {
+              // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+              handler.requests;
+            }).toThrowError(error);
+
+            // @ts-expect-error Checking that no intercepted requests are saved.
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            expect(handler.client._requests).toHaveLength(0);
+
+            const numberOfRequests = 5;
+
+            for (let index = 0; index < numberOfRequests; index++) {
+              const response = await fetch(joinURL(baseURL, '/users'), { method: 'GET' });
+              expect(response.status).toBe(200);
+            }
+
+            expect(() => {
+              // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+              handler.requests;
+            }).toThrowError(error);
+
+            // @ts-expect-error Checking that no intercepted requests are saved.
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            expect(handler.client._requests).toHaveLength(0);
+          }
+        });
+      },
+    );
+
+    it('should not save intercepted requests if disabled', async () => {
+      await usingHttpInterceptor<{
+        '/users': {
+          GET: MethodSchema;
+        };
+      }>({ ...interceptorOptions, requestSaving: { enabled: false } }, async (interceptor) => {
+        const handler = await promiseIfRemote(
+          interceptor.get('/users').respond({
+            status: 200,
+            headers: DEFAULT_ACCESS_CONTROL_HEADERS,
+          }),
+          interceptor,
+        );
+
+        const error = new DisabledRequestSavingError();
+
+        expect(() => {
+          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+          handler.requests;
+        }).toThrowError(error);
+
+        // @ts-expect-error Checking that no intercepted requests are saved.
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        expect(handler.client._requests).toHaveLength(0);
+
+        const numberOfRequests = 5;
+
+        for (let index = 0; index < numberOfRequests; index++) {
+          const response = await fetch(joinURL(baseURL, '/users'), { method: 'GET' });
+          expect(response.status).toBe(200);
+        }
+
+        expect(() => {
+          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+          handler.requests;
+        }).toThrowError(error);
+
+        // @ts-expect-error Checking that no intercepted requests are saved.
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        expect(handler.client._requests).toHaveLength(0);
+      });
+    });
+
+    it('should save intercepted requests if enabled', async () => {
+      await usingHttpInterceptor<{
+        '/users': {
+          GET: MethodSchema;
+        };
+      }>({ ...interceptorOptions, requestSaving: { enabled: true } }, async (interceptor) => {
+        const handler = await promiseIfRemote(
+          interceptor.get('/users').respond({
+            status: 200,
+            headers: DEFAULT_ACCESS_CONTROL_HEADERS,
+          }),
+          interceptor,
+        );
+
+        expect(handler.requests).toHaveLength(0);
+
+        const numberOfRequests = 5;
+
+        for (let index = 0; index < numberOfRequests; index++) {
+          const response = await fetch(joinURL(baseURL, '/users'), { method: 'GET' });
+          expect(response.status).toBe(200);
+        }
+
+        expect(handler.requests).toHaveLength(numberOfRequests);
+      });
+    });
+  });
+
+  it('should support changing the request saving configuration after created', async () => {
+    await usingHttpInterceptor<{
+      '/users': {
+        GET: MethodSchema;
+        POST: MethodSchema;
+        PUT: MethodSchema;
+        PATCH: MethodSchema;
+        DELETE: MethodSchema;
+        HEAD: MethodSchema;
+        OPTIONS: MethodSchema;
+      };
+    }>({ ...interceptorOptions, requestSaving: { enabled: true } }, async (interceptor) => {
+      const handler = await promiseIfRemote(
+        interceptor.get('/users').respond({
+          status: 200,
+          headers: DEFAULT_ACCESS_CONTROL_HEADERS,
+        }),
+        interceptor,
+      );
+
+      expect(interceptor.requestSaving).toEqual<HttpInterceptorRequestSaving>({
+        enabled: true,
+        safeLimit: DEFAULT_REQUEST_SAVING_SAFE_LIMIT,
+      });
+
+      interceptor.requestSaving.enabled = false;
+
+      expect(interceptor.requestSaving).toEqual<HttpInterceptorRequestSaving>({
+        enabled: false,
+        safeLimit: 1000,
+      });
+
+      interceptor.requestSaving.safeLimit = 500;
+
+      expect(interceptor.requestSaving).toEqual<HttpInterceptorRequestSaving>({
+        enabled: false,
+        safeLimit: 500,
+      });
+
+      const error = new DisabledRequestSavingError();
+
+      expect(() => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+        handler.requests;
+      }).toThrowError(error);
+
+      // @ts-expect-error Checking that no intercepted requests are saved.
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      expect(handler.client._requests).toHaveLength(0);
+
+      const numberOfRequests = 5;
+
+      for (let index = 0; index < numberOfRequests; index++) {
+        const response = await fetch(joinURL(baseURL, '/users'), { method: 'GET' });
+        expect(response.status).toBe(200);
+      }
+
+      expect(() => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+        handler.requests;
+      }).toThrowError(error);
+
+      // @ts-expect-error Checking that no intercepted requests are saved.
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      expect(handler.client._requests).toHaveLength(0);
+
+      expect(interceptor.requestSaving).toEqual<HttpInterceptorRequestSaving>({
+        enabled: false,
+        safeLimit: 500,
+      });
+
+      interceptor.requestSaving = {
+        enabled: true,
+        safeLimit: 1500,
+      };
+
+      expect(interceptor.requestSaving).toEqual<HttpInterceptorRequestSaving>({
+        enabled: true,
+        safeLimit: 1500,
+      });
+
+      expect(handler.requests).toHaveLength(0);
+
+      for (let index = 0; index < numberOfRequests; index++) {
+        const response = await fetch(joinURL(baseURL, '/users'), { method: 'GET' });
+        expect(response.status).toBe(200);
+      }
+
+      expect(handler.requests).toHaveLength(numberOfRequests);
+    });
+  });
+}

--- a/packages/zimic-interceptor/src/http/interceptor/errors/RequestSavingSafeLimitExceededError.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/errors/RequestSavingSafeLimitExceededError.ts
@@ -1,0 +1,22 @@
+/**
+ * Error thrown when the safe limit of saved intercepted requests is exceeded.
+ *
+ * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#saving-requests Saving intercepted requests}
+ */
+class RequestSavingSafeLimitExceededError extends TypeError {
+  constructor(numberOfSavedRequests: number, safeLimit: number) {
+    super(
+      `The number of intercepted requests saved in memory (${numberOfSavedRequests}) exceeded the safe limit of ` +
+        `${safeLimit}. Did you forget to call \`interceptor.clear()\`?\n\n` +
+        'If you need to save requests, make sure to regularly call `interceptor.clear()`. Alternatively, you can ' +
+        'hide this warning by increasing `requestSaving.safeLimit` in your interceptor. Note that saving too many ' +
+        'requests in memory can lead to performance issues.\n\n' +
+        'If you do not need to save requests, consider setting `requestSaving.enabled: false` in your ' +
+        'interceptor.\n\n' +
+        'Learn more: https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#saving-requests',
+    );
+    this.name = 'RequestSavingSafeLimitExceededError';
+  }
+}
+
+export default RequestSavingSafeLimitExceededError;

--- a/packages/zimic-interceptor/src/http/interceptor/types/options.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/types/options.ts
@@ -1,5 +1,6 @@
 import { PossiblePromise } from '@zimic/utils/types';
 
+import { HttpInterceptorRequestSaving } from './public';
 import { UnhandledHttpInterceptorRequest } from './requests';
 
 /**
@@ -119,20 +120,13 @@ export interface SharedHttpInterceptorOptions {
   baseURL: string;
 
   /**
-   * Whether {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#httprequesthandler request handlers}
-   * should save their intercepted requests in memory and make them accessible through
+   * Configuration options for saving intercepted requests in memory and making them accessible through
    * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlerrequests `handler.requests`}.
    *
-   * **Important**: If `saveRequests` is true, make sure to regularly clear the interceptor to avoid that the requests
-   * accumulate in memory. A common practice is to call
-   * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-interceptorclear `interceptor.clear()`}
-   * after each test.
-   *
-   * @default false
    * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#saving-requests Saving intercepted requests}
    * @see {@link https://github.com/zimicjs/zimic/wiki/guides‐testing‐interceptor Testing}
    */
-  saveRequests?: boolean;
+  requestSaving?: Partial<HttpInterceptorRequestSaving>;
 }
 
 /**

--- a/packages/zimic-interceptor/src/http/interceptor/types/options.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/types/options.ts
@@ -120,8 +120,7 @@ export interface SharedHttpInterceptorOptions {
   baseURL: string;
 
   /**
-   * Configuration options for saving intercepted requests in memory and making them accessible through
-   * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlerrequests `handler.requests`}.
+   * Configures if the intercepted requests are saved and how they are handled.
    *
    * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#saving-requests Saving intercepted requests}
    * @see {@link https://github.com/zimicjs/zimic/wiki/guides‐testing‐interceptor Testing}

--- a/packages/zimic-interceptor/src/http/interceptor/types/public.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/types/public.ts
@@ -4,6 +4,46 @@ import { SyncHttpInterceptorMethodHandler, AsyncHttpInterceptorMethodHandler } f
 import { HttpInterceptorPlatform, UnhandledRequestStrategy } from './options';
 
 /**
+ * Configuration options for saving intercepted requests in memory and making them accessible through
+ * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlerrequests `handler.requests`}.
+ *
+ * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#saving-requests Saving intercepted requests}
+ * @see {@link https://github.com/zimicjs/zimic/wiki/guides‐testing‐interceptor Testing}
+ */
+export interface HttpInterceptorRequestSaving {
+  /**
+   * Whether {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#httprequesthandler request handlers}
+   * should save their intercepted requests in memory and make them accessible through
+   * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlerrequests `handler.requests`}.
+   *
+   * If you are using
+   * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-interceptorchecktimes `interceptor.checkTimes()`}
+   * or
+   * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlerchecktimes `handler.checkTimes()`}
+   * during tests, consider enabling this option to get more detailed information in `TimesCheckError` errors.
+   *
+   * **Important**: If `requestSaving.enabled` is true, make sure to regularly clear the interceptor to avoid that the
+   * requests accumulate in memory. A common practice is to call
+   * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-interceptorclear `interceptor.clear()`}
+   * after each test.
+   *
+   * @default process.env.NODE_ENV === 'test'
+   */
+  enabled: boolean;
+
+  /**
+   * The safe number of requests to save in memory before logging warnings in the console. If `requestSaving.enabled` is
+   * true and the interceptor is not regularly cleared with
+   * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-interceptorclear `interceptor.clear()`},
+   * the requests may accumulate in memory and cause performance issues. This option does not limit the number of
+   * requests saved in memory, but it logs warnings when the limit is reached.
+   *
+   * @default 1000
+   */
+  safeLimit: number;
+}
+
+/**
  * An interceptor to handle HTTP requests and return mock responses. The methods, paths, status codes, parameters, and
  * responses are statically-typed based on the provided service schema.
  *
@@ -20,20 +60,13 @@ export interface HttpInterceptor<_Schema extends HttpSchema> {
   baseURL: string;
 
   /**
-   * Whether {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#httprequesthandler request handlers}
-   * should save their intercepted requests in memory and make them accessible through
+   * Configuration options for saving intercepted requests in memory and making them accessible through
    * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlerrequests `handler.requests`}.
    *
-   * **Important**: If `saveRequests` is true, make sure to regularly clear the interceptor to avoid that the requests
-   * accumulate in memory. A common practice is to call
-   * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-interceptorclear `interceptor.clear()`}
-   * after each test.
-   *
-   * @default process.env.NODE_ENV === 'test'
    * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#saving-requests Saving intercepted requests}
    * @see {@link https://github.com/zimicjs/zimic/wiki/guides‐testing‐interceptor Testing}
    */
-  saveRequests: boolean;
+  requestSaving: HttpInterceptorRequestSaving;
 
   /**
    * The platform the interceptor is running on.
@@ -86,8 +119,9 @@ export interface HttpInterceptor<_Schema extends HttpSchema> {
    * of each test.
    *
    * When
-   * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#createhttpinterceptoroptions `saveRequests: true`}
-   * is enabled in your interceptor, the `TimesCheckError` errors will also list each unmatched request with diff of the
+   * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#createhttpinterceptoroptions
+   * `requestSaving.enabled`}
+   * is true in your interceptor, the `TimesCheckError` errors will also list each unmatched request with diff of the
    * expected and received data. This is useful for debugging requests that did not match a handler with
    * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlerwithrestriction restrictions}.
    *

--- a/packages/zimic-interceptor/src/http/interceptor/types/public.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/types/public.ts
@@ -21,8 +21,8 @@ export interface HttpInterceptorRequestSaving {
    * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlerchecktimes `handler.checkTimes()`}
    * during tests, consider enabling this option to get more detailed information in `TimesCheckError` errors.
    *
-   * **Important**: If `requestSaving.enabled` is true, make sure to regularly clear the interceptor to avoid that the
-   * requests accumulate in memory. A common practice is to call
+   * **Important**: If `requestSaving.enabled` is `true`, make sure to regularly clear the interceptor to avoid requests
+   * accumulating in memory. A common practice is to call
    * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-interceptorclear `interceptor.clear()`}
    * after each test.
    *
@@ -32,10 +32,10 @@ export interface HttpInterceptorRequestSaving {
 
   /**
    * The safe number of requests to save in memory before logging warnings in the console. If `requestSaving.enabled` is
-   * true and the interceptor is not regularly cleared with
+   * `true` and the interceptor is not regularly cleared with
    * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-interceptorclear `interceptor.clear()`},
    * the requests may accumulate in memory and cause performance issues. This option does not limit the number of
-   * requests saved in memory, but it logs warnings when the limit is reached.
+   * requests saved in memory, only when to log warnings.
    *
    * @default 1000
    */
@@ -59,8 +59,7 @@ export interface HttpInterceptor<_Schema extends HttpSchema> {
   baseURL: string;
 
   /**
-   * Configuration options for saving intercepted requests in memory and making them accessible through
-   * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlerrequests `handler.requests`}.
+   * Configures if the intercepted requests are saved and how they are handled.
    *
    * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#saving-requests Saving intercepted requests}
    * @see {@link https://github.com/zimicjs/zimic/wiki/guides‐testing‐interceptor Testing}

--- a/packages/zimic-interceptor/src/http/interceptor/types/public.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/types/public.ts
@@ -4,8 +4,7 @@ import { SyncHttpInterceptorMethodHandler, AsyncHttpInterceptorMethodHandler } f
 import { HttpInterceptorPlatform, UnhandledRequestStrategy } from './options';
 
 /**
- * Configuration options for saving intercepted requests in memory and making them accessible through
- * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlerrequests `handler.requests`}.
+ * Configures if the intercepted requests are saved and how they are handled.
  *
  * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#saving-requests Saving intercepted requests}
  * @see {@link https://github.com/zimicjs/zimic/wiki/guides‐testing‐interceptor Testing}
@@ -119,9 +118,9 @@ export interface HttpInterceptor<_Schema extends HttpSchema> {
    * of each test.
    *
    * When
-   * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#createhttpinterceptoroptions
-   * `requestSaving.enabled`}
-   * is true in your interceptor, the `TimesCheckError` errors will also list each unmatched request with diff of the
+   * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#saving-requests
+   * `requestSaving.enabled`} is
+   * `true` in your interceptor, the `TimesCheckError` errors will also list each unmatched request with diff of the
    * expected and received data. This is useful for debugging requests that did not match a handler with
    * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlerwithrestriction restrictions}.
    *

--- a/packages/zimic-interceptor/src/http/requestHandler/HttpRequestHandlerClient.ts
+++ b/packages/zimic-interceptor/src/http/requestHandler/HttpRequestHandlerClient.ts
@@ -91,7 +91,8 @@ class HttpRequestHandlerClient<
 
     newThis.numberOfMatchedRequests = 0;
     newThis.unmatchedRequestGroups.length = 0;
-    newThis._requests.length = 0;
+
+    newThis.clearInterceptedRequests();
 
     this.interceptor.registerRequestHandler(this.handler);
 
@@ -148,7 +149,8 @@ class HttpRequestHandlerClient<
 
     this.numberOfMatchedRequests = 0;
     this.unmatchedRequestGroups.length = 0;
-    this._requests.length = 0;
+
+    this.clearInterceptedRequests();
 
     this.createResponseDeclaration = undefined;
 
@@ -380,6 +382,12 @@ class HttpRequestHandlerClient<
   ) {
     const interceptedRequest = this.createInterceptedRequest(request, response);
     this._requests.push(interceptedRequest);
+    this.interceptor.incrementNumberOfSavedRequests(1);
+  }
+
+  private clearInterceptedRequests() {
+    this.interceptor.incrementNumberOfSavedRequests(-this._requests.length);
+    this._requests.length = 0;
   }
 
   private createInterceptedRequest(

--- a/packages/zimic-interceptor/src/http/requestHandler/HttpRequestHandlerClient.ts
+++ b/packages/zimic-interceptor/src/http/requestHandler/HttpRequestHandlerClient.ts
@@ -132,7 +132,7 @@ class HttpRequestHandlerClient<
         declarationPointer: this.timesDeclarationPointer,
         unmatchedRequestGroups: this.unmatchedRequestGroups,
         hasRestrictions: this.restrictions.length > 0,
-        hasSavedRequests: this.interceptor.saveRequests,
+        requestSaving: this.interceptor.requestSaving,
       });
     }
   }
@@ -168,7 +168,9 @@ class HttpRequestHandlerClient<
       this.numberOfMatchedRequests++;
     } else {
       const shouldSaveUnmatchedGroup =
-        this.interceptor.saveRequests && this.restrictions.length > 0 && this.timesDeclarationPointer !== undefined;
+        this.interceptor.requestSaving.enabled &&
+        this.restrictions.length > 0 &&
+        this.timesDeclarationPointer !== undefined;
 
       if (shouldSaveUnmatchedGroup) {
         this.unmatchedRequestGroups.push({ request, diff: restrictionsMatch.diff });
@@ -401,7 +403,7 @@ class HttpRequestHandlerClient<
   }
 
   get requests(): readonly InterceptedHttpInterceptorRequest<Path, Default<Schema[Path][Method]>, StatusCode>[] {
-    if (!this.interceptor.saveRequests) {
+    if (!this.interceptor.requestSaving.enabled) {
       throw new DisabledRequestSavingError();
     }
 

--- a/packages/zimic-interceptor/src/http/requestHandler/__tests__/shared/times.ts
+++ b/packages/zimic-interceptor/src/http/requestHandler/__tests__/shared/times.ts
@@ -350,7 +350,7 @@ export function declareTimesHttpRequestHandlerTests(
   describe('Unmatched requests', () => {
     describe('Restrictions', () => {
       it('should not include the requests unmatched due to restrictions if not saving requests', async () => {
-        const interceptor = createInternalHttpInterceptor<Schema>({ type, baseURL, saveRequests: false });
+        const interceptor = createInternalHttpInterceptor<Schema>({ type, baseURL, requestSaving: { enabled: false } });
         const interceptorClient = interceptor.client as SharedHttpInterceptorClient<Schema>;
 
         const handler = new Handler<Schema, 'POST', '/users'>(interceptorClient, 'POST', '/users')
@@ -366,7 +366,7 @@ export function declareTimesHttpRequestHandlerTests(
             message: [
               'Expected exactly 1 matching request, but got 0.',
               '',
-              'Tip: enable `saveRequests: true` in your interceptor for more details about the unmatched requests.',
+              'Tip: use `requestSaving.enabled: true` in your interceptor for more details about the unmatched requests.',
             ].join('\n'),
             numberOfRequests: 1,
           },
@@ -385,7 +385,7 @@ export function declareTimesHttpRequestHandlerTests(
             message: [
               'Expected exactly 1 matching request, but got 0.',
               '',
-              'Tip: enable `saveRequests: true` in your interceptor for more details about the unmatched requests.',
+              'Tip: use `requestSaving.enabled: true` in your interceptor for more details about the unmatched requests.',
             ].join('\n'),
             numberOfRequests: 1,
           },

--- a/packages/zimic-interceptor/src/http/requestHandler/__tests__/shared/times.ts
+++ b/packages/zimic-interceptor/src/http/requestHandler/__tests__/shared/times.ts
@@ -350,7 +350,11 @@ export function declareTimesHttpRequestHandlerTests(
   describe('Unmatched requests', () => {
     describe('Restrictions', () => {
       it('should not include the requests unmatched due to restrictions if not saving requests', async () => {
-        const interceptor = createInternalHttpInterceptor<Schema>({ type, baseURL, requestSaving: { enabled: false } });
+        const interceptor = createInternalHttpInterceptor<Schema>({
+          type,
+          baseURL,
+          requestSaving: { enabled: false },
+        });
         const interceptorClient = interceptor.client as SharedHttpInterceptorClient<Schema>;
 
         const handler = new Handler<Schema, 'POST', '/users'>(interceptorClient, 'POST', '/users')

--- a/packages/zimic-interceptor/src/http/requestHandler/errors/DisabledRequestSavingError.ts
+++ b/packages/zimic-interceptor/src/http/requestHandler/errors/DisabledRequestSavingError.ts
@@ -7,7 +7,7 @@ class DisabledRequestSavingError extends TypeError {
   constructor() {
     super(
       'Intercepted requests are not being saved. ' +
-        'Did you forget to use `saveRequests: true` when creating the interceptor?\n\n' +
+        'Did you forget to use `requestSaving.enabled: true` in your interceptor?\n\n' +
         'Learn more: https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#saving-requests',
     );
     this.name = 'DisabledRequestSavingError';

--- a/packages/zimic-interceptor/src/http/requestHandler/errors/TimesCheckError.ts
+++ b/packages/zimic-interceptor/src/http/requestHandler/errors/TimesCheckError.ts
@@ -2,6 +2,7 @@ import isNonEmpty from '@zimic/utils/data/isNonEmpty';
 import { Range } from '@zimic/utils/types';
 import chalk from 'chalk';
 
+import { HttpInterceptorRequestSaving } from '@/http/interceptor/types/public';
 import { stringifyValueToLog } from '@/utils/console';
 
 import { UnmatchedHttpInterceptorRequestGroup } from '../types/restrictions';
@@ -13,7 +14,7 @@ interface TimesCheckErrorOptions {
   declarationPointer: TimesDeclarationPointer | undefined;
   unmatchedRequestGroups: UnmatchedHttpInterceptorRequestGroup[];
   hasRestrictions: boolean;
-  hasSavedRequests: boolean;
+  requestSaving: HttpInterceptorRequestSaving;
 }
 
 function createMessageHeader({
@@ -51,9 +52,9 @@ function createMessageHeader({
     .join('');
 }
 
-function createMessageDiffs({ hasSavedRequests, unmatchedRequestGroups }: TimesCheckErrorOptions) {
-  if (!hasSavedRequests) {
-    return 'Tip: enable `saveRequests: true` in your interceptor for more details about the unmatched requests.';
+function createMessageDiffs({ requestSaving, unmatchedRequestGroups }: TimesCheckErrorOptions) {
+  if (!requestSaving.enabled) {
+    return 'Tip: use `requestSaving.enabled: true` in your interceptor for more details about the unmatched requests.';
   }
 
   return unmatchedRequestGroups

--- a/packages/zimic-interceptor/src/http/requestHandler/types/public.ts
+++ b/packages/zimic-interceptor/src/http/requestHandler/types/public.ts
@@ -147,8 +147,9 @@ export interface LocalHttpRequestHandler<
    * that was not satisfied.
    *
    * When
-   * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#createhttpinterceptoroptions `saveRequests: true`}
-   * is enabled in your interceptor, the `TimesCheckError` errors will also list each unmatched request with diff of the
+   * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#createhttpinterceptoroptions
+   * `requestSaving.enabled`}
+   * is true in your interceptor, the `TimesCheckError` errors will also list each unmatched request with diff of the
    * expected and received data. This is useful for debugging requests that did not match a handler with
    * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlerwithrestriction restrictions}.
    *
@@ -178,11 +179,11 @@ export interface LocalHttpRequestHandler<
    * The intercepted requests that matched this handler, along with the responses returned to each of them. This is
    * useful for testing that the correct requests were made by your application.
    *
-   * **Important**: This method can only be used if `saveRequests` was set to `true` when creating the interceptor. See
+   * **Important**: This method can only be used if `requestSaving.enabled` is `true` in the interceptor. See
    * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#saving-requests Saving intercepted requests}
    * for more information.
    *
-   * @throws {DisabledRequestSavingError} If the interceptor was not created with `saveRequests: true`.
+   * @throws {DisabledRequestSavingError} If the interceptor has `requestSaving.enabled: false`.
    * @readonly
    * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlerrequests `handler.requests` API reference}
    */
@@ -284,8 +285,9 @@ export interface SyncedRemoteHttpRequestHandler<
    * that was not satisfied.
    *
    * When
-   * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#createhttpinterceptoroptions `saveRequests: true`}
-   * is enabled in your interceptor, the `TimesCheckError` errors will also list each unmatched request with diff of the
+   * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#createhttpinterceptoroptions
+   * `requestSaving.enabled`}
+   * is true in your interceptor, the `TimesCheckError` errors will also list each unmatched request with diff of the
    * expected and received data. This is useful for debugging requests that did not match a handler with
    * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlerwithrestriction restrictions}.
    *
@@ -315,11 +317,11 @@ export interface SyncedRemoteHttpRequestHandler<
    * The intercepted requests that matched this handler, along with the responses returned to each of them. This is
    * useful for testing that the correct requests were made by your application.
    *
-   * **Important**: This method can only be used if `saveRequests` was set to `true` when creating the interceptor. See
+   * **Important**: This method can only be used if `requestSaving.enabled` is `true` in the interceptor. See
    * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#saving-requests Saving intercepted requests}
    * for more information.
    *
-   * @throws {DisabledRequestSavingError} If the interceptor was not created with `saveRequests: true`.
+   * @throws {DisabledRequestSavingError} If the interceptor has `requestSaving.enabled: false`.
    * @readonly
    * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlerrequests `handler.requests` API reference}
    */

--- a/packages/zimic-interceptor/src/http/requestHandler/types/public.ts
+++ b/packages/zimic-interceptor/src/http/requestHandler/types/public.ts
@@ -147,9 +147,9 @@ export interface LocalHttpRequestHandler<
    * that was not satisfied.
    *
    * When
-   * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#createhttpinterceptoroptions
-   * `requestSaving.enabled`}
-   * is true in your interceptor, the `TimesCheckError` errors will also list each unmatched request with diff of the
+   * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#saving-requests
+   * `requestSaving.enabled`} is
+   * `true` in your interceptor, the `TimesCheckError` errors will also list each unmatched request with diff of the
    * expected and received data. This is useful for debugging requests that did not match a handler with
    * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlerwithrestriction restrictions}.
    *
@@ -179,7 +179,10 @@ export interface LocalHttpRequestHandler<
    * The intercepted requests that matched this handler, along with the responses returned to each of them. This is
    * useful for testing that the correct requests were made by your application.
    *
-   * **Important**: This method can only be used if `requestSaving.enabled` is `true` in the interceptor. See
+   * **Important**: This method can only be used if
+   * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#saving-requests
+   * `requestSaving.enabled`} is
+   * `true` in the interceptor. See
    * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#saving-requests Saving intercepted requests}
    * for more information.
    *
@@ -285,9 +288,9 @@ export interface SyncedRemoteHttpRequestHandler<
    * that was not satisfied.
    *
    * When
-   * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#createhttpinterceptoroptions
-   * `requestSaving.enabled`}
-   * is true in your interceptor, the `TimesCheckError` errors will also list each unmatched request with diff of the
+   * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#saving-requests
+   * `requestSaving.enabled`} is
+   * true in your interceptor, the `TimesCheckError` errors will also list each unmatched request with diff of the
    * expected and received data. This is useful for debugging requests that did not match a handler with
    * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#http-handlerwithrestriction restrictions}.
    *
@@ -317,7 +320,10 @@ export interface SyncedRemoteHttpRequestHandler<
    * The intercepted requests that matched this handler, along with the responses returned to each of them. This is
    * useful for testing that the correct requests were made by your application.
    *
-   * **Important**: This method can only be used if `requestSaving.enabled` is `true` in the interceptor. See
+   * **Important**: This method can only be used if
+   * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#saving-requests
+   * `requestSaving.enabled`} is
+   * `true` in the interceptor. See
    * {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐interceptor‐http#saving-requests Saving intercepted requests}
    * for more information.
    *

--- a/packages/zimic-interceptor/tests/utils/interceptors.ts
+++ b/packages/zimic-interceptor/tests/utils/interceptors.ts
@@ -60,7 +60,7 @@ export function createInternalHttpInterceptor<Schema extends HttpSchema>(
 ): LocalHttpInterceptor<HttpSchema<Schema>> | RemoteHttpInterceptor<HttpSchema<Schema>>;
 export function createInternalHttpInterceptor<Schema extends HttpSchema>(options: HttpInterceptorOptions) {
   return createHttpInterceptor<Schema>({
-    saveRequests: true,
+    requestSaving: { enabled: true },
     onUnhandledRequest: { action: 'reject', log: false },
     ...options,
   }) satisfies HttpInterceptor<Schema> as LocalHttpInterceptor<Schema> | RemoteHttpInterceptor<Schema>;


### PR DESCRIPTION
### Features
- Changed the HTTP interceptor option from `saveRequests` to `requestSaving`, which is now an object with the properties `enabled` and `safeLimit`. The `safeLimit` indicates how many requests it is safe to save in memory. Saving more than such limit will cause warnings in the console, which let users know they should use `interceptor.clear()`, increase the limit, or set `requestSaving.enabled` to false.

```diff
const interceptor = createHttpInterceptor<Schema>({
  type: 'local',
  baseURL: 'http://localhost:3000',
- saveRequests: true,
+ requestSaving: { enabled: true },
})
```

```ts
const interceptor = createHttpInterceptor<Schema>({
  type: 'local',
  baseURL: 'http://localhost:3000',
  requestSaving: { enabled: true, safeLimit: 1000 },
})
```

Closes #349.