### PR TITLE
fix(interceptor): lazily instantiate msw websocket broadcast channels (#728)

### DIFF
--- a/packages/zimic-interceptor/scripts/__tests__/postinstall.node.test.ts
+++ b/packages/zimic-interceptor/scripts/__tests__/postinstall.node.test.ts
@@ -2,7 +2,13 @@ import fs from 'fs';
 import path from 'path';
 import { describe, expect, it } from 'vitest';
 
-import { MSW_PACKAGE_PATH, MSW_BROWSER_DIRECTORY, MSWPackage, postinstallPromise } from '../postinstall';
+import {
+  MSW_PACKAGE_PATH,
+  MSW_BROWSER_DIRECTORY,
+  MSWPackage,
+  postinstallPromise,
+  MSW_CORE_DIRECTORY,
+} from '../postinstall';
 
 describe('Post-install script', () => {
   it('should patch msw/package.json exports', async () => {
@@ -26,6 +32,28 @@ describe('Post-install script', () => {
       const mswBrowserContent = await fs.promises.readFile(mswBrowserPath, 'utf-8');
 
       expect(mswBrowserContent).toContain('if (!request || responseJson.type?.includes("opaque")) {');
+    },
+  );
+
+  it.each(['ws.js', 'ws.mjs'])(
+    'should patch the web socket channel to be created lazily in msw/core/%s',
+    async (webSocketFileName) => {
+      await postinstallPromise;
+
+      const mswWebSocketPath = path.join(MSW_CORE_DIRECTORY, webSocketFileName);
+      const mswWebSocketContent = await fs.promises.readFile(mswWebSocketPath, 'utf-8');
+
+      expect(mswWebSocketContent).toContain('let webSocketChannel;');
+      expect(mswWebSocketContent).toContain(
+        [
+          '  if (!webSocketChannel) {',
+          '    webSocketChannel = new BroadcastChannel("msw:websocket-client-manager");',
+          '    if (isBroadcastChannelWithUnref(webSocketChannel)) {',
+          '      webSocketChannel.unref();',
+          '    }',
+          '  }',
+        ].join('\n'),
+      );
     },
   );
 });

--- a/packages/zimic-interceptor/scripts/__tests__/postinstall.node.test.ts
+++ b/packages/zimic-interceptor/scripts/__tests__/postinstall.node.test.ts
@@ -4,10 +4,10 @@ import { describe, expect, it } from 'vitest';
 
 import {
   MSW_PACKAGE_PATH,
+  MSW_CORE_DIRECTORY,
   MSW_BROWSER_DIRECTORY,
   MSWPackage,
   postinstallPromise,
-  MSW_CORE_DIRECTORY,
 } from '../postinstall';
 
 describe('Post-install script', () => {

--- a/packages/zimic-interceptor/scripts/postinstall.ts
+++ b/packages/zimic-interceptor/scripts/postinstall.ts
@@ -36,67 +36,71 @@ async function patchMSWExports() {
 
 // This is a temporary workaround. Once https://github.com/mswjs/msw/issues/2146 is fixed, we should remove it.
 async function patchMSWBrowserEntry() {
-  for (const indexFileName of ['index.js', 'index.mjs']) {
-    const mswBrowserPath = path.join(MSW_BROWSER_DIRECTORY, indexFileName);
-    const mswBrowserContent = await fs.promises.readFile(mswBrowserPath, 'utf-8');
+  await Promise.all(
+    ['index.js', 'index.mjs'].map(async (indexFileName) => {
+      const mswBrowserPath = path.join(MSW_BROWSER_DIRECTORY, indexFileName);
+      const mswBrowserContent = await fs.promises.readFile(mswBrowserPath, 'utf-8');
 
-    const patchedMSWBrowserContent = mswBrowserContent.replace(
-      ['    if (responseJson.type?.includes("opaque")) {', '      return;', '    }'].join('\n'),
-      ['    if (!request || responseJson.type?.includes("opaque")) {', '      return;', '    }'].join('\n'),
-    );
-
-    await fs.promises.writeFile(mswBrowserPath, patchedMSWBrowserContent);
-  }
-}
-
-// This is a temporary workaround. Once https://github.com/mswjs/msw/issues/ is fixed, we should remove it.
-async function patchMSWWebSocketBroadcastChannel() {
-  for (const webSocketFileName of ['ws.js', 'ws.mjs']) {
-    const mswWebSocketPath = path.join(MSW_CORE_DIRECTORY, webSocketFileName);
-    const mswWebSocketContent = await fs.promises.readFile(mswWebSocketPath, 'utf-8');
-
-    const patchedMSWWebSocketContent = mswWebSocketContent
-      .replace(
-        [
-          'const webSocketChannel = new BroadcastChannel("msw:websocket-client-manager");',
-          'if (isBroadcastChannelWithUnref(webSocketChannel)) {',
-          '  webSocketChannel.unref();',
-          '}',
-        ].join('\n'),
-        'let webSocketChannel;',
-      )
-      .replace(
-        [
-          '  );',
-          '  const clientManager = new import_WebSocketClientManager.WebSocketClientManager(webSocketChannel);',
-        ].join('\n'),
-        [
-          '  );',
-          '  if (!webSocketChannel) {',
-          '    webSocketChannel = new BroadcastChannel("msw:websocket-client-manager");',
-          '    if (isBroadcastChannelWithUnref(webSocketChannel)) {',
-          '      webSocketChannel.unref();',
-          '    }',
-          '  }',
-          '  const clientManager = new import_WebSocketClientManager.WebSocketClientManager(webSocketChannel);',
-        ].join('\n'),
-      )
-      .replace(
-        ['  );', '  const clientManager = new WebSocketClientManager(webSocketChannel);'].join('\n'),
-        [
-          '  );',
-          '  if (!webSocketChannel) {',
-          '    webSocketChannel = new BroadcastChannel("msw:websocket-client-manager");',
-          '    if (isBroadcastChannelWithUnref(webSocketChannel)) {',
-          '      webSocketChannel.unref();',
-          '    }',
-          '  }',
-          '  const clientManager = new WebSocketClientManager(webSocketChannel);',
-        ].join('\n'),
+      const patchedMSWBrowserContent = mswBrowserContent.replace(
+        ['    if (responseJson.type?.includes("opaque")) {', '      return;', '    }'].join('\n'),
+        ['    if (!request || responseJson.type?.includes("opaque")) {', '      return;', '    }'].join('\n'),
       );
 
-    await fs.promises.writeFile(mswWebSocketPath, patchedMSWWebSocketContent);
-  }
+      await fs.promises.writeFile(mswBrowserPath, patchedMSWBrowserContent);
+    }),
+  );
+}
+
+// This is a temporary workaround. Once https://github.com/stackblitz/core/issues/3323 is fixed, we should remove it.
+async function patchMSWWebSocketBroadcastChannel() {
+  await Promise.all(
+    ['ws.js', 'ws.mjs'].map(async (webSocketFileName) => {
+      const mswWebSocketPath = path.join(MSW_CORE_DIRECTORY, webSocketFileName);
+      const mswWebSocketContent = await fs.promises.readFile(mswWebSocketPath, 'utf-8');
+
+      const patchedMSWWebSocketContent = mswWebSocketContent
+        .replace(
+          [
+            'const webSocketChannel = new BroadcastChannel("msw:websocket-client-manager");',
+            'if (isBroadcastChannelWithUnref(webSocketChannel)) {',
+            '  webSocketChannel.unref();',
+            '}',
+          ].join('\n'),
+          'let webSocketChannel;',
+        )
+        .replace(
+          [
+            '  );',
+            '  const clientManager = new import_WebSocketClientManager.WebSocketClientManager(webSocketChannel);',
+          ].join('\n'),
+          [
+            '  );',
+            '  if (!webSocketChannel) {',
+            '    webSocketChannel = new BroadcastChannel("msw:websocket-client-manager");',
+            '    if (isBroadcastChannelWithUnref(webSocketChannel)) {',
+            '      webSocketChannel.unref();',
+            '    }',
+            '  }',
+            '  const clientManager = new import_WebSocketClientManager.WebSocketClientManager(webSocketChannel);',
+          ].join('\n'),
+        )
+        .replace(
+          ['  );', '  const clientManager = new WebSocketClientManager(webSocketChannel);'].join('\n'),
+          [
+            '  );',
+            '  if (!webSocketChannel) {',
+            '    webSocketChannel = new BroadcastChannel("msw:websocket-client-manager");',
+            '    if (isBroadcastChannelWithUnref(webSocketChannel)) {',
+            '      webSocketChannel.unref();',
+            '    }',
+            '  }',
+            '  const clientManager = new WebSocketClientManager(webSocketChannel);',
+          ].join('\n'),
+        );
+
+      await fs.promises.writeFile(mswWebSocketPath, patchedMSWWebSocketContent);
+    }),
+  );
 }
 
 async function postinstall() {

--- a/packages/zimic-interceptor/turbo.json
+++ b/packages/zimic-interceptor/turbo.json
@@ -23,17 +23,17 @@
 
     "test:turbo": {
       "dependsOn": ["^build", "@zimic/http#build", "deps:init-msw"],
-      "inputs": ["{src,tests}/**/*.{ts,json}", "{package,tsconfig}.json", "vitest.config.mts"]
+      "inputs": ["{src,tests,scripts}/**/*.{ts,json}", "{package,tsconfig}.json", "vitest.config.mts"]
     },
 
     "lint:turbo": {
       "dependsOn": ["^build", "@zimic/http#build"],
-      "inputs": ["{src,tests}/**/*.{ts,json}", "{package,tsconfig}.json", "eslint.config.mjs"]
+      "inputs": ["{src,tests,scripts}/**/*.{ts,json}", "{package,tsconfig}.json", "eslint.config.mjs"]
     },
 
     "types:check": {
       "dependsOn": ["^build", "@zimic/http#build"],
-      "inputs": ["{src,tests}/**/*.{ts,json}", "{package,tsconfig}.json"]
+      "inputs": ["{src,tests,scripts}/**/*.{ts,json}", "{package,tsconfig}.json"]
     }
   }
 }


### PR DESCRIPTION
### Fixes
- [interceptor] Added a patch to `@zimic/interceptor`'s postinstall script to apply the following diff to https://github.com/mswjs/msw/blob/69ae82d866aedbe4d72ae1914805798dc14e94d4/src/core/ws.ts#L20.

  <details>
  <summary>Diff</summary>
  
  ```diff
  -const webSocketChannel = new BroadcastChannel('msw:websocket-client-manager')
  +let webSocketChannel: BroadcastChannel | undefined

  -if (isBroadcastChannelWithUnref(webSocketChannel)) {
  -  webSocketChannel.unref()
  -}

  // ...

  function createWebSocketLinkHandler(url: Path): WebSocketLink {
    invariant(url, 'Expected a WebSocket server URL but got undefined')

    invariant(
      isPath(url),
      'Expected a WebSocket server URL to be a valid path but got %s',
      typeof url,
    )

  + if (!webSocketChannel) {
  +   webSocketChannel = new BroadcastChannel('msw:websocket-client-manager')
  +
  +   if (isBroadcastChannelWithUnref(webSocketChannel)) {
  +     webSocketChannel.unref()
  +   }
  + }

    const clientManager = new WebSocketClientManager(webSocketChannel)

    // ...
  ```

  </details>

  It delays the instantiation of MSW's WebSocket channel until first used. This is a temporary workaround until https://github.com/stackblitz/core/issues/3323 is resolved on StackBlitz. `@zimic/interceptor` does not yet use WebSocket mocks, so I think it makes little sense for the examples to fail on StackBlitz due to an MSW implementation that is not even needed by Zimic.

Closes #728.