### PR TITLE
fix(interceptor): expect blob equality even in non-strict restrictions

### DIFF
--- a/packages/zimic-interceptor/src/http/requestHandler/HttpRequestHandlerClient.ts
+++ b/packages/zimic-interceptor/src/http/requestHandler/HttpRequestHandlerClient.ts
@@ -9,7 +9,6 @@ import {
   HttpRequestSearchParamsSchema,
   HttpRequestHeadersSchema,
 } from '@zimic/http';
-import blobContains from '@zimic/utils/data/blobContains';
 import blobEquals from '@zimic/utils/data/blobEquals';
 import jsonContains from '@zimic/utils/data/jsonContains';
 import jsonEquals from '@zimic/utils/data/jsonEquals';
@@ -338,9 +337,7 @@ class HttpRequestHandlerClient<
         };
       }
 
-      const matchesRestriction = restriction.exact
-        ? await blobEquals(body, restrictionBody)
-        : await blobContains(body, restrictionBody);
+      const matchesRestriction = await blobEquals(body, restrictionBody);
 
       return matchesRestriction
         ? { value: true }

--- a/packages/zimic-utils/data/blobContains.d.ts
+++ b/packages/zimic-utils/data/blobContains.d.ts
@@ -1,4 +1,0 @@
-import blobContains from '../dist/data/blobContains';
-
-export * from '../dist/data/blobContains';
-export default blobContains;

--- a/packages/zimic-utils/package.json
+++ b/packages/zimic-utils/package.json
@@ -61,12 +61,6 @@
       "require": "./dist/data/isNonEmpty.js",
       "default": "./dist/data/isNonEmpty.js"
     },
-    "./data/blobContains": {
-      "types": "./data/blobContains.d.ts",
-      "import": "./dist/data/blobContains.mjs",
-      "require": "./dist/data/blobContains.js",
-      "default": "./dist/data/blobContains.js"
-    },
     "./data/blobEquals": {
       "types": "./data/blobEquals.d.ts",
       "import": "./dist/data/blobEquals.mjs",

--- a/packages/zimic-utils/src/data/blobContains.ts
+++ b/packages/zimic-utils/src/data/blobContains.ts
@@ -1,7 +1,0 @@
-async function blobContains(blob: Blob, otherBlob: Blob) {
-  return (
-    blob.type === otherBlob.type && blob.size >= otherBlob.size && (await blob.text()).includes(await otherBlob.text())
-  );
-}
-
-export default blobContains;

--- a/packages/zimic-utils/src/data/blobEquals.ts
+++ b/packages/zimic-utils/src/data/blobEquals.ts
@@ -1,7 +1,60 @@
 async function blobEquals(blob: Blob, otherBlob: Blob) {
-  return (
-    blob.type === otherBlob.type && blob.size === otherBlob.size && (await blob.text()) === (await otherBlob.text())
-  );
+  if (blob.type !== otherBlob.type || blob.size !== otherBlob.size) {
+    return false;
+  }
+
+  const reader = blob.stream().getReader();
+  const otherReader = otherBlob.stream().getReader();
+
+  let buffer: Uint8Array = new Uint8Array(0);
+  let otherBuffer: Uint8Array = new Uint8Array(0);
+
+  try {
+    while (true) {
+      await Promise.all([
+        buffer.length === 0 &&
+          reader.read().then((result) => {
+            if (!result.done) {
+              buffer = result.value;
+            }
+          }),
+
+        otherBuffer.length === 0 &&
+          otherReader.read().then((result) => {
+            if (!result.done) {
+              otherBuffer = result.value;
+            }
+          }),
+      ]);
+
+      const streamsEndedTogether = buffer.length === 0 && otherBuffer.length === 0;
+
+      if (streamsEndedTogether) {
+        return true;
+      }
+
+      const oneStreamEndedBeforeTheOther =
+        (buffer.length === 0 && otherBuffer.length > 0) || (buffer.length > 0 && otherBuffer.length === 0);
+
+      if (oneStreamEndedBeforeTheOther) {
+        return false;
+      }
+
+      const minimumByteLength = Math.min(buffer.length, otherBuffer.length);
+
+      for (let byteIndex = 0; byteIndex < minimumByteLength; byteIndex++) {
+        if (buffer[byteIndex] !== otherBuffer[byteIndex]) {
+          return false;
+        }
+      }
+
+      buffer = buffer.slice(minimumByteLength);
+      otherBuffer = otherBuffer.slice(minimumByteLength);
+    }
+  } finally {
+    reader.releaseLock();
+    otherReader.releaseLock();
+  }
 }
 
 export default blobEquals;

--- a/packages/zimic-utils/tsup.config.ts
+++ b/packages/zimic-utils/tsup.config.ts
@@ -22,7 +22,6 @@ const neutralConfig = (['cjs', 'esm'] as const).map<Options>((format) => ({
     'data/isDefined': 'src/data/isDefined.ts',
     'data/isNonEmpty': 'src/data/isNonEmpty.ts',
     'data/blobEquals': 'src/data/blobEquals.ts',
-    'data/blobContains': 'src/data/blobContains.ts',
     'data/fileEquals': 'src/data/fileEquals.ts',
     'data/jsonContains': 'src/data/jsonContains.ts',
     'data/jsonEquals': 'src/data/jsonEquals.ts',


### PR DESCRIPTION
- refactor(utils): remove `blobContains`
- refactor(utils): optimize `blobEquals`
- fix(interceptor): check blob equality even in non-strict restrictions
