### PR TITLE
fix(fetch): empty and non-empty request type inference

### DIFF
--- a/apps/zimic-test-client/tests/exports/exports.test.ts
+++ b/apps/zimic-test-client/tests/exports/exports.test.ts
@@ -193,6 +193,7 @@ describe('Exports', () => {
 
     expect(typeof createFetch).toBe('function');
     expectTypeOf<Fetch<never>>().not.toBeAny();
+    expectTypeOf<Fetch.Loose>().not.toBeAny();
     expectTypeOf<FetchOptions<never>>().not.toBeAny();
     expectTypeOf<InferFetchSchema<never>>().not.toBeAny();
     expectTypeOf<FetchInput<never, never, never>>().not.toBeAny();

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -337,6 +337,7 @@ export default [
     files: ['**/__tests__/**/*.ts*', '**/*.test.ts*', '**/*.spec.ts*', '**/tests/**/utils/*.ts'],
     rules: {
       '@typescript-eslint/no-non-null-assertion': 'off',
+      '@typescript-eslint/unbound-method': 'off',
     },
   },
 ];

--- a/packages/zimic-fetch/src/client/FetchClient.ts
+++ b/packages/zimic-fetch/src/client/FetchClient.ts
@@ -11,14 +11,7 @@ import excludeURLParams from '@zimic/utils/url/excludeURLParams';
 import joinURL from '@zimic/utils/url/joinURL';
 
 import FetchResponseError from './errors/FetchResponseError';
-import {
-  FetchInput,
-  FetchOptions,
-  Fetch,
-  FetchClient as PublicFetchClient,
-  FetchDefaults,
-  FetchFunction,
-} from './types/public';
+import { FetchInput, FetchOptions, Fetch, FetchClient as PublicFetchClient, FetchDefaults } from './types/public';
 import { FetchRequestConstructor, FetchRequestInit, FetchRequest, FetchResponse } from './types/requests';
 
 class FetchClient<Schema extends HttpSchema>
@@ -36,7 +29,7 @@ class FetchClient<Schema extends HttpSchema>
     };
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    this.fetch.loose = this.fetch as Fetch<any> as FetchFunction.Loose;
+    this.fetch.loose = this.fetch as Fetch<any> as Fetch.Loose;
 
     this.fetch.Request = this.createRequestClass(this.fetch.defaults);
     this.fetch.onRequest = onRequest;

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.blob.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.blob.test.ts
@@ -61,9 +61,7 @@ describe('FetchClient > Bodies > Blob', () => {
 
       expectTypeOf(response.json).toEqualTypeOf<() => Promise<never>>();
       expectTypeOf(response.text).toEqualTypeOf<() => Promise<string>>();
-      // eslint-disable-next-line @typescript-eslint/unbound-method
       expectTypeOf(response.blob).toEqualTypeOf<() => Promise<Blob>>();
-      // eslint-disable-next-line @typescript-eslint/unbound-method
       expectTypeOf(response.arrayBuffer).toEqualTypeOf<() => Promise<ArrayBuffer>>();
       expectTypeOf(response.formData).toEqualTypeOf<() => Promise<FormData>>();
       expectTypeOf(response.clone).toEqualTypeOf<() => typeof response>();
@@ -80,7 +78,6 @@ describe('FetchClient > Bodies > Blob', () => {
       >();
 
       expectTypeOf(response.request.json).toEqualTypeOf<() => Promise<never>>();
-      // eslint-disable-next-line @typescript-eslint/unbound-method
       expectTypeOf(response.request.blob).toEqualTypeOf<() => Promise<Blob>>();
       expect(await response.request.blob()).toEqual(requestBlob);
       expectTypeOf(response.request.text).toEqualTypeOf<() => Promise<string>>();
@@ -136,9 +133,7 @@ describe('FetchClient > Bodies > Blob', () => {
 
       expectTypeOf(response.json).toEqualTypeOf<() => Promise<null>>();
       expectTypeOf(response.text).toEqualTypeOf<() => Promise<string>>();
-      // eslint-disable-next-line @typescript-eslint/unbound-method
       expectTypeOf(response.blob).toEqualTypeOf<() => Promise<Blob>>();
-      // eslint-disable-next-line @typescript-eslint/unbound-method
       expectTypeOf(response.arrayBuffer).toEqualTypeOf<() => Promise<ArrayBuffer>>();
       expectTypeOf(response.formData).toEqualTypeOf<() => Promise<FormData>>();
       expectTypeOf(response.clone).toEqualTypeOf<() => typeof response>();
@@ -155,7 +150,6 @@ describe('FetchClient > Bodies > Blob', () => {
       >();
 
       expectTypeOf(response.request.json).toEqualTypeOf<() => Promise<null>>();
-      // eslint-disable-next-line @typescript-eslint/unbound-method
       expectTypeOf(response.request.blob).toEqualTypeOf<() => Promise<Blob>>();
       expect(await response.request.blob()).toEqual(new Blob([], { type: 'application/octet-stream' }));
       expectTypeOf(response.request.text).toEqualTypeOf<() => Promise<string>>();
@@ -220,7 +214,6 @@ describe('FetchClient > Bodies > Blob', () => {
 
       expectTypeOf(response.json).toEqualTypeOf<() => Promise<never>>();
       expectTypeOf(response.text).toEqualTypeOf<() => Promise<string>>();
-      // eslint-disable-next-line @typescript-eslint/unbound-method
       expectTypeOf(response.arrayBuffer).toEqualTypeOf<() => Promise<ArrayBuffer>>();
       expectTypeOf(response.formData).toEqualTypeOf<() => Promise<FormData>>();
       expectTypeOf(response.clone).toEqualTypeOf<() => typeof response>();
@@ -237,7 +230,6 @@ describe('FetchClient > Bodies > Blob', () => {
       >();
 
       expectTypeOf(response.request.json).toEqualTypeOf<() => Promise<never>>();
-      // eslint-disable-next-line @typescript-eslint/unbound-method
       expectTypeOf(response.request.arrayBuffer).toEqualTypeOf<() => Promise<ArrayBuffer>>();
       expect(await response.request.arrayBuffer()).toEqual(requestArrayBuffer);
       expectTypeOf(response.request.text).toEqualTypeOf<() => Promise<string>>();
@@ -293,7 +285,6 @@ describe('FetchClient > Bodies > Blob', () => {
 
       expectTypeOf(response.json).toEqualTypeOf<() => Promise<null>>();
       expectTypeOf(response.text).toEqualTypeOf<() => Promise<string>>();
-      // eslint-disable-next-line @typescript-eslint/unbound-method
       expectTypeOf(response.arrayBuffer).toEqualTypeOf<() => Promise<ArrayBuffer>>();
       expectTypeOf(response.formData).toEqualTypeOf<() => Promise<FormData>>();
       expectTypeOf(response.clone).toEqualTypeOf<() => typeof response>();
@@ -310,7 +301,6 @@ describe('FetchClient > Bodies > Blob', () => {
       >();
 
       expectTypeOf(response.request.json).toEqualTypeOf<() => Promise<null>>();
-      // eslint-disable-next-line @typescript-eslint/unbound-method
       expectTypeOf(response.request.arrayBuffer).toEqualTypeOf<() => Promise<ArrayBuffer>>();
       expect(await response.request.arrayBuffer()).toEqual(new ArrayBuffer(0));
       expectTypeOf(response.request.text).toEqualTypeOf<() => Promise<string>>();

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.formData.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.formData.test.ts
@@ -74,7 +74,6 @@ describe('FetchClient > Bodies > Form data', () => {
 
       expectTypeOf(response.json).toEqualTypeOf<() => Promise<never>>();
       expectTypeOf(response.text).toEqualTypeOf<() => Promise<string>>();
-      // eslint-disable-next-line @typescript-eslint/unbound-method
       expectTypeOf(response.arrayBuffer).toEqualTypeOf<() => Promise<ArrayBuffer>>();
       expectTypeOf(response.formData).toEqualTypeOf<() => Promise<StrictFormData<FormDataSchema>>>();
       expectTypeOf(response.clone).toEqualTypeOf<() => typeof response>();
@@ -144,7 +143,6 @@ describe('FetchClient > Bodies > Form data', () => {
 
       expectTypeOf(response.json).toEqualTypeOf<() => Promise<null>>();
       expectTypeOf(response.text).toEqualTypeOf<() => Promise<string>>();
-      // eslint-disable-next-line @typescript-eslint/unbound-method
       expectTypeOf(response.arrayBuffer).toEqualTypeOf<() => Promise<ArrayBuffer>>();
       expectTypeOf(response.formData).toEqualTypeOf<() => Promise<StrictFormData<FormDataSchema> | FormData>>();
       expectTypeOf(response.clone).toEqualTypeOf<() => typeof response>();

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.json.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.json.test.ts
@@ -67,7 +67,6 @@ describe('FetchClient > Bodies > JSON', () => {
 
       expectTypeOf(response.json).toEqualTypeOf<() => Promise<User>>();
       expectTypeOf(response.text).toEqualTypeOf<() => Promise<string>>();
-      // eslint-disable-next-line @typescript-eslint/unbound-method
       expectTypeOf(response.arrayBuffer).toEqualTypeOf<() => Promise<ArrayBuffer>>();
       expectTypeOf(response.formData).toEqualTypeOf<() => Promise<FormData>>();
       expectTypeOf(response.clone).toEqualTypeOf<() => typeof response>();
@@ -135,7 +134,6 @@ describe('FetchClient > Bodies > JSON', () => {
 
       expectTypeOf(response.json).toEqualTypeOf<() => Promise<number>>();
       expectTypeOf(response.text).toEqualTypeOf<() => Promise<string>>();
-      // eslint-disable-next-line @typescript-eslint/unbound-method
       expectTypeOf(response.arrayBuffer).toEqualTypeOf<() => Promise<ArrayBuffer>>();
       expectTypeOf(response.formData).toEqualTypeOf<() => Promise<FormData>>();
       expectTypeOf(response.clone).toEqualTypeOf<() => typeof response>();
@@ -203,7 +201,6 @@ describe('FetchClient > Bodies > JSON', () => {
 
       expectTypeOf(response.json).toEqualTypeOf<() => Promise<boolean>>();
       expectTypeOf(response.text).toEqualTypeOf<() => Promise<string>>();
-      // eslint-disable-next-line @typescript-eslint/unbound-method
       expectTypeOf(response.arrayBuffer).toEqualTypeOf<() => Promise<ArrayBuffer>>();
       expectTypeOf(response.formData).toEqualTypeOf<() => Promise<FormData>>();
       expectTypeOf(response.clone).toEqualTypeOf<() => typeof response>();
@@ -265,7 +262,6 @@ describe('FetchClient > Bodies > JSON', () => {
 
       expectTypeOf(response.json).toEqualTypeOf<() => Promise<null>>();
       expectTypeOf(response.text).toEqualTypeOf<() => Promise<string>>();
-      // eslint-disable-next-line @typescript-eslint/unbound-method
       expectTypeOf(response.arrayBuffer).toEqualTypeOf<() => Promise<ArrayBuffer>>();
       expectTypeOf(response.formData).toEqualTypeOf<() => Promise<FormData>>();
       expectTypeOf(response.clone).toEqualTypeOf<() => typeof response>();

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.plainText.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.plainText.test.ts
@@ -57,7 +57,6 @@ describe('FetchClient > Bodies > Plain text', () => {
 
       expectTypeOf(response.json).toEqualTypeOf<() => Promise<never>>();
       expectTypeOf(response.text).toEqualTypeOf<() => Promise<'response'>>();
-      // eslint-disable-next-line @typescript-eslint/unbound-method
       expectTypeOf(response.arrayBuffer).toEqualTypeOf<() => Promise<ArrayBuffer>>();
       expectTypeOf(response.formData).toEqualTypeOf<() => Promise<FormData>>();
       expectTypeOf(response.clone).toEqualTypeOf<() => typeof response>();
@@ -123,7 +122,6 @@ describe('FetchClient > Bodies > Plain text', () => {
       expectTypeOf(response.json).toEqualTypeOf<() => Promise<null>>();
       expectTypeOf(response.text).toEqualTypeOf<() => Promise<string>>();
       expectTypeOf(response.text).toEqualTypeOf<() => Promise<string>>();
-      // eslint-disable-next-line @typescript-eslint/unbound-method
       expectTypeOf(response.arrayBuffer).toEqualTypeOf<() => Promise<ArrayBuffer>>();
       expectTypeOf(response.formData).toEqualTypeOf<() => Promise<FormData>>();
       expectTypeOf(response.clone).toEqualTypeOf<() => typeof response>();

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.searchParams.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.searchParams.test.ts
@@ -73,7 +73,6 @@ describe('FetchClient > Bodies > Search params', () => {
 
       expectTypeOf(response.json).toEqualTypeOf<() => Promise<never>>();
       expectTypeOf(response.text).toEqualTypeOf<() => Promise<string>>();
-      // eslint-disable-next-line @typescript-eslint/unbound-method
       expectTypeOf(response.arrayBuffer).toEqualTypeOf<() => Promise<ArrayBuffer>>();
       expectTypeOf(response.formData).toEqualTypeOf<() => Promise<StrictFormData<SearchParamsSchema>>>();
       expectTypeOf(response.clone).toEqualTypeOf<() => typeof response>();
@@ -139,7 +138,6 @@ describe('FetchClient > Bodies > Search params', () => {
 
       expectTypeOf(response.json).toEqualTypeOf<() => Promise<null>>();
       expectTypeOf(response.text).toEqualTypeOf<() => Promise<string>>();
-      // eslint-disable-next-line @typescript-eslint/unbound-method
       expectTypeOf(response.arrayBuffer).toEqualTypeOf<() => Promise<ArrayBuffer>>();
       expectTypeOf(response.formData).toEqualTypeOf<() => Promise<StrictFormData<SearchParamsSchema> | FormData>>();
       expectTypeOf(response.clone).toEqualTypeOf<() => typeof response>();

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.test.ts
@@ -1,9 +1,12 @@
 import { HttpSchema } from '@zimic/http';
-import { describe, it } from 'vitest';
+import joinURL from '@zimic/utils/url/joinURL';
+import { describe, expect, expectTypeOf, it } from 'vitest';
 
 import { usingHttpInterceptor } from '@tests/utils/interceptors';
+import { expectResponseStatus } from '@tests/utils/requests';
 
 import createFetch from '../factory';
+import { FetchRequest } from '../types/requests';
 
 describe('FetchClient > Bodies', () => {
   const baseURL = 'http://localhost:3000';
@@ -19,9 +22,7 @@ describe('FetchClient > Bodies', () => {
           request: {
             body: { name?: string };
           };
-          response: {
-            204: {};
-          };
+          response: { 204: {} };
         };
       };
     }>;
@@ -160,5 +161,165 @@ describe('FetchClient > Bodies', () => {
     createFetch<{ '/users': { OPTIONS: { response: { 204: { body: null } } } } }>({ baseURL });
     createFetch<{ '/users': { OPTIONS: { response: { 204: { body: undefined } } } } }>({ baseURL });
     createFetch<{ '/users': { OPTIONS: { response: { 204: {} } } } }>({ baseURL });
+  });
+
+  it('should support requests with no body and no request declaration', async () => {
+    type Schema = HttpSchema<{
+      '/users': {
+        POST: {
+          response: { 204: {} };
+        };
+      };
+    }>;
+
+    await usingHttpInterceptor<Schema>({ baseURL }, async (interceptor) => {
+      await interceptor.post('/users').respond({ status: 204 }).times(8);
+
+      const fetch = createFetch<Schema>({ baseURL });
+
+      const responses = [
+        await fetch('/users', { method: 'POST' }),
+        await fetch('/users', { method: 'POST', body: null }),
+        await fetch('/users', { method: 'POST', body: undefined }),
+        // @ts-expect-error Forcing a body
+        await fetch('/users', { method: 'POST', body: {} }),
+      ];
+
+      for (const request of [
+        new fetch.Request('/users', { method: 'POST' }),
+        new fetch.Request('/users', { method: 'POST', body: null }),
+        new fetch.Request('/users', { method: 'POST', body: undefined }),
+        // @ts-expect-error Forcing some headers
+        new fetch.Request('/users', { method: 'POST', body: {} }),
+      ]) {
+        expect(request).toBeInstanceOf(Request);
+        expectTypeOf(request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'POST', '/users'>>();
+
+        expect(request.url).toBe(joinURL(baseURL, '/users'));
+
+        expectTypeOf(request.json).toEqualTypeOf<() => Promise<null>>();
+        expectTypeOf(request.text).toEqualTypeOf<() => Promise<string>>();
+        expectTypeOf(request.arrayBuffer).toEqualTypeOf<() => Promise<ArrayBuffer>>();
+        expectTypeOf(request.formData).toEqualTypeOf<() => Promise<FormData>>();
+
+        const response = await fetch(request);
+        responses.push(response);
+      }
+
+      for (const response of responses) {
+        expectTypeOf(response.status).toEqualTypeOf<204>();
+        expectResponseStatus(response, 204);
+
+        expect(await response.text()).toBe('');
+      }
+    });
+  });
+
+  it('should support requests with no body and an empty request declaration', async () => {
+    type Schema = HttpSchema<{
+      '/users': {
+        POST: {
+          request: {};
+          response: { 204: {} };
+        };
+      };
+    }>;
+
+    await usingHttpInterceptor<Schema>({ baseURL }, async (interceptor) => {
+      await interceptor.post('/users').respond({ status: 204 }).times(8);
+
+      const fetch = createFetch<Schema>({ baseURL });
+
+      const responses = [
+        await fetch('/users', { method: 'POST' }),
+        await fetch('/users', { method: 'POST', body: null }),
+        await fetch('/users', { method: 'POST', body: undefined }),
+        // @ts-expect-error Forcing a body
+        await fetch('/users', { method: 'POST', body: {} }),
+      ];
+
+      for (const request of [
+        new fetch.Request('/users', { method: 'POST' }),
+        new fetch.Request('/users', { method: 'POST', body: null }),
+        new fetch.Request('/users', { method: 'POST', body: undefined }),
+        // @ts-expect-error Forcing some headers
+        new fetch.Request('/users', { method: 'POST', body: {} }),
+      ]) {
+        expect(request).toBeInstanceOf(Request);
+        expectTypeOf(request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'POST', '/users'>>();
+
+        expect(request.url).toBe(joinURL(baseURL, '/users'));
+
+        expectTypeOf(request.json).toEqualTypeOf<() => Promise<null>>();
+        expectTypeOf(request.text).toEqualTypeOf<() => Promise<string>>();
+        expectTypeOf(request.arrayBuffer).toEqualTypeOf<() => Promise<ArrayBuffer>>();
+        expectTypeOf(request.formData).toEqualTypeOf<() => Promise<FormData>>();
+
+        const response = await fetch(request);
+        responses.push(response);
+      }
+
+      for (const response of responses) {
+        expectTypeOf(response.status).toEqualTypeOf<204>();
+        expectResponseStatus(response, 204);
+
+        expect(await response.text()).toBe('');
+      }
+    });
+  });
+
+  it('should support requests with no body and a non-empty request declaration', async () => {
+    type Schema = HttpSchema<{
+      '/users': {
+        POST: {
+          request: { headers: { language: string } };
+          response: { 204: {} };
+        };
+      };
+    }>;
+
+    await usingHttpInterceptor<Schema>({ baseURL }, async (interceptor) => {
+      const headers = { language: 'en' };
+
+      await interceptor.post('/users').with({ headers }).respond({ status: 204 }).times(8);
+
+      const fetch = createFetch<Schema>({ baseURL });
+
+      const responses = [
+        await fetch('/users', { method: 'POST', headers }),
+        await fetch('/users', { method: 'POST', headers, body: null }),
+        await fetch('/users', { method: 'POST', headers, body: undefined }),
+        // @ts-expect-error Forcing a body
+        await fetch('/users', { method: 'POST', headers, body: {} }),
+      ];
+
+      for (const request of [
+        new fetch.Request('/users', { method: 'POST', headers }),
+        new fetch.Request('/users', { method: 'POST', headers, body: null }),
+        new fetch.Request('/users', { method: 'POST', headers, body: undefined }),
+        // @ts-expect-error Forcing some headers
+        new fetch.Request('/users', { method: 'POST', headers, body: {} }),
+      ]) {
+        expect(request).toBeInstanceOf(Request);
+        expectTypeOf(request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'POST', '/users'>>();
+
+        expect(request.url).toBe(joinURL(baseURL, '/users'));
+
+        expectTypeOf(request.json).toEqualTypeOf<() => Promise<null>>();
+        expectTypeOf(request.text).toEqualTypeOf<() => Promise<string>>();
+        expectTypeOf(request.arrayBuffer).toEqualTypeOf<() => Promise<ArrayBuffer>>();
+        expectTypeOf(request.formData).toEqualTypeOf<() => Promise<FormData>>();
+
+        const response = await fetch(request);
+        responses.push(response);
+      }
+
+      for (const response of responses) {
+        expectTypeOf(response.status).toEqualTypeOf<204>();
+        expectResponseStatus(response, 204);
+
+        expect(await response.text()).toBe('');
+      }
+    });
   });
 });

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.headers.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.headers.test.ts
@@ -21,7 +21,7 @@ describe('FetchClient > Headers', () => {
     { id: '2', name: 'User 2' },
   ];
 
-  it('should support requests with headers as object', async () => {
+  it('should support requests with headers as an object', async () => {
     type RequestHeaders = HttpSchema.Headers<{
       'content-type': string;
     }>;
@@ -81,7 +81,7 @@ describe('FetchClient > Headers', () => {
     });
   });
 
-  it('should support requests with headers as instance', async () => {
+  it('should support requests with headers as an instance', async () => {
     type RequestHeaders = HttpSchema.Headers<{
       'content-type': string;
     }>;
@@ -205,7 +205,7 @@ describe('FetchClient > Headers', () => {
     });
   });
 
-  it('should support requests with no headers', async () => {
+  it('should support requests with no headers and no request declaration', async () => {
     type Schema = HttpSchema<{
       '/users': {
         GET: {
@@ -215,31 +215,25 @@ describe('FetchClient > Headers', () => {
     }>;
 
     await usingHttpInterceptor<Schema>({ baseURL }, async (interceptor) => {
-      await interceptor
-        .get('/users')
-        .respond({
-          status: 200,
-          body: users,
-        })
-        .times(8);
+      await interceptor.get('/users').respond({ status: 200, body: users }).times(8);
 
       const fetch = createFetch<Schema>({ baseURL });
 
       const responses = [
         await fetch('/users', { method: 'GET' }),
         await fetch('/users', { method: 'GET', headers: undefined }),
-        // @ts-expect-error Forcing the headers to be defined
+        // @ts-expect-error Forcing some headers
         await fetch('/users', { method: 'GET', headers: {} }),
-        // @ts-expect-error Forcing the headers to be defined
+        // @ts-expect-error Forcing some headers
         await fetch('/users', { method: 'GET', headers: new HttpHeaders() }),
       ];
 
       for (const request of [
         new fetch.Request('/users', { method: 'GET' }),
         new fetch.Request('/users', { method: 'GET', headers: undefined }),
-        // @ts-expect-error Forcing the headers to be defined
+        // @ts-expect-error Forcing some headers
         new fetch.Request('/users', { method: 'GET', headers: {} }),
-        // @ts-expect-error Forcing the headers to be defined
+        // @ts-expect-error Forcing some headers
         new fetch.Request('/users', { method: 'GET', headers: new HttpHeaders() }),
       ]) {
         expect(request).toBeInstanceOf(Request);
@@ -250,7 +244,8 @@ describe('FetchClient > Headers', () => {
         expect(request.headers).toBeInstanceOf(Headers);
         expectTypeOf(request.headers).toEqualTypeOf<StrictHeaders<never>>();
 
-        responses.push(await fetch(request));
+        const response = await fetch(request);
+        responses.push(response);
       }
 
       for (const response of responses) {
@@ -262,7 +257,115 @@ describe('FetchClient > Headers', () => {
     });
   });
 
-  it('should support responses with headers as object', async () => {
+  it('should support requests with no headers and an empty request declaration', async () => {
+    type Schema = HttpSchema<{
+      '/users': {
+        GET: {
+          request: {};
+          response: { 200: { body: User[] } };
+        };
+      };
+    }>;
+
+    await usingHttpInterceptor<Schema>({ baseURL }, async (interceptor) => {
+      await interceptor.get('/users').respond({ status: 200, body: users }).times(8);
+
+      const fetch = createFetch<Schema>({ baseURL });
+
+      const responses = [
+        await fetch('/users', { method: 'GET' }),
+        await fetch('/users', { method: 'GET', headers: undefined }),
+        // @ts-expect-error Forcing some headers
+        await fetch('/users', { method: 'GET', headers: {} }),
+        // @ts-expect-error Forcing some headers
+        await fetch('/users', { method: 'GET', headers: new HttpHeaders() }),
+      ];
+
+      for (const request of [
+        new fetch.Request('/users', { method: 'GET' }),
+        new fetch.Request('/users', { method: 'GET', headers: undefined }),
+        // @ts-expect-error Forcing some headers
+        new fetch.Request('/users', { method: 'GET', headers: {} }),
+        // @ts-expect-error Forcing some headers
+        new fetch.Request('/users', { method: 'GET', headers: new HttpHeaders() }),
+      ]) {
+        expect(request).toBeInstanceOf(Request);
+        expectTypeOf(request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'GET', '/users'>>();
+
+        expect(request.url).toBe(joinURL(baseURL, '/users'));
+
+        expect(request.headers).toBeInstanceOf(Headers);
+        expectTypeOf(request.headers).toEqualTypeOf<StrictHeaders<never>>();
+
+        const response = await fetch(request);
+        responses.push(response);
+      }
+
+      for (const response of responses) {
+        expectTypeOf(response.status).toEqualTypeOf<200>();
+        expectResponseStatus(response, 200);
+
+        expect(await response.json()).toEqual(users);
+      }
+    });
+  });
+
+  it('should support requests with no headers and a non-empty request declaration', async () => {
+    type Schema = HttpSchema<{
+      '/users': {
+        GET: {
+          request: { searchParams: { query: string } };
+          response: { 200: { body: User[] } };
+        };
+      };
+    }>;
+
+    await usingHttpInterceptor<Schema>({ baseURL }, async (interceptor) => {
+      const searchParams = { query: users[0].name };
+
+      await interceptor.get('/users').with({ searchParams }).respond({ status: 200, body: users }).times(8);
+
+      const fetch = createFetch<Schema>({ baseURL });
+
+      const responses = [
+        await fetch('/users', { method: 'GET', searchParams }),
+        await fetch('/users', { method: 'GET', searchParams, headers: undefined }),
+        // @ts-expect-error Forcing some headers
+        await fetch('/users', { method: 'GET', searchParams, headers: {} }),
+        // @ts-expect-error Forcing some headers
+        await fetch('/users', { method: 'GET', searchParams, headers: new HttpHeaders() }),
+      ];
+
+      for (const request of [
+        new fetch.Request('/users', { method: 'GET', searchParams }),
+        new fetch.Request('/users', { method: 'GET', searchParams, headers: undefined }),
+        // @ts-expect-error Forcing some headers
+        new fetch.Request('/users', { method: 'GET', searchParams, headers: {} }),
+        // @ts-expect-error Forcing some headers
+        new fetch.Request('/users', { method: 'GET', searchParams, headers: new HttpHeaders() }),
+      ]) {
+        expect(request).toBeInstanceOf(Request);
+        expectTypeOf(request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'GET', '/users'>>();
+
+        expect(request.url).toBe(joinURL(baseURL, '/users?query=User+1'));
+
+        expect(request.headers).toBeInstanceOf(Headers);
+        expectTypeOf(request.headers).toEqualTypeOf<StrictHeaders<never>>();
+
+        const response = await fetch(request);
+        responses.push(response);
+      }
+
+      for (const response of responses) {
+        expectTypeOf(response.status).toEqualTypeOf<200>();
+        expectResponseStatus(response, 200);
+
+        expect(await response.json()).toEqual(users);
+      }
+    });
+  });
+
+  it('should support responses with headers as an object', async () => {
     type ResponseHeaders = HttpSchema.Headers<{
       'content-type': string;
     }>;
@@ -316,7 +419,7 @@ describe('FetchClient > Headers', () => {
     });
   });
 
-  it('should support responses with headers as instance', async () => {
+  it('should support responses with headers as an instance', async () => {
     type ResponseHeaders = HttpSchema.Headers<{
       'content-type': string;
     }>;
@@ -428,7 +531,55 @@ describe('FetchClient > Headers', () => {
     });
   });
 
-  it('should support responses with no headers', async () => {
+  it('should support responses with no headers and an empty response declaration', async () => {
+    type Schema = HttpSchema<{
+      '/users': {
+        GET: {
+          response: { 200: {} };
+        };
+      };
+    }>;
+
+    await usingHttpInterceptor<Schema>({ baseURL }, async (interceptor) => {
+      await interceptor.get('/users').respond({ status: 200 }).times(4);
+
+      const fetch = createFetch<Schema>({ baseURL });
+
+      const responses = [
+        await fetch('/users', { method: 'GET' }),
+        await fetch('/users', { method: 'GET', headers: undefined }),
+        // @ts-expect-error Forcing some headers
+        await fetch('/users', { method: 'GET', headers: {} }),
+        // @ts-expect-error Forcing some headers
+        await fetch('/users', { method: 'GET', headers: new HttpHeaders() }),
+      ];
+
+      for (const response of responses) {
+        expectTypeOf(response.status).toEqualTypeOf<200>();
+        expectResponseStatus(response, 200);
+
+        expect(await response.text()).toBe('');
+
+        expect(response).toBeInstanceOf(Response);
+        expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'GET', '/users'>>();
+
+        expect(response.url).toBe(joinURL(baseURL, '/users'));
+
+        expect(response.headers).toBeInstanceOf(Headers);
+        expectTypeOf(response.headers).toEqualTypeOf<StrictHeaders<never>>();
+
+        expect(response.request).toBeInstanceOf(Request);
+        expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'GET', '/users'>>();
+
+        expect(response.request.url).toBe(joinURL(baseURL, '/users'));
+
+        expect(response.request.headers).toBeInstanceOf(Headers);
+        expectTypeOf(response.request.headers).toEqualTypeOf<StrictHeaders<never>>();
+      }
+    });
+  });
+
+  it('should support responses with no headers and and a non-empty response declaration', async () => {
     type Schema = HttpSchema<{
       '/users': {
         GET: {
@@ -438,22 +589,16 @@ describe('FetchClient > Headers', () => {
     }>;
 
     await usingHttpInterceptor<Schema>({ baseURL }, async (interceptor) => {
-      await interceptor
-        .get('/users')
-        .respond({
-          status: 200,
-          body: users,
-        })
-        .times(4);
+      await interceptor.get('/users').respond({ status: 200, body: users }).times(4);
 
       const fetch = createFetch<Schema>({ baseURL });
 
       const responses = [
         await fetch('/users', { method: 'GET' }),
         await fetch('/users', { method: 'GET', headers: undefined }),
-        // @ts-expect-error Forcing the headers to be defined
+        // @ts-expect-error Forcing some headers
         await fetch('/users', { method: 'GET', headers: {} }),
-        // @ts-expect-error Forcing the headers to be defined
+        // @ts-expect-error Forcing some headers
         await fetch('/users', { method: 'GET', headers: new HttpHeaders() }),
       ];
 

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.listeners.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.listeners.test.ts
@@ -58,9 +58,8 @@ describe('FetchClient > Listeners', () => {
         expect(request.headers).toBeInstanceOf(Headers);
         expectTypeOf(request.headers).toEqualTypeOf<Headers>();
 
-        // eslint-disable-next-line @typescript-eslint/unbound-method, @typescript-eslint/no-explicit-any
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         expectTypeOf(request.json).toEqualTypeOf<() => Promise<any>>();
-        // eslint-disable-next-line @typescript-eslint/unbound-method
         expectTypeOf(request.formData).toEqualTypeOf<() => Promise<FormData>>();
         expectTypeOf(request.clone).toEqualTypeOf<() => typeof request>();
 
@@ -157,10 +156,8 @@ describe('FetchClient > Listeners', () => {
         expect(request.headers).toBeInstanceOf(Headers);
         expectTypeOf(request.headers).toEqualTypeOf<Headers>();
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/unbound-method
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         expectTypeOf(request.json).toEqualTypeOf<() => Promise<any>>();
-
-        // eslint-disable-next-line @typescript-eslint/unbound-method
         expectTypeOf(request.formData).toEqualTypeOf<() => Promise<FormData>>();
         expectTypeOf(request.clone).toEqualTypeOf<() => typeof request>();
 
@@ -534,10 +531,9 @@ describe('FetchClient > Listeners', () => {
         expect(response.headers).toBeInstanceOf(Headers);
         expectTypeOf(response.headers).toEqualTypeOf<Headers>();
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/unbound-method
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         expectTypeOf(response.json).toEqualTypeOf<() => Promise<any>>();
 
-        // eslint-disable-next-line @typescript-eslint/unbound-method
         expectTypeOf(response.formData).toEqualTypeOf<() => Promise<FormData>>();
         expectTypeOf(response.clone).toEqualTypeOf<() => typeof response>();
 
@@ -547,10 +543,9 @@ describe('FetchClient > Listeners', () => {
         expect(response.request.headers).toBeInstanceOf(Headers);
         expectTypeOf(response.request.headers).toEqualTypeOf<Headers>();
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/unbound-method
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         expectTypeOf(response.request.json).toEqualTypeOf<() => Promise<any>>();
 
-        // eslint-disable-next-line @typescript-eslint/unbound-method
         expectTypeOf(response.request.formData).toEqualTypeOf<() => Promise<FormData>>();
         expectTypeOf(response.request.clone).toEqualTypeOf<() => typeof response.request>();
 
@@ -627,10 +622,9 @@ describe('FetchClient > Listeners', () => {
         expect(response.headers).toBeInstanceOf(Headers);
         expectTypeOf(response.headers).toEqualTypeOf<Headers>();
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/unbound-method
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         expectTypeOf(response.json).toEqualTypeOf<() => Promise<any>>();
 
-        // eslint-disable-next-line @typescript-eslint/unbound-method
         expectTypeOf(response.formData).toEqualTypeOf<() => Promise<FormData>>();
         expectTypeOf(response.clone).toEqualTypeOf<() => typeof response>();
 
@@ -640,10 +634,9 @@ describe('FetchClient > Listeners', () => {
         expect(response.request.headers).toBeInstanceOf(Headers);
         expectTypeOf(response.request.headers).toEqualTypeOf<Headers>();
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/unbound-method
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         expectTypeOf(response.request.json).toEqualTypeOf<() => Promise<any>>();
 
-        // eslint-disable-next-line @typescript-eslint/unbound-method
         expectTypeOf(response.request.formData).toEqualTypeOf<() => Promise<FormData>>();
         expectTypeOf(response.request.clone).toEqualTypeOf<() => typeof response.request>();
 

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.searchParams.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.searchParams.test.ts
@@ -21,7 +21,7 @@ describe('FetchClient > Search params', () => {
     { id: '2', name: 'User 2' },
   ];
 
-  it('should support requests with search params as object', async () => {
+  it('should support requests with search params as an object', async () => {
     type RequestSearchParams = HttpSchema.SearchParams<{
       name?: string;
     }>;
@@ -76,7 +76,7 @@ describe('FetchClient > Search params', () => {
     });
   });
 
-  it('should support requests with search params as instance', async () => {
+  it('should support requests with search params as an instance', async () => {
     type RequestSearchParams = HttpSchema.SearchParams<{
       name?: string;
     }>;
@@ -200,7 +200,7 @@ describe('FetchClient > Search params', () => {
     });
   });
 
-  it('should support requests with no search params', async () => {
+  it('should support requests with no search params and no request declaration', async () => {
     type Schema = HttpSchema<{
       '/users': {
         GET: {
@@ -210,32 +210,126 @@ describe('FetchClient > Search params', () => {
     }>;
 
     await usingHttpInterceptor<Schema>({ baseURL }, async (interceptor) => {
-      await interceptor
-        .get('/users')
-        .respond({
-          status: 200,
-          body: users,
-        })
-        .times(8);
+      await interceptor.get('/users').respond({ status: 200, body: users }).times(8);
 
       const fetch = createFetch<Schema>({ baseURL });
 
       const responses = [
         await fetch('/users', { method: 'GET' }),
         await fetch('/users', { method: 'GET', searchParams: undefined }),
-        // @ts-expect-error Forcing the search params to be defined
+        // @ts-expect-error Forcing some search params
         await fetch('/users', { method: 'GET', searchParams: {} }),
-        // @ts-expect-error Forcing the search params to be defined
+        // @ts-expect-error Forcing some search params
         await fetch('/users', { method: 'GET', searchParams: new HttpSearchParams() }),
       ];
 
       for (const request of [
         new fetch.Request('/users', { method: 'GET' }),
         new fetch.Request('/users', { method: 'GET', searchParams: undefined }),
-        // @ts-expect-error Forcing the search params to be defined
+        // @ts-expect-error Forcing some search params
         new fetch.Request('/users', { method: 'GET', searchParams: {} }),
-        // @ts-expect-error Forcing the search params to be defined
+        // @ts-expect-error Forcing some search params
         new fetch.Request('/users', { method: 'GET', searchParams: new HttpSearchParams() }),
+      ]) {
+        expect(request).toBeInstanceOf(Request);
+        expectTypeOf(request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'GET', '/users'>>();
+
+        expect(request.url).toBe(joinURL(baseURL, '/users'));
+
+        responses.push(await fetch(request));
+      }
+
+      for (const response of responses) {
+        expectTypeOf(response.status).toEqualTypeOf<200>();
+        expectResponseStatus(response, 200);
+
+        expect(await response.json()).toEqual(users);
+      }
+    });
+  });
+
+  it('should support requests with no search params and an empty request declaration', async () => {
+    type Schema = HttpSchema<{
+      '/users': {
+        GET: {
+          request: {};
+          response: { 200: { body: User[] } };
+        };
+      };
+    }>;
+
+    await usingHttpInterceptor<Schema>({ baseURL }, async (interceptor) => {
+      await interceptor.get('/users').respond({ status: 200, body: users }).times(8);
+
+      const fetch = createFetch<Schema>({ baseURL });
+
+      const responses = [
+        await fetch('/users', { method: 'GET' }),
+        await fetch('/users', { method: 'GET', searchParams: undefined }),
+        // @ts-expect-error Forcing some search params
+        await fetch('/users', { method: 'GET', searchParams: {} }),
+        // @ts-expect-error Forcing some search params
+        await fetch('/users', { method: 'GET', searchParams: new HttpSearchParams() }),
+      ];
+
+      for (const request of [
+        new fetch.Request('/users', { method: 'GET' }),
+        new fetch.Request('/users', { method: 'GET', searchParams: undefined }),
+        // @ts-expect-error Forcing some search params
+        new fetch.Request('/users', { method: 'GET', searchParams: {} }),
+        // @ts-expect-error Forcing some search params
+        new fetch.Request('/users', { method: 'GET', searchParams: new HttpSearchParams() }),
+      ]) {
+        expect(request).toBeInstanceOf(Request);
+        expectTypeOf(request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'GET', '/users'>>();
+
+        expect(request.url).toBe(joinURL(baseURL, '/users'));
+
+        responses.push(await fetch(request));
+      }
+
+      for (const response of responses) {
+        expectTypeOf(response.status).toEqualTypeOf<200>();
+        expectResponseStatus(response, 200);
+
+        expect(await response.json()).toEqual(users);
+      }
+    });
+  });
+
+  it('should support requests with no search params and a non-empty request declaration', async () => {
+    type Schema = HttpSchema<{
+      '/users': {
+        GET: {
+          request: { headers: { language: string } };
+          response: { 200: { body: User[] } };
+        };
+      };
+    }>;
+
+    await usingHttpInterceptor<Schema>({ baseURL }, async (interceptor) => {
+      const headers = { language: 'en' };
+
+      await interceptor.get('/users').with({ headers }).respond({ status: 200, body: users }).times(8);
+
+      const fetch = createFetch<Schema>({ baseURL });
+
+      const responses = [
+        await fetch('/users', { method: 'GET', headers }),
+        await fetch('/users', { method: 'GET', headers, searchParams: undefined }),
+        // @ts-expect-error Forcing some search params
+        await fetch('/users', { method: 'GET', headers, searchParams: {} }),
+        // @ts-expect-error Forcing some search params
+        await fetch('/users', { method: 'GET', headers, searchParams: new HttpSearchParams() }),
+      ];
+
+      for (const request of [
+        new fetch.Request('/users', { method: 'GET', headers }),
+        new fetch.Request('/users', { method: 'GET', headers, searchParams: undefined }),
+        // @ts-expect-error Forcing some search params
+        new fetch.Request('/users', { method: 'GET', headers, searchParams: {} }),
+        // @ts-expect-error Forcing some search params
+        new fetch.Request('/users', { method: 'GET', headers, searchParams: new HttpSearchParams() }),
       ]) {
         expect(request).toBeInstanceOf(Request);
         expectTypeOf(request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'GET', '/users'>>();

--- a/packages/zimic-fetch/src/client/types/requests.ts
+++ b/packages/zimic-fetch/src/client/types/requests.ts
@@ -30,37 +30,42 @@ type FetchRequestInitHeaders<RequestSchema extends HttpRequestSchema> =
   | RequestSchema['headers']
   | HttpHeaders<Default<RequestSchema['headers']>>;
 
-type FetchRequestInitWithHeaders<RequestSchema extends HttpRequestSchema> = [RequestSchema['headers']] extends [never]
-  ? { headers?: undefined }
-  : undefined extends RequestSchema['headers']
-    ? { headers?: FetchRequestInitHeaders<RequestSchema> }
-    : { headers: FetchRequestInitHeaders<RequestSchema> };
+type FetchRequestInitWithHeaders<RequestSchema extends HttpRequestSchema> = 'headers' extends keyof RequestSchema
+  ? [RequestSchema['headers']] extends [never]
+    ? { headers?: undefined }
+    : undefined extends RequestSchema['headers']
+      ? { headers?: FetchRequestInitHeaders<RequestSchema> }
+      : { headers: FetchRequestInitHeaders<RequestSchema> }
+  : { headers?: undefined };
 
 type FetchRequestInitSearchParams<RequestSchema extends HttpRequestSchema> =
   | RequestSchema['searchParams']
   | HttpSearchParams<Default<RequestSchema['searchParams']>>;
 
-type FetchRequestInitWithSearchParams<RequestSchema extends HttpRequestSchema> = [
-  RequestSchema['searchParams'],
-] extends [never]
-  ? { searchParams?: undefined }
-  : undefined extends RequestSchema['searchParams']
-    ? { searchParams?: FetchRequestInitSearchParams<RequestSchema> }
-    : { searchParams: FetchRequestInitSearchParams<RequestSchema> };
+type FetchRequestInitWithSearchParams<RequestSchema extends HttpRequestSchema> =
+  'searchParams' extends keyof RequestSchema
+    ? [RequestSchema['searchParams']] extends [never]
+      ? { searchParams?: undefined }
+      : undefined extends RequestSchema['searchParams']
+        ? { searchParams?: FetchRequestInitSearchParams<RequestSchema> }
+        : { searchParams: FetchRequestInitSearchParams<RequestSchema> }
+    : { searchParams?: undefined };
 
-type FetchRequestInitWithBody<RequestSchema extends HttpRequestSchema> = [RequestSchema['body']] extends [never]
-  ? { body?: null }
-  : RequestSchema['body'] extends string
-    ? undefined extends RequestSchema['body']
-      ? { body?: ReplaceBy<RequestSchema['body'], undefined, null> }
-      : { body: RequestSchema['body'] }
-    : RequestSchema['body'] extends JSONValue
+type FetchRequestInitWithBody<RequestSchema extends HttpRequestSchema> = 'body' extends keyof RequestSchema
+  ? [RequestSchema['body']] extends [never]
+    ? { body?: null }
+    : RequestSchema['body'] extends string
       ? undefined extends RequestSchema['body']
-        ? { body?: JSONStringified<ReplaceBy<RequestSchema['body'], undefined, null>> }
-        : { body: JSONStringified<RequestSchema['body']> }
-      : undefined extends RequestSchema['body']
         ? { body?: ReplaceBy<RequestSchema['body'], undefined, null> }
-        : { body: RequestSchema['body'] };
+        : { body: RequestSchema['body'] }
+      : RequestSchema['body'] extends JSONValue
+        ? undefined extends RequestSchema['body']
+          ? { body?: JSONStringified<ReplaceBy<RequestSchema['body'], undefined, null>> }
+          : { body: JSONStringified<RequestSchema['body']> }
+        : undefined extends RequestSchema['body']
+          ? { body?: ReplaceBy<RequestSchema['body'], undefined, null> }
+          : { body: RequestSchema['body'] }
+  : { body?: null };
 
 type FetchRequestInitPerPath<RequestSchema extends HttpRequestSchema> = FetchRequestInitWithHeaders<RequestSchema> &
   FetchRequestInitWithSearchParams<RequestSchema> &

--- a/packages/zimic-interceptor/src/webSocket/__tests__/utils.ts
+++ b/packages/zimic-interceptor/src/webSocket/__tests__/utils.ts
@@ -5,7 +5,6 @@ import { vi } from 'vitest';
 const { WebSocketServer: ServerSocket } = ClientSocket;
 
 export function delayClientSocketOpen(delayDuration: number) {
-  // eslint-disable-next-line @typescript-eslint/unbound-method
   const originalClientSocketAddEventListener = ClientSocket.prototype.addEventListener;
 
   const delayedClientSocketAddEventListener = vi
@@ -22,7 +21,6 @@ export function delayClientSocketOpen(delayDuration: number) {
 }
 
 export function delayServerSocketConnection() {
-  // eslint-disable-next-line @typescript-eslint/unbound-method
   const originalServerSocketOn = ServerSocket.prototype.on;
 
   const delayedServerSocketOnSpy = vi.spyOn(ServerSocket.prototype, 'on').mockImplementation(function (
@@ -46,7 +44,6 @@ export function delayServerSocketConnection() {
 }
 
 export function delayClientSocketClose(delayDuration: number) {
-  // eslint-disable-next-line @typescript-eslint/unbound-method
   const originalClientSocketClose = ClientSocket.prototype.close;
 
   const delayedClientSocketClose = vi.spyOn(ClientSocket.prototype, 'close').mockImplementationOnce(function (
@@ -62,7 +59,6 @@ export function delayClientSocketClose(delayDuration: number) {
 }
 
 export function delayServerSocketClose(delayDuration: number) {
-  // eslint-disable-next-line @typescript-eslint/unbound-method
   const originalServerSocketClose = ServerSocket.prototype.close;
 
   const delayedServerSocketClose = vi.spyOn(ServerSocket.prototype, 'close').mockImplementationOnce(function (


### PR DESCRIPTION
### Fixes
- [fetch] The fetch client was not correctly typing the request parameters if the schema had an empty or non-empty `request` key, such as shown below. In this case, `headers` and `searchParams` were inferred to `unknown` and any value was accepted in the `fetch` calls. The types were working only when no `request` existed. This PR fixes this issue.

```ts
type Schema = HttpSchema<{
  '/users': {
    GET: {
      request: {}; // empty request causing 
      response: { 200: { body: User[] } };
    };
  };
}>;


const fetch = createFetch<Schema>({ baseURL });

await fetch('/users', {
  method: 'GET',
  headers: { 'my-custom-headers: 'example' }, // should be a type error because the schema has no headers
  searchParams: { option: '1' } // should be a type error because the schema has no search params
}),
```

### Performance
- [fetch] Optimized the `Fetch` type, which was previously an intersection and now is a interface extending `FetchClient`. This was necessary after the fixes in the request type inference.