### PR TITLE
feat(fetch): `includeRequestBody` and `includeResponseBody`

### DIFF
--- a/apps/zimic-test-client/tests/exports/exports.test.ts
+++ b/apps/zimic-test-client/tests/exports/exports.test.ts
@@ -189,6 +189,8 @@ describe('Exports', () => {
     expect(typeof FetchResponseError).toBe('function');
     expectTypeOf<FetchResponseErrorObject>().not.toBeAny();
     expectTypeOf<FetchResponseErrorObjectOptions>().not.toBeAny();
+    expectTypeOf<FetchResponseErrorObjectOptions.WithBody>().not.toBeAny();
+    expectTypeOf<FetchResponseErrorObjectOptions.WithoutBody>().not.toBeAny();
     expectTypeOf<JSONStringified<never>>().not.toBeAny();
 
     expectTypeOf(createHttpInterceptor).not.toBeAny();

--- a/docs/wiki/api‐zimic‐fetch.md
+++ b/docs/wiki/api‐zimic‐fetch.md
@@ -746,22 +746,24 @@ if (!response.ok) {
 
 `fetchResponseError.toObject(options?)`
 
-| Argument  | Type                                         | Description                            |
-| --------- | -------------------------------------------- | -------------------------------------- |
-| `options` | `FetchResponseErrorObjectOptions` (optional) | The options for serializing the error. |
+| Argument  | Type                                         | Description                                               |
+| --------- | -------------------------------------------- | --------------------------------------------------------- |
+| `options` | `FetchResponseErrorObjectOptions` (optional) | The options for converting the error into a plain object. |
 
 `options` is an object supporting the following properties:
 
-| Option        | Type                                  | Description                                                                      |
-| ------------- | ------------------------------------- | -------------------------------------------------------------------------------- |
-| `includeBody` | `boolean` (optional, default `false`) | Whether to include the body of the request and response in the serialized error. |
+| Option                | Type                                  | Description                                                      |
+| --------------------- | ------------------------------------- | ---------------------------------------------------------------- |
+| `includeRequestBody`  | `boolean` (optional, default `false`) | Whether to include the body of the request in the plain object.  |
+| `includeResponseBody` | `boolean` (optional, default `false`) | Whether to include the body of the response in the plain object. |
 
 > [!NOTE]
 >
-> When using `options.includeBody: true`, you can only call `toObject()` if the bodies of the request and response have
-> not been consumed yet. In case you access their bodies before or after calling `toObject()`, use
+> When using `options.includeRequestBody: true` or `options.includeResponseBody: true`, you can only call `toObject()`
+> if the bodies of the request or response have not been consumed yet, respectively. In case you access their bodies
+> before or after calling `toObject()`, consider using
 > [`request.clone()`](https://developer.mozilla.org/docs/Web/API/Request/clone) and
-> [`response.clone()`](https://developer.mozilla.org/en-US/docs/Web/API/Response/clone) to allow multiple reads.
+> [`response.clone()`](https://developer.mozilla.org/en-US/docs/Web/API/Response/clone).
 
 ```ts
 const response = await fetch(`/users/${userId}`, {
@@ -773,17 +775,19 @@ const body = await response.clone().json();
 console.log(body);
 
 if (!response.ok) {
-  // `toObject()` can be called as the response body was consumed from the clone
-  const plainError = await response.error.toObject({ includeBody: true });
+  // `toObject()` can include the response body because it was only consumed from the clone
+  const plainError = await response.error.toObject({
+    includeResponseBody: true,
+  });
   console.log(plainError);
 }
 ```
 
 #### `FetchResponseError#toObject` return
 
-A plain object representing this error. If `options.includeBody` is `true`, the body of the request and response will be
-included and the return of this method will be a `Promise`. Otherwise, the return will be the plain object itself
-without the body.
+A plain object representing this error. If `options.includeRequestBody` or `options.includeResponseBody` is `true`, the
+body of the request and response will be included, respectively, and the return is a `Promise`. Otherwise, the return is
+the plain object itself without the bodies.
 
 ## Guides
 
@@ -1266,12 +1270,15 @@ if (error instanceof FetchResponseError) {
 ```
 
 Request and response bodies are not included by default. If you want to include them, use
-[`fetchResponseError.toObject({ includeBody: true })`](#fetchresponseerrortoobject-arguments). Note that the result will
-be a `Promise` if `includeBody` is `true`.
+[`includeRequestBody`](#fetchresponseerrortoobject-arguments) and
+[`includeResponseBody`](#fetchresponseerrortoobject-arguments). Note that the result will be a `Promise`.
 
 ```ts
 if (error instanceof FetchResponseError) {
-  const plainError = await error.toObject({ includeBody: true });
+  const plainError = await error.toObject({
+    includeRequestBody: true,
+    includeResponseBody: true,
+  });
   console.error(JSON.stringify(plainError));
 }
 ```
@@ -1284,9 +1291,8 @@ include the body conditionally.
 if (error instanceof FetchResponseError) {
   const plainError = await error.toObject({
     // Include the body only if the content type is JSON
-    includeBody:
-      error.request.headers.get('content-type') === 'application/json' ||
-      error.response.headers.get('content-type') === 'application/json',
+    includeRequestBody: error.request.headers.get('content-type') === 'application/json',
+    includeResponseBody: error.response.headers.get('content-type') === 'application/json',
   });
   console.error(JSON.stringify(plainError));
 }

--- a/docs/wiki/api‐zimic‐fetch.md
+++ b/docs/wiki/api‐zimic‐fetch.md
@@ -40,6 +40,7 @@
     - [Using a file or binary body](#using-a-file-or-binary-body)
   - [Handling authentication](#handling-authentication)
   - [Handling errors](#handling-errors)
+    - [Handling errors: Logging](#handling-errors-logging)
 
 ---
 
@@ -1242,6 +1243,8 @@ if (!response.ok) {
 const user = await response.json(); // User
 ```
 
+#### Handling errors: Logging
+
 When logging fetch response errors (e.g. in a global handler), consider using
 [`fetchResponseError.toObject()`](#fetchresponseerrortoobject) to get a plain object representation serializable to
 JSON.
@@ -1269,6 +1272,22 @@ be a `Promise` if `includeBody` is `true`.
 ```ts
 if (error instanceof FetchResponseError) {
   const plainError = await error.toObject({ includeBody: true });
+  console.error(JSON.stringify(plainError));
+}
+```
+
+If you are working with form data or blob bodies, such as file uploads or downloads, logging the body may not be useful
+as binary data won't be human-readable. To handle this, you can check the content type of the request and response and
+include the body conditionally.
+
+```ts
+if (error instanceof FetchResponseError) {
+  const plainError = await error.toObject({
+    // Include the body only if the content type is JSON
+    includeBody:
+      error.request.headers.get('content-type') === 'application/json' ||
+      error.response.headers.get('content-type') === 'application/json',
+  });
   console.error(JSON.stringify(plainError));
 }
 ```

--- a/packages/zimic-fetch/src/client/FetchClient.ts
+++ b/packages/zimic-fetch/src/client/FetchClient.ts
@@ -179,7 +179,9 @@ class FetchClient<Schema extends HttpSchema>
         if (input instanceof globalThis.Request) {
           // Optimize type checking by narrowing the type of input
           const request = input as globalThis.Request;
-          const headersFromRequest = new HttpHeaders(input.headers);
+
+          // Optimize type checking by narrowing the type of headers
+          const headersFromRequest = new HttpHeaders(input.headers as Headers);
 
           initWithDefaults.headers = {
             ...headersFromDefaults.toObject(),

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.errors.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.errors.test.ts
@@ -372,7 +372,7 @@ describe('FetchClient > Errors', () => {
       { includeRequestBody: undefined, includeResponseBody: false as const },
       { includeRequestBody: false as const, includeResponseBody: false as const },
     ] satisfies FetchResponseErrorObjectOptions[])(
-      'should correctly convert response errors to plain objects (includeRequestBody: %s)',
+      'should correctly convert response errors to plain objects (%s)',
       async ({ includeRequestBody, includeResponseBody }) => {
         type Schema = HttpSchema<{
           '/users': {
@@ -480,7 +480,7 @@ describe('FetchClient > Errors', () => {
       { includeRequestBody: undefined, includeResponseBody: true as const },
       { includeRequestBody: true as const, includeResponseBody: true as const },
     ] satisfies FetchResponseErrorObjectOptions[])(
-      'should correctly convert response errors to plain objects (includeBody: %s)',
+      'should correctly convert response errors to plain objects (%s)',
       async ({ includeRequestBody, includeResponseBody }) => {
         type Schema = HttpSchema<{
           '/users': {
@@ -559,7 +559,7 @@ describe('FetchClient > Errors', () => {
               path: '/users',
               method: 'POST',
               headers: { 'content-type': 'application/json' },
-              body: JSON.stringify(users[0]),
+              body: includeRequestBody ? JSON.stringify(users[0]) : undefined,
               cache: 'default',
               destination: '',
               credentials: 'same-origin',
@@ -577,7 +577,7 @@ describe('FetchClient > Errors', () => {
               statusText: '',
               ok: false,
               headers: { 'content-type': 'application/json' },
-              body: JSON.stringify({ code: 409, message: 'Conflict' }),
+              body: includeResponseBody ? JSON.stringify({ code: 409, message: 'Conflict' }) : undefined,
               redirected: false,
             },
           });

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.errors.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.errors.test.ts
@@ -5,7 +5,10 @@ import { describe, expect, expectTypeOf, it } from 'vitest';
 import { isClientSide } from '@/utils/environment';
 import { usingHttpInterceptor } from '@tests/utils/interceptors';
 
-import FetchResponseError, { FetchResponseErrorObject } from '../errors/FetchResponseError';
+import FetchResponseError, {
+  FetchResponseErrorObject,
+  FetchResponseErrorObjectOptions,
+} from '../errors/FetchResponseError';
 import createFetch from '../factory';
 import { FetchResponse, FetchResponsePerStatusCode } from '../types/requests';
 
@@ -363,9 +366,14 @@ describe('FetchClient > Errors', () => {
   });
 
   describe('Plain object', () => {
-    it.each([{ includeBody: undefined }, { includeBody: false as const }])(
-      'should correctly convert response errors to plain objects (includeBody: %s)',
-      async ({ includeBody }) => {
+    it.each([
+      { includeRequestBody: undefined, includeResponseBody: undefined },
+      { includeRequestBody: false as const, includeResponseBody: undefined },
+      { includeRequestBody: undefined, includeResponseBody: false as const },
+      { includeRequestBody: false as const, includeResponseBody: false as const },
+    ] satisfies FetchResponseErrorObjectOptions[])(
+      'should correctly convert response errors to plain objects (includeRequestBody: %s)',
+      async ({ includeRequestBody, includeResponseBody }) => {
         type Schema = HttpSchema<{
           '/users': {
             POST: {
@@ -431,7 +439,11 @@ describe('FetchClient > Errors', () => {
 
           expectTypeOf(error).toEqualTypeOf<FetchResponseError<Schema, 'POST', '/users'>>();
 
-          expect(error.toObject({ includeBody })).toEqual<FetchResponseErrorObject>({
+          const toObjectResult = error.toObject({ includeRequestBody, includeResponseBody });
+          expectTypeOf(toObjectResult).toEqualTypeOf<FetchResponseErrorObject>();
+
+          const errorObject = toObjectResult;
+          expect(errorObject).toEqual<FetchResponseErrorObject>({
             message: `POST ${joinURL(baseURL, '/users')} failed with status 409: `,
             name: 'FetchResponseError',
             request: {
@@ -463,9 +475,13 @@ describe('FetchClient > Errors', () => {
       },
     );
 
-    it.each([{ includeBody: true as const }])(
+    it.each([
+      { includeRequestBody: true as const, includeResponseBody: undefined },
+      { includeRequestBody: undefined, includeResponseBody: true as const },
+      { includeRequestBody: true as const, includeResponseBody: true as const },
+    ] satisfies FetchResponseErrorObjectOptions[])(
       'should correctly convert response errors to plain objects (includeBody: %s)',
-      async ({ includeBody }) => {
+      async ({ includeRequestBody, includeResponseBody }) => {
         type Schema = HttpSchema<{
           '/users': {
             POST: {
@@ -531,7 +547,11 @@ describe('FetchClient > Errors', () => {
 
           expectTypeOf(error).toEqualTypeOf<FetchResponseError<Schema, 'POST', '/users'>>();
 
-          expect(await error.toObject({ includeBody })).toEqual<FetchResponseErrorObject>({
+          const toObjectResult = error.toObject({ includeRequestBody, includeResponseBody });
+          expectTypeOf(toObjectResult).toEqualTypeOf<Promise<FetchResponseErrorObject> | FetchResponseErrorObject>();
+
+          const errorObject = await toObjectResult;
+          expect(errorObject).toEqual<FetchResponseErrorObject>({
             message: `POST ${joinURL(baseURL, '/users')} failed with status 409: `,
             name: 'FetchResponseError',
             request: {
@@ -624,7 +644,11 @@ describe('FetchClient > Errors', () => {
 
         expectTypeOf(error).toEqualTypeOf<FetchResponseError<Schema, 'POST', '/users'>>();
 
-        expect(await error.toObject({ includeBody: true })).toEqual<FetchResponseErrorObject>({
+        const toObjectResult = error.toObject({ includeRequestBody: true, includeResponseBody: true });
+        expectTypeOf(toObjectResult).toEqualTypeOf<Promise<FetchResponseErrorObject>>();
+
+        const errorObject = await toObjectResult;
+        expect(errorObject).toEqual<FetchResponseErrorObject>({
           message: `POST ${joinURL(baseURL, '/users')} failed with status 409: `,
           name: 'FetchResponseError',
           request: {


### PR DESCRIPTION
### Features
- Split `includeBody` into `includeRequestBody` and `includeResponseBody` in `FetchResponseErrorObjectOptions`, to allow a more granular control over which bodies are included.

### Documentation
- Adapted the documentation to `includeRequestBody` and `includeResponseBody` and added a snippet handling binary and form data.