### PR TITLE
docs(web): improve style compatibility (#517)

### DIFF
--- a/apps/zimic-web/docs/zimic-fetch/1-index.md
+++ b/apps/zimic-web/docs/zimic-fetch/1-index.md
@@ -10,7 +10,6 @@ slug: /fetch
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic-fetch/2-motivation.md
+++ b/apps/zimic-web/docs/zimic-fetch/2-motivation.md
@@ -10,7 +10,6 @@ slug: /fetch/motivation
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic-fetch/3-getting-started.md
+++ b/apps/zimic-web/docs/zimic-fetch/3-getting-started.md
@@ -10,7 +10,6 @@ slug: /fetch/getting-started
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic-fetch/4-comparison.md
+++ b/apps/zimic-web/docs/zimic-fetch/4-comparison.md
@@ -10,7 +10,6 @@ slug: /fetch/comparison
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic-fetch/api/1-create-fetch.md
+++ b/apps/zimic-web/docs/zimic-fetch/api/1-create-fetch.md
@@ -10,7 +10,6 @@ slug: /fetch/api/create-fetch
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic-fetch/api/2-fetch.md
+++ b/apps/zimic-web/docs/zimic-fetch/api/2-fetch.md
@@ -10,7 +10,6 @@ slug: /fetch/api/fetch
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic-fetch/api/3-fetch-request.md
+++ b/apps/zimic-web/docs/zimic-fetch/api/3-fetch-request.md
@@ -10,7 +10,6 @@ slug: /fetch/api/fetch-request
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic-fetch/api/4-fetch-response.md
+++ b/apps/zimic-web/docs/zimic-fetch/api/4-fetch-response.md
@@ -10,7 +10,6 @@ slug: /fetch/api/fetch-response
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic-fetch/api/5-fetch-response-error.md
+++ b/apps/zimic-web/docs/zimic-fetch/api/5-fetch-response-error.md
@@ -10,7 +10,6 @@ slug: /fetch/api/fetch-response-error
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic-fetch/guides/1-headers.md
+++ b/apps/zimic-web/docs/zimic-fetch/guides/1-headers.md
@@ -10,7 +10,6 @@ slug: /fetch/guides/headers
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic-fetch/guides/2-search-params.md
+++ b/apps/zimic-web/docs/zimic-fetch/guides/2-search-params.md
@@ -10,7 +10,6 @@ slug: /fetch/guides/search-params
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic-fetch/guides/3-path-params.md
+++ b/apps/zimic-web/docs/zimic-fetch/guides/3-path-params.md
@@ -10,7 +10,6 @@ slug: /fetch/guides/path-params
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic-fetch/guides/4-bodies.md
+++ b/apps/zimic-web/docs/zimic-fetch/guides/4-bodies.md
@@ -10,7 +10,6 @@ slug: /fetch/guides/bodies
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic-fetch/guides/5-authentication.md
+++ b/apps/zimic-web/docs/zimic-fetch/guides/5-authentication.md
@@ -10,7 +10,6 @@ slug: /fetch/guides/authentication
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic-fetch/guides/6-error-handling.md
+++ b/apps/zimic-web/docs/zimic-fetch/guides/6-error-handling.md
@@ -10,7 +10,6 @@ slug: /fetch/guides/error-handling
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic-fetch/guides/7-testing.md
+++ b/apps/zimic-web/docs/zimic-fetch/guides/7-testing.md
@@ -10,7 +10,6 @@ slug: /fetch/guides/testing
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic-fetch/guides/8-typegen.md
+++ b/apps/zimic-web/docs/zimic-fetch/guides/8-typegen.md
@@ -10,8 +10,7 @@ slug: /fetch/guides/typegen
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::
 
@@ -21,7 +20,6 @@ yet complete.
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic-http/1-index.md
+++ b/apps/zimic-web/docs/zimic-http/1-index.md
@@ -10,7 +10,6 @@ slug: /http
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic-http/2-motivation.md
+++ b/apps/zimic-web/docs/zimic-http/2-motivation.md
@@ -10,7 +10,6 @@ slug: /http/motivation
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic-http/3-getting-started.md
+++ b/apps/zimic-web/docs/zimic-http/3-getting-started.md
@@ -10,7 +10,6 @@ slug: /http/getting-started
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic-http/4-comparison.md
+++ b/apps/zimic-web/docs/zimic-http/4-comparison.md
@@ -10,7 +10,6 @@ slug: /http/comparison
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic-http/api/1-http-schema.md
+++ b/apps/zimic-web/docs/zimic-http/api/1-http-schema.md
@@ -10,7 +10,6 @@ slug: /http/api/http-schema
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic-http/api/10-typegen.md
+++ b/apps/zimic-web/docs/zimic-http/api/10-typegen.md
@@ -10,8 +10,7 @@ slug: /http/api/typegen
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::
 
@@ -21,7 +20,6 @@ yet complete.
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic-http/api/2-http-headers.md
+++ b/apps/zimic-web/docs/zimic-http/api/2-http-headers.md
@@ -10,7 +10,6 @@ slug: /http/api/http-headers
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic-http/api/3-http-form-data.md
+++ b/apps/zimic-web/docs/zimic-http/api/3-http-form-data.md
@@ -10,7 +10,6 @@ slug: /http/api/http-form-data
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic-http/api/4-http-search-params.md
+++ b/apps/zimic-web/docs/zimic-http/api/4-http-search-params.md
@@ -10,7 +10,6 @@ slug: /http/api/http-search-params
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic-http/cli/1-typegen.md
+++ b/apps/zimic-web/docs/zimic-http/cli/1-typegen.md
@@ -10,8 +10,7 @@ slug: /http/cli/typegen
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::
 
@@ -21,7 +20,6 @@ yet complete.
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic-http/guides/1-http-schemas.md
+++ b/apps/zimic-web/docs/zimic-http/guides/1-http-schemas.md
@@ -10,7 +10,6 @@ slug: /http/guides/schemas
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic-http/guides/2-inferring-paths.md
+++ b/apps/zimic-web/docs/zimic-http/guides/2-inferring-paths.md
@@ -10,7 +10,6 @@ slug: /http/guides/inferring-paths
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic-http/guides/3-typegen.md
+++ b/apps/zimic-web/docs/zimic-http/guides/3-typegen.md
@@ -10,8 +10,7 @@ slug: /http/guides/typegen
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::
 
@@ -21,7 +20,6 @@ yet complete.
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic-interceptor/1-index.md
+++ b/apps/zimic-web/docs/zimic-interceptor/1-index.md
@@ -10,7 +10,6 @@ slug: /interceptor
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic-interceptor/2-motivation.md
+++ b/apps/zimic-web/docs/zimic-interceptor/2-motivation.md
@@ -10,7 +10,6 @@ slug: /interceptor/motivation
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic-interceptor/3-getting-started.md
+++ b/apps/zimic-web/docs/zimic-interceptor/3-getting-started.md
@@ -10,7 +10,6 @@ slug: /interceptor/getting-started
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic-interceptor/4-comparison.md
+++ b/apps/zimic-web/docs/zimic-interceptor/4-comparison.md
@@ -10,7 +10,6 @@ slug: /interceptor/comparison
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic-interceptor/api/1-create-http-interceptor.md
+++ b/apps/zimic-web/docs/zimic-interceptor/api/1-create-http-interceptor.md
@@ -10,7 +10,6 @@ slug: /interceptor/api/create-http-interceptor
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic-interceptor/api/2-http-interceptor.md
+++ b/apps/zimic-web/docs/zimic-interceptor/api/2-http-interceptor.md
@@ -10,8 +10,7 @@ slug: /interceptor/api/http-interceptor
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::
 

--- a/apps/zimic-web/docs/zimic-interceptor/api/3-http-request-handler.md
+++ b/apps/zimic-web/docs/zimic-interceptor/api/3-http-request-handler.md
@@ -10,8 +10,7 @@ slug: /interceptor/api/http-request-handler
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::
 

--- a/apps/zimic-web/docs/zimic-interceptor/api/4-interceptor-server.md
+++ b/apps/zimic-web/docs/zimic-interceptor/api/4-interceptor-server.md
@@ -10,7 +10,6 @@ slug: /interceptor/api/interceptor-server
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic-interceptor/cli/1-server.md
+++ b/apps/zimic-web/docs/zimic-interceptor/cli/1-server.md
@@ -10,7 +10,6 @@ slug: /interceptor/cli/server
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic-interceptor/cli/2-browser.md
+++ b/apps/zimic-web/docs/zimic-interceptor/cli/2-browser.md
@@ -10,7 +10,6 @@ slug: /interceptor/cli/browser
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic-interceptor/guides/1-local-interceptors.md
+++ b/apps/zimic-web/docs/zimic-interceptor/guides/1-local-interceptors.md
@@ -10,7 +10,6 @@ slug: /interceptor/guides/interceptors/local
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic-interceptor/guides/10-typegen.md
+++ b/apps/zimic-web/docs/zimic-interceptor/guides/10-typegen.md
@@ -10,8 +10,7 @@ slug: /interceptor/guides/typegen
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::
 
@@ -21,7 +20,6 @@ yet complete.
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic-interceptor/guides/11-testing.md
+++ b/apps/zimic-web/docs/zimic-interceptor/guides/11-testing.md
@@ -10,7 +10,6 @@ slug: /interceptor/guides/testing
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic-interceptor/guides/2-remote-interceptors.md
+++ b/apps/zimic-web/docs/zimic-interceptor/guides/2-remote-interceptors.md
@@ -12,8 +12,7 @@ slug: /interceptor/guides/interceptors/remote
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::
 
@@ -23,8 +22,7 @@ yet complete.
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::
 
@@ -34,7 +32,6 @@ yet complete.
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic-interceptor/guides/3-headers.md
+++ b/apps/zimic-web/docs/zimic-interceptor/guides/3-headers.md
@@ -10,7 +10,6 @@ slug: /interceptor/guides/headers
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic-interceptor/guides/4-search-params.md
+++ b/apps/zimic-web/docs/zimic-interceptor/guides/4-search-params.md
@@ -10,7 +10,6 @@ slug: /interceptor/guides/search-params
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic-interceptor/guides/5-path-params.md
+++ b/apps/zimic-web/docs/zimic-interceptor/guides/5-path-params.md
@@ -10,7 +10,6 @@ slug: /interceptor/guides/path-params
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic-interceptor/guides/6-bodies.md
+++ b/apps/zimic-web/docs/zimic-interceptor/guides/6-bodies.md
@@ -10,7 +10,6 @@ slug: /interceptor/guides/bodies
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic-interceptor/guides/7-declarative-assertions.md
+++ b/apps/zimic-web/docs/zimic-interceptor/guides/7-declarative-assertions.md
@@ -10,7 +10,6 @@ slug: /interceptor/guides/declarative-assertions
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic-interceptor/guides/8-unhandled-requests.md
+++ b/apps/zimic-web/docs/zimic-interceptor/guides/8-unhandled-requests.md
@@ -10,7 +10,6 @@ slug: /interceptor/guides/unhandled-requests
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic-interceptor/guides/9-authentication.md
+++ b/apps/zimic-web/docs/zimic-interceptor/guides/9-authentication.md
@@ -10,7 +10,6 @@ slug: /interceptor/guides/authentication
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic/1-index.md
+++ b/apps/zimic-web/docs/zimic/1-index.md
@@ -8,7 +8,6 @@ slug: /
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/docs/zimic/2-motivation.md
+++ b/apps/zimic-web/docs/zimic/2-motivation.md
@@ -8,7 +8,6 @@ slug: /motivation
 
 🚧 This section is a work in progress.
 
-Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](https://zimic.dev) is not
-yet complete.
+Please use the [old documentation](https://github.com/zimicjs/zimic/wiki) while [zimic.dev](/) is not yet complete.
 
 :::

--- a/apps/zimic-web/package.json
+++ b/apps/zimic-web/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.1",
   "private": true,
   "scripts": {
-    "dev": "docusaurus start --no-open",
+    "dev": "docusaurus start --host :: --no-open",
     "build": "docusaurus build",
     "start": "docusaurus serve --no-open",
     "lint": "eslint --cache --no-error-on-unmatched-pattern --no-warn-ignored --fix",

--- a/apps/zimic-web/src/pages/components/GradientBackground.tsx
+++ b/apps/zimic-web/src/pages/components/GradientBackground.tsx
@@ -1,10 +1,22 @@
 function GradientBackground() {
   return (
     <div className="-z-1 fixed inset-0 overflow-hidden">
-      <div className="bg-highlight-600/5 dark:bg-highlight-600/30 h-128 w-128 -z-1 absolute -right-64 -top-64 rounded-full blur-[8rem]" />
-      <div className="bg-highlight-500/5 dark:bg-highlight-500/10 -z-1 h-128 w-128 absolute left-0 top-24 rounded-full blur-[8rem]" />
-      <div className="bg-highlight-400/5 dark:bg-highlight-400/10 -z-1 absolute bottom-36 right-8 h-96 w-96 rounded-full blur-[8rem]" />
-      <div className="bg-highlight-300/5 dark:bg-highlight-300/15 -z-1 h-128 w-128 absolute -bottom-64 left-32 rounded-full blur-[10rem]" />
+      <div
+        className="bg-highlight-600/5 dark:bg-highlight-600/30 h-128 w-128 -z-1 absolute -right-64 -top-64 rounded-full"
+        style={{ filter: 'blur(8rem)' }}
+      />
+      <div
+        className="bg-highlight-500/5 dark:bg-highlight-500/10 -z-1 h-128 w-128 absolute left-0 top-24 rounded-full"
+        style={{ filter: 'blur(8rem)' }}
+      />
+      <div
+        className="bg-highlight-400/5 dark:bg-highlight-400/10 -z-1 absolute bottom-36 right-8 h-96 w-96 rounded-full"
+        style={{ filter: 'blur(8rem)' }}
+      />
+      <div
+        className="bg-highlight-300/5 dark:bg-highlight-300/15 -z-1 h-128 w-128 absolute -bottom-64 left-32 rounded-full"
+        style={{ filter: 'blur(10rem)' }}
+      />
     </div>
   );
 }

--- a/apps/zimic-web/src/pages/components/HighlightCard.tsx
+++ b/apps/zimic-web/src/pages/components/HighlightCard.tsx
@@ -10,7 +10,7 @@ function HighlightCard({ hoverable = false, className, children, ...rest }: Prop
   return (
     <article
       className={cn(
-        'border-primary-500/10 dark:border-primary-500/20 bg-primary-500/5 dark:bg-primary-500/15 h-full w-full space-y-4 rounded-xl border-2 p-6 backdrop-blur-sm transition-colors',
+        'border-primary-500/10 dark:border-primary-500/20 bg-primary-500/5 dark:bg-primary-500/15 h-full w-full space-y-4 rounded-xl border-2 p-6 transition-colors',
         hoverable && 'hover:bg-primary-500/15 dark:hover:bg-primary-600/30',
         className,
       )}

--- a/apps/zimic-web/src/pages/index.tsx
+++ b/apps/zimic-web/src/pages/index.tsx
@@ -25,7 +25,10 @@ function HomePage() {
         <div className="mx-auto max-w-[96rem] space-y-16 px-12">
           <div className="flex flex-col items-center space-y-8">
             <div className="relative">
-              <div className="bg-highlight-500/40 -z-1 absolute -inset-4 h-[calc(100%+2rem)] w-[calc(100%+2rem)] rounded-full blur-3xl" />
+              <div
+                className="bg-highlight-500/30 -z-1 absolute -inset-4 h-[calc(100%+2rem)] w-[calc(100%+2rem)] rounded-full"
+                style={{ filter: 'blur(4rem)' }}
+              />
 
               {/* This component is an SVG that acts as a logo. */}
               {/* eslint-disable-next-line jsx-a11y/prefer-tag-over-role */}

--- a/apps/zimic-web/src/styles/global.css
+++ b/apps/zimic-web/src/styles/global.css
@@ -46,6 +46,8 @@
 
   --ifm-code-font-size: 95%;
 
+  --ifm-hover-overlay: color-mix(in oklab, var(--color-primary-600) /* #2167ed */ 5%, transparent);
+
   --highlighted-code-background-color: rgba(0, 0, 0, 0.1);
 
   --error-code-background-color: rgba(250, 56, 62, 0.2);
@@ -76,6 +78,8 @@
 
   --ifm-footer-link-color: var(--ifm-font-color-base);
   --ifm-footer-background-color: var(--ifm-navbar-background-color);
+
+  --ifm-hover-overlay: color-mix(in oklab, var(--color-primary-600) /* #2167ed */ 20%, transparent);
 
   --highlighted-code-background-color: rgba(0, 0, 0, 0.3);
 
@@ -214,8 +218,9 @@ textarea {
   @apply rounded-lg;
 }
 
+.card,
 .pagination-nav__link {
-  @apply hover:bg-primary-600/5 dark:hover:bg-primary-600/20 hover:border-primary-600/20 border-2 border-transparent transition-colors;
+  @apply hover:bg-primary-600/5 dark:hover:bg-primary-600/20 hover:border-primary-600/20 shadow-none transition-colors;
 }
 
 @media (max-width: 996px) {


### PR DESCRIPTION
### Documentation
- [web] Changed the blur of the elements to be set with `style`, rather than `className`. The native `blur-<size>` tailwind class is apparently not working in some Android devices (Chrome mobile).
- [web] Improved some styles and changed the `zimic.dev` links to not open in a new tab.