### PR TITLE
fix(fetch): export `FetchResponsePerStatusCode`

### DIFF
--- a/apps/zimic-test-client/tests/exports/exports.test.ts
+++ b/apps/zimic-test-client/tests/exports/exports.test.ts
@@ -9,6 +9,7 @@ import {
   type FetchRequestObject,
   type FetchRequestInit,
   type FetchResponse,
+  type FetchResponsePerStatusCode,
   type FetchResponseObject,
   type JSONStringified,
   FetchResponseError,
@@ -202,6 +203,7 @@ describe('Exports', () => {
     expectTypeOf<FetchRequestConstructor<never>>().not.toBeAny();
     expectTypeOf<FetchRequestInit<never, never, never>>().not.toBeAny();
     expectTypeOf<FetchResponse<never, never, never>>().not.toBeAny();
+    expectTypeOf<FetchResponsePerStatusCode<never, never, never, never>>().not.toBeAny();
     expectTypeOf<FetchResponseObject>().not.toBeAny();
     expectTypeOf<FetchResponseError<never, never, never>>().not.toBeAny();
     expect(typeof FetchResponseError).toBe('function');

--- a/packages/zimic-fetch/src/client/FetchClient.ts
+++ b/packages/zimic-fetch/src/client/FetchClient.ts
@@ -11,12 +11,10 @@ import excludeURLParams from '@zimic/utils/url/excludeURLParams';
 import joinURL from '@zimic/utils/url/joinURL';
 
 import FetchResponseError from './errors/FetchResponseError';
-import { FetchInput, FetchOptions, Fetch, FetchClient as PublicFetchClient, FetchDefaults } from './types/public';
+import { FetchInput, FetchOptions, Fetch, FetchDefaults } from './types/public';
 import { FetchRequestConstructor, FetchRequestInit, FetchRequest, FetchResponse } from './types/requests';
 
-class FetchClient<Schema extends HttpSchema>
-  implements Omit<PublicFetchClient<Schema>, 'defaults' | 'loose' | 'Request'>
-{
+class FetchClient<Schema extends HttpSchema> implements Omit<Fetch<Schema>, 'defaults' | 'loose' | 'Request'> {
   fetch: Fetch<Schema>;
 
   constructor({ onRequest, onResponse, ...defaults }: FetchOptions<Schema>) {

--- a/packages/zimic-fetch/src/client/types/requests.ts
+++ b/packages/zimic-fetch/src/client/types/requests.ts
@@ -245,6 +245,12 @@ export type FetchRequestObject = Pick<
   body?: string | null;
 };
 
+/**
+ * A {@link FetchResponse `FetchResponse`} instance with a specific status code.
+ *
+ * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐fetch#fetchresponse `FetchResponse` API reference}
+ * @see {@link https://developer.mozilla.org/docs/Web/API/Response}
+ */
 export interface FetchResponsePerStatusCode<
   Schema extends HttpSchema,
   Method extends HttpSchemaMethod<Schema>,

--- a/packages/zimic-fetch/src/index.ts
+++ b/packages/zimic-fetch/src/index.ts
@@ -8,6 +8,7 @@ export type {
   FetchRequestObject,
   FetchRequestInit,
   FetchResponse,
+  FetchResponsePerStatusCode,
   FetchResponseObject,
 } from './client/types/requests';
 


### PR DESCRIPTION
- fix(fetch): export `FetchResponsePerStatusCode`
- refactor(fetch): unify `Fetch` and `FetchClient`
