### PR TITLE
chore(root): enable source maps in node scripts

### DIFF
--- a/packages/zimic-fetch/package.json
+++ b/packages/zimic-fetch/package.json
@@ -58,7 +58,6 @@
   },
   "scripts": {
     "dev": "tsup --watch",
-    "cli": "node --enable-source-maps ./dist/cli.js",
     "build": "tsup",
     "lint": "eslint --cache --no-error-on-unmatched-pattern --no-warn-ignored --fix",
     "lint:turbo": "pnpm lint . --max-warnings 0",

--- a/packages/zimic-fetch/package.json
+++ b/packages/zimic-fetch/package.json
@@ -58,7 +58,7 @@
   },
   "scripts": {
     "dev": "tsup --watch",
-    "cli": "node ./dist/cli.js",
+    "cli": "node --enable-source-maps ./dist/cli.js",
     "build": "tsup",
     "lint": "eslint --cache --no-error-on-unmatched-pattern --no-warn-ignored --fix",
     "lint:turbo": "pnpm lint . --max-warnings 0",

--- a/packages/zimic-http/package.json
+++ b/packages/zimic-http/package.json
@@ -67,7 +67,7 @@
   },
   "scripts": {
     "dev": "tsup --watch",
-    "cli": "node ./dist/cli.js",
+    "cli": "node --enable-source-maps ./dist/cli.js",
     "build": "tsup",
     "lint": "eslint --cache --no-error-on-unmatched-pattern --no-warn-ignored --fix",
     "lint:turbo": "pnpm lint . --max-warnings 0",

--- a/packages/zimic-interceptor/package.json
+++ b/packages/zimic-interceptor/package.json
@@ -76,7 +76,7 @@
   },
   "scripts": {
     "dev": "tsup --watch",
-    "cli": "node ./dist/cli.js",
+    "cli": "node --enable-source-maps ./dist/cli.js",
     "build": "tsup",
     "lint": "eslint --cache --no-error-on-unmatched-pattern --no-warn-ignored --fix",
     "lint:turbo": "pnpm lint . --max-warnings 0",
@@ -89,7 +89,7 @@
     "deps:install-playwright": "playwright install chromium",
     "deps:init-msw": "msw init ./public --no-save",
     "deps:init": "pnpm deps:install-playwright && pnpm deps:init-msw",
-    "postinstall": "node -e \"try{require('./dist/scripts/postinstall')}catch(error){console.error(error)}\""
+    "postinstall": "node --enable-source-maps -e \"try{require('./dist/scripts/postinstall')}catch(error){console.error(error)}\""
   },
   "dependencies": {
     "@whatwg-node/server": "0.10.3",

--- a/packages/zimic-utils/package.json
+++ b/packages/zimic-utils/package.json
@@ -149,7 +149,7 @@
   },
   "scripts": {
     "dev": "tsup --watch",
-    "cli": "node ./dist/cli.js",
+    "cli": "node --enable-source-maps ./dist/cli.js",
     "build": "tsup",
     "lint": "eslint --cache --no-error-on-unmatched-pattern --no-warn-ignored --fix",
     "lint:turbo": "pnpm lint . --max-warnings 0",

--- a/packages/zimic-utils/package.json
+++ b/packages/zimic-utils/package.json
@@ -149,7 +149,6 @@
   },
   "scripts": {
     "dev": "tsup --watch",
-    "cli": "node --enable-source-maps ./dist/cli.js",
     "build": "tsup",
     "lint": "eslint --cache --no-error-on-unmatched-pattern --no-warn-ignored --fix",
     "lint:turbo": "pnpm lint . --max-warnings 0",


### PR DESCRIPTION
### Chore

- Updated the `node` scripts to include the option `--enable-source-maps`, making sure that source maps are used in case of an error executing the script.
