### PR TITLE
feat(http)!: json content type inference (#750)

### DIFF
--- a/apps/zimic-test-client/tests/fetch/FetchClient.test.ts
+++ b/apps/zimic-test-client/tests/fetch/FetchClient.test.ts
@@ -574,7 +574,7 @@ describe('Fetch client', async () => {
       async function updateUser(userId: string, payload: Partial<UserCreationRequestBody>) {
         const response = await authFetch(`/users/${userId}`, {
           method: 'PATCH',
-          headers: { 'content-type': 'application/json', authorization: 'Bearer token' },
+          headers: { 'content-type': 'application/json' },
           body: JSON.stringify(payload),
         });
 
@@ -589,7 +589,7 @@ describe('Fetch client', async () => {
         const updateHandler = authInterceptor
           .patch(`/users/${user.id}`)
           .with({
-            headers: { 'content-type': 'application/json', authorization: 'Bearer token' },
+            headers: { 'content-type': 'application/json' },
             body: updatePayload,
           })
           .respond((request) => {
@@ -620,7 +620,7 @@ describe('Fetch client', async () => {
         expect(updateHandler.requests).toHaveLength(1);
 
         expectTypeOf(updateHandler.requests[0].headers).branded.toEqualTypeOf<
-          HttpHeaders<{ 'content-type': 'application/json'; authorization: string }>
+          HttpHeaders<{ 'content-type': string }>
         >();
 
         expectTypeOf(updateHandler.requests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();

--- a/apps/zimic-test-client/tests/fetch/FetchClient.test.ts
+++ b/apps/zimic-test-client/tests/fetch/FetchClient.test.ts
@@ -150,7 +150,9 @@ describe('Fetch client', async () => {
         expectTypeOf(creationHandler.requests[0].body).toEqualTypeOf<UserCreationRequestBody>();
         expect(creationHandler.requests[0].body).toEqual(creationPayload);
 
-        expectTypeOf(creationHandler.requests[0].raw).toEqualTypeOf<HttpRequest<UserCreationRequestBody>>();
+        expectTypeOf(creationHandler.requests[0].raw).toEqualTypeOf<
+          HttpRequest<UserCreationRequestBody, { 'content-type': 'application/json' }>
+        >();
         expect(creationHandler.requests[0].raw).toBeInstanceOf(Request);
         expectTypeOf(creationHandler.requests[0].raw.json).toEqualTypeOf<() => Promise<UserCreationRequestBody>>();
         expect(await creationHandler.requests[0].raw.json()).toEqual(creationPayload);
@@ -158,7 +160,9 @@ describe('Fetch client', async () => {
         expectTypeOf(creationHandler.requests[0].response.body).toEqualTypeOf<JSONSerialized<User>>();
         expect(creationHandler.requests[0].response.body).toEqual(createdUser);
 
-        expectTypeOf(creationHandler.requests[0].response.raw).toEqualTypeOf<HttpResponse<JSONSerialized<User>, 201>>();
+        expectTypeOf(creationHandler.requests[0].response.raw).branded.toEqualTypeOf<
+          HttpResponse<JSONSerialized<User>, { 'x-user-id': User['id']; 'content-type': 'application/json' }, 201>
+        >();
         expect(creationHandler.requests[0].response.raw).toBeInstanceOf(Response);
         expectTypeOf(creationHandler.requests[0].response.raw.json).toEqualTypeOf<
           () => Promise<JSONSerialized<User>>
@@ -202,7 +206,9 @@ describe('Fetch client', async () => {
         expectTypeOf(creationHandler.requests[0].body).toEqualTypeOf<UserCreationRequestBody>();
         expect(creationHandler.requests[0].body).toEqual(invalidPayload);
 
-        expectTypeOf(creationHandler.requests[0].raw).toEqualTypeOf<HttpRequest<UserCreationRequestBody>>();
+        expectTypeOf(creationHandler.requests[0].raw).toEqualTypeOf<
+          HttpRequest<UserCreationRequestBody, { 'content-type': 'application/json' }>
+        >();
         expect(creationHandler.requests[0].raw).toBeInstanceOf(Request);
         expectTypeOf(creationHandler.requests[0].raw.json).toEqualTypeOf<() => Promise<UserCreationRequestBody>>();
         expect(await creationHandler.requests[0].raw.json()).toEqual(invalidPayload);
@@ -210,7 +216,9 @@ describe('Fetch client', async () => {
         expectTypeOf(creationHandler.requests[0].response.body).toEqualTypeOf<ValidationError>();
         expect(creationHandler.requests[0].response.body).toEqual(validationError);
 
-        expectTypeOf(creationHandler.requests[0].response.raw).toEqualTypeOf<HttpResponse<ValidationError, 400>>();
+        expectTypeOf(creationHandler.requests[0].response.raw).toEqualTypeOf<
+          HttpResponse<ValidationError, { 'content-type': 'application/json' }, 400>
+        >();
         expect(creationHandler.requests[0].response.raw).toBeInstanceOf(Response);
         expectTypeOf(creationHandler.requests[0].response.raw.json).toEqualTypeOf<() => Promise<ValidationError>>();
         expect(await creationHandler.requests[0].response.raw.json()).toEqual(validationError);
@@ -251,7 +259,9 @@ describe('Fetch client', async () => {
         expectTypeOf(creationHandler.requests[0].body).toEqualTypeOf<UserCreationRequestBody>();
         expect(creationHandler.requests[0].body).toEqual(conflictingPayload);
 
-        expectTypeOf(creationHandler.requests[0].raw).toEqualTypeOf<HttpRequest<UserCreationRequestBody>>();
+        expectTypeOf(creationHandler.requests[0].raw).toEqualTypeOf<
+          HttpRequest<UserCreationRequestBody, { 'content-type': 'application/json' }>
+        >();
         expect(creationHandler.requests[0].raw).toBeInstanceOf(Request);
         expectTypeOf(creationHandler.requests[0].raw.json).toEqualTypeOf<() => Promise<UserCreationRequestBody>>();
         expect(await creationHandler.requests[0].raw.json()).toEqual(creationPayload);
@@ -259,7 +269,9 @@ describe('Fetch client', async () => {
         expectTypeOf(creationHandler.requests[0].response.body).toEqualTypeOf<ConflictError>();
         expect(creationHandler.requests[0].response.body).toEqual(conflictError);
 
-        expectTypeOf(creationHandler.requests[0].response.raw).toEqualTypeOf<HttpResponse<ConflictError, 409>>();
+        expectTypeOf(creationHandler.requests[0].response.raw).toEqualTypeOf<
+          HttpResponse<ConflictError, { 'content-type': 'application/json' }, 409>
+        >();
         expect(creationHandler.requests[0].response.raw).toBeInstanceOf(Response);
         expectTypeOf(creationHandler.requests[0].response.raw.json).toEqualTypeOf<() => Promise<ConflictError>>();
         expect(await creationHandler.requests[0].response.raw.json()).toEqual(conflictError);
@@ -332,7 +344,7 @@ describe('Fetch client', async () => {
         expectTypeOf(listHandler.requests[0].body).toEqualTypeOf<null>();
         expect(listHandler.requests[0].body).toBe(null);
 
-        expectTypeOf(listHandler.requests[0].raw).toEqualTypeOf<HttpRequest<null>>();
+        expectTypeOf(listHandler.requests[0].raw).toEqualTypeOf<HttpRequest<null, never>>();
         expect(listHandler.requests[0].raw).toBeInstanceOf(Request);
         expectTypeOf(listHandler.requests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
         expect(await listHandler.requests[0].raw.text()).toBe('');
@@ -340,7 +352,9 @@ describe('Fetch client', async () => {
         expectTypeOf(listHandler.requests[0].response.body).toEqualTypeOf<JSONSerialized<User>[]>();
         expect(listHandler.requests[0].response.body).toEqual(users.map(serializeUser));
 
-        expectTypeOf(listHandler.requests[0].response.raw).toEqualTypeOf<HttpResponse<JSONSerialized<User>[], 200>>();
+        expectTypeOf(listHandler.requests[0].response.raw).toEqualTypeOf<
+          HttpResponse<JSONSerialized<User>[], { 'content-type': 'application/json' }, 200>
+        >();
         expect(listHandler.requests[0].response.raw).toBeInstanceOf(Response);
         expectTypeOf(listHandler.requests[0].response.raw.json).toEqualTypeOf<() => Promise<JSONSerialized<User>[]>>();
         expect(await listHandler.requests[0].response.raw.json()).toEqual(users.map(serializeUser));
@@ -374,7 +388,7 @@ describe('Fetch client', async () => {
         expectTypeOf(listHandler.requests[0].body).toEqualTypeOf<null>();
         expect(listHandler.requests[0].body).toBe(null);
 
-        expectTypeOf(listHandler.requests[0].raw).toEqualTypeOf<HttpRequest<null>>();
+        expectTypeOf(listHandler.requests[0].raw).toEqualTypeOf<HttpRequest<null, never>>();
         expect(listHandler.requests[0].raw).toBeInstanceOf(Request);
         expectTypeOf(listHandler.requests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
         expect(await listHandler.requests[0].raw.text()).toBe('');
@@ -382,7 +396,9 @@ describe('Fetch client', async () => {
         expectTypeOf(listHandler.requests[0].response.body).toEqualTypeOf<JSONSerialized<User>[]>();
         expect(listHandler.requests[0].response.body).toEqual([serializeUser(user)]);
 
-        expectTypeOf(listHandler.requests[0].response.raw).toEqualTypeOf<HttpResponse<JSONSerialized<User>[], 200>>();
+        expectTypeOf(listHandler.requests[0].response.raw).toEqualTypeOf<
+          HttpResponse<JSONSerialized<User>[], { 'content-type': 'application/json' }, 200>
+        >();
         expect(listHandler.requests[0].response.raw).toBeInstanceOf(Response);
         expectTypeOf(listHandler.requests[0].response.raw.json).toEqualTypeOf<() => Promise<JSONSerialized<User>[]>>();
         expect(await listHandler.requests[0].response.raw.json()).toEqual([serializeUser(user)]);
@@ -420,7 +436,7 @@ describe('Fetch client', async () => {
         expectTypeOf(listHandler.requests[0].body).toEqualTypeOf<null>();
         expect(listHandler.requests[0].body).toBe(null);
 
-        expectTypeOf(listHandler.requests[0].raw).toEqualTypeOf<HttpRequest<null>>();
+        expectTypeOf(listHandler.requests[0].raw).toEqualTypeOf<HttpRequest<null, never>>();
         expect(listHandler.requests[0].raw).toBeInstanceOf(Request);
         expectTypeOf(listHandler.requests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
         expect(await listHandler.requests[0].raw.text()).toBe('');
@@ -428,7 +444,9 @@ describe('Fetch client', async () => {
         expectTypeOf(listHandler.requests[0].response.body).toEqualTypeOf<JSONSerialized<User>[]>();
         expect(listHandler.requests[0].response.body).toEqual(usersSortedByDescendingEmail.map(serializeUser));
 
-        expectTypeOf(listHandler.requests[0].response.raw).toEqualTypeOf<HttpResponse<JSONSerialized<User>[], 200>>();
+        expectTypeOf(listHandler.requests[0].response.raw).toEqualTypeOf<
+          HttpResponse<JSONSerialized<User>[], { 'content-type': 'application/json' }, 200>
+        >();
         expect(listHandler.requests[0].response.raw).toBeInstanceOf(Response);
         expectTypeOf(listHandler.requests[0].response.raw.json).toEqualTypeOf<() => Promise<JSONSerialized<User>[]>>();
         expect(await listHandler.requests[0].response.raw.json()).toEqual(
@@ -475,7 +493,7 @@ describe('Fetch client', async () => {
         expectTypeOf(getHandler.requests[0].body).toEqualTypeOf<null>();
         expect(getHandler.requests[0].body).toBe(null);
 
-        expectTypeOf(getHandler.requests[0].raw).toEqualTypeOf<HttpRequest<null>>();
+        expectTypeOf(getHandler.requests[0].raw).toEqualTypeOf<HttpRequest<null, never>>();
         expect(getHandler.requests[0].raw).toBeInstanceOf(Request);
         expectTypeOf(getHandler.requests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
         expect(await getHandler.requests[0].raw.text()).toBe('');
@@ -483,7 +501,9 @@ describe('Fetch client', async () => {
         expectTypeOf(getHandler.requests[0].response.body).toEqualTypeOf<JSONSerialized<User>>();
         expect(getHandler.requests[0].response.body).toEqual(serializeUser(user));
 
-        expectTypeOf(getHandler.requests[0].response.raw).toEqualTypeOf<HttpResponse<JSONSerialized<User>, 200>>();
+        expectTypeOf(getHandler.requests[0].response.raw).toEqualTypeOf<
+          HttpResponse<JSONSerialized<User>, { 'content-type': 'application/json' }, 200>
+        >();
         expect(getHandler.requests[0].response.raw).toBeInstanceOf(Response);
         expectTypeOf(getHandler.requests[0].response.raw.json).toEqualTypeOf<() => Promise<JSONSerialized<User>>>();
         expect(await getHandler.requests[0].response.raw.json()).toEqual(serializeUser(user));
@@ -526,7 +546,7 @@ describe('Fetch client', async () => {
         expectTypeOf(getHandler.requests[0].body).toEqualTypeOf<null>();
         expect(getHandler.requests[0].body).toBe(null);
 
-        expectTypeOf(getHandler.requests[0].raw).toEqualTypeOf<HttpRequest<null>>();
+        expectTypeOf(getHandler.requests[0].raw).toEqualTypeOf<HttpRequest<null, never>>();
         expect(getHandler.requests[0].raw).toBeInstanceOf(Request);
         expectTypeOf(getHandler.requests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
         expect(await getHandler.requests[0].raw.text()).toBe('');
@@ -534,7 +554,9 @@ describe('Fetch client', async () => {
         expectTypeOf(getHandler.requests[0].response.body).toEqualTypeOf<NotFoundError>();
         expect(getHandler.requests[0].response.body).toEqual(notFoundError);
 
-        expectTypeOf(getHandler.requests[0].response.raw).toEqualTypeOf<HttpResponse<NotFoundError, 404>>();
+        expectTypeOf(getHandler.requests[0].response.raw).toEqualTypeOf<
+          HttpResponse<NotFoundError, { 'content-type': 'application/json' }, 404>
+        >();
         expect(getHandler.requests[0].response.raw).toBeInstanceOf(Response);
         expectTypeOf(getHandler.requests[0].response.raw.json).toEqualTypeOf<() => Promise<NotFoundError>>();
         expect(await getHandler.requests[0].response.raw.json()).toEqual(notFoundError);
@@ -574,7 +596,7 @@ describe('Fetch client', async () => {
         expectTypeOf(deleteHandler.requests[0].body).toEqualTypeOf<null>();
         expect(deleteHandler.requests[0].body).toBe(null);
 
-        expectTypeOf(deleteHandler.requests[0].raw).toEqualTypeOf<HttpRequest<null>>();
+        expectTypeOf(deleteHandler.requests[0].raw).toEqualTypeOf<HttpRequest<null, never>>();
         expect(deleteHandler.requests[0].raw).toBeInstanceOf(Request);
         expectTypeOf(deleteHandler.requests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
         expect(await deleteHandler.requests[0].raw.text()).toBe('');
@@ -582,7 +604,7 @@ describe('Fetch client', async () => {
         expectTypeOf(deleteHandler.requests[0].response.body).toEqualTypeOf<null>();
         expect(deleteHandler.requests[0].response.body).toBe(null);
 
-        expectTypeOf(deleteHandler.requests[0].response.raw).toEqualTypeOf<HttpResponse<null, 204>>();
+        expectTypeOf(deleteHandler.requests[0].response.raw).toEqualTypeOf<HttpResponse<null, never, 204>>();
         expect(deleteHandler.requests[0].response.raw).toBeInstanceOf(Response);
         expectTypeOf(deleteHandler.requests[0].response.raw.json).toEqualTypeOf<() => Promise<null>>();
         expect(await deleteHandler.requests[0].response.raw.text()).toBe('');
@@ -621,7 +643,7 @@ describe('Fetch client', async () => {
         expectTypeOf(deleteHandler.requests[0].body).toEqualTypeOf<null>();
         expect(deleteHandler.requests[0].body).toBe(null);
 
-        expectTypeOf(deleteHandler.requests[0].raw).toEqualTypeOf<HttpRequest<null>>();
+        expectTypeOf(deleteHandler.requests[0].raw).toEqualTypeOf<HttpRequest<null, never>>();
         expect(deleteHandler.requests[0].raw).toBeInstanceOf(Request);
         expectTypeOf(deleteHandler.requests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
         expect(await deleteHandler.requests[0].raw.text()).toBe('');
@@ -629,7 +651,9 @@ describe('Fetch client', async () => {
         expectTypeOf(deleteHandler.requests[0].response.body).toEqualTypeOf<NotFoundError>();
         expect(deleteHandler.requests[0].response.body).toEqual(notFoundError);
 
-        expectTypeOf(deleteHandler.requests[0].response.raw).toEqualTypeOf<HttpResponse<NotFoundError, 404>>();
+        expectTypeOf(deleteHandler.requests[0].response.raw).toEqualTypeOf<
+          HttpResponse<NotFoundError, { 'content-type': 'application/json' }, 404>
+        >();
         expect(deleteHandler.requests[0].response.raw).toBeInstanceOf(Response);
         expectTypeOf(deleteHandler.requests[0].response.raw.json).toEqualTypeOf<() => Promise<NotFoundError>>();
         expect(await deleteHandler.requests[0].response.raw.json()).toEqual(notFoundError);
@@ -698,7 +722,7 @@ describe('Fetch client', async () => {
         expectTypeOf(listHandler.requests[0].body).toEqualTypeOf<null>();
         expect(listHandler.requests[0].body).toBe(null);
 
-        expectTypeOf(listHandler.requests[0].raw).toEqualTypeOf<HttpRequest<null>>();
+        expectTypeOf(listHandler.requests[0].raw).toEqualTypeOf<HttpRequest<null, never>>();
         expect(listHandler.requests[0].raw).toBeInstanceOf(Request);
         expectTypeOf(listHandler.requests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
         expect(await listHandler.requests[0].raw.text()).toBe('');
@@ -706,7 +730,9 @@ describe('Fetch client', async () => {
         expectTypeOf(listHandler.requests[0].response.body).toEqualTypeOf<Notification[]>();
         expect(listHandler.requests[0].response.body).toEqual([notification]);
 
-        expectTypeOf(listHandler.requests[0].response.raw).toEqualTypeOf<HttpResponse<Notification[], 200>>();
+        expectTypeOf(listHandler.requests[0].response.raw).toEqualTypeOf<
+          HttpResponse<Notification[], { 'content-type': 'application/json' }, 200>
+        >();
         expect(listHandler.requests[0].response.raw).toBeInstanceOf(Response);
         expectTypeOf(listHandler.requests[0].response.raw.json).toEqualTypeOf<() => Promise<Notification[]>>();
         expect(await listHandler.requests[0].response.raw.json()).toEqual([notification]);

--- a/apps/zimic-test-client/tests/interceptor/thirdParty/shared/httpInterceptor.ts
+++ b/apps/zimic-test-client/tests/interceptor/thirdParty/shared/httpInterceptor.ts
@@ -173,7 +173,9 @@ async function declareHttpInterceptorTests(options: ClientTestOptionsByWorkerTyp
         expectTypeOf(creationHandler.requests[0].body).toEqualTypeOf<UserCreationRequestBody>();
         expect(creationHandler.requests[0].body).toEqual(creationPayload);
 
-        expectTypeOf(creationHandler.requests[0].raw).toEqualTypeOf<HttpRequest<UserCreationRequestBody>>();
+        expectTypeOf(creationHandler.requests[0].raw).toEqualTypeOf<
+          HttpRequest<UserCreationRequestBody, { 'content-type': 'application/json' }>
+        >();
         expect(creationHandler.requests[0].raw).toBeInstanceOf(Request);
         expectTypeOf(creationHandler.requests[0].raw.json).toEqualTypeOf<() => Promise<UserCreationRequestBody>>();
         expect(await creationHandler.requests[0].raw.json()).toEqual(creationPayload);
@@ -181,7 +183,9 @@ async function declareHttpInterceptorTests(options: ClientTestOptionsByWorkerTyp
         expectTypeOf(creationHandler.requests[0].response.body).toEqualTypeOf<JSONSerialized<User>>();
         expect(creationHandler.requests[0].response.body).toEqual(createdUser);
 
-        expectTypeOf(creationHandler.requests[0].response.raw).toEqualTypeOf<HttpResponse<JSONSerialized<User>, 201>>();
+        expectTypeOf(creationHandler.requests[0].response.raw).branded.toEqualTypeOf<
+          HttpResponse<JSONSerialized<User>, { 'x-user-id': User['id']; 'content-type': 'application/json' }, 201>
+        >();
         expect(creationHandler.requests[0].response.raw).toBeInstanceOf(Response);
         expectTypeOf(creationHandler.requests[0].response.raw.json).toEqualTypeOf<
           () => Promise<JSONSerialized<User>>
@@ -219,7 +223,9 @@ async function declareHttpInterceptorTests(options: ClientTestOptionsByWorkerTyp
         expectTypeOf(creationHandler.requests[0].body).toEqualTypeOf<UserCreationRequestBody>();
         expect(creationHandler.requests[0].body).toEqual(invalidPayload);
 
-        expectTypeOf(creationHandler.requests[0].raw).toEqualTypeOf<HttpRequest<UserCreationRequestBody>>();
+        expectTypeOf(creationHandler.requests[0].raw).toEqualTypeOf<
+          HttpRequest<UserCreationRequestBody, { 'content-type': 'application/json' }>
+        >();
         expect(creationHandler.requests[0].raw).toBeInstanceOf(Request);
         expectTypeOf(creationHandler.requests[0].raw.json).toEqualTypeOf<() => Promise<UserCreationRequestBody>>();
         expect(await creationHandler.requests[0].raw.json()).toEqual(invalidPayload);
@@ -227,7 +233,9 @@ async function declareHttpInterceptorTests(options: ClientTestOptionsByWorkerTyp
         expectTypeOf(creationHandler.requests[0].response.body).toEqualTypeOf<ValidationError>();
         expect(creationHandler.requests[0].response.body).toEqual(validationError);
 
-        expectTypeOf(creationHandler.requests[0].response.raw).toEqualTypeOf<HttpResponse<ValidationError, 400>>();
+        expectTypeOf(creationHandler.requests[0].response.raw).toEqualTypeOf<
+          HttpResponse<ValidationError, { 'content-type': 'application/json' }, 400>
+        >();
         expect(creationHandler.requests[0].response.raw).toBeInstanceOf(Response);
         expectTypeOf(creationHandler.requests[0].response.raw.json).toEqualTypeOf<() => Promise<ValidationError>>();
         expect(await creationHandler.requests[0].response.raw.json()).toEqual(validationError);
@@ -261,7 +269,9 @@ async function declareHttpInterceptorTests(options: ClientTestOptionsByWorkerTyp
         expectTypeOf(creationHandler.requests[0].body).toEqualTypeOf<UserCreationRequestBody>();
         expect(creationHandler.requests[0].body).toEqual(conflictingPayload);
 
-        expectTypeOf(creationHandler.requests[0].raw).toEqualTypeOf<HttpRequest<UserCreationRequestBody>>();
+        expectTypeOf(creationHandler.requests[0].raw).toEqualTypeOf<
+          HttpRequest<UserCreationRequestBody, { 'content-type': 'application/json' }>
+        >();
         expect(creationHandler.requests[0].raw).toBeInstanceOf(Request);
         expectTypeOf(creationHandler.requests[0].raw.json).toEqualTypeOf<() => Promise<UserCreationRequestBody>>();
         expect(await creationHandler.requests[0].raw.json()).toEqual(creationPayload);
@@ -269,7 +279,9 @@ async function declareHttpInterceptorTests(options: ClientTestOptionsByWorkerTyp
         expectTypeOf(creationHandler.requests[0].response.body).toEqualTypeOf<ConflictError>();
         expect(creationHandler.requests[0].response.body).toEqual(conflictError);
 
-        expectTypeOf(creationHandler.requests[0].response.raw).toEqualTypeOf<HttpResponse<ConflictError, 409>>();
+        expectTypeOf(creationHandler.requests[0].response.raw).toEqualTypeOf<
+          HttpResponse<ConflictError, { 'content-type': 'application/json' }, 409>
+        >();
         expect(creationHandler.requests[0].response.raw).toBeInstanceOf(Response);
         expectTypeOf(creationHandler.requests[0].response.raw.json).toEqualTypeOf<() => Promise<ConflictError>>();
         expect(await creationHandler.requests[0].response.raw.json()).toEqual(conflictError);
@@ -336,7 +348,7 @@ async function declareHttpInterceptorTests(options: ClientTestOptionsByWorkerTyp
         expectTypeOf(listHandler.requests[0].body).toEqualTypeOf<null>();
         expect(listHandler.requests[0].body).toBe(null);
 
-        expectTypeOf(listHandler.requests[0].raw).toEqualTypeOf<HttpRequest<null>>();
+        expectTypeOf(listHandler.requests[0].raw).toEqualTypeOf<HttpRequest<null, never>>();
         expect(listHandler.requests[0].raw).toBeInstanceOf(Request);
         expectTypeOf(listHandler.requests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
         expect(await listHandler.requests[0].raw.text()).toBe('');
@@ -344,7 +356,9 @@ async function declareHttpInterceptorTests(options: ClientTestOptionsByWorkerTyp
         expectTypeOf(listHandler.requests[0].response.body).toEqualTypeOf<JSONSerialized<User>[]>();
         expect(listHandler.requests[0].response.body).toEqual(users.map(serializeUser));
 
-        expectTypeOf(listHandler.requests[0].response.raw).toEqualTypeOf<HttpResponse<JSONSerialized<User>[], 200>>();
+        expectTypeOf(listHandler.requests[0].response.raw).toEqualTypeOf<
+          HttpResponse<JSONSerialized<User>[], { 'content-type': 'application/json' }, 200>
+        >();
         expect(listHandler.requests[0].response.raw).toBeInstanceOf(Response);
         expectTypeOf(listHandler.requests[0].response.raw.json).toEqualTypeOf<() => Promise<JSONSerialized<User>[]>>();
         expect(await listHandler.requests[0].response.raw.json()).toEqual(users.map(serializeUser));
@@ -377,7 +391,7 @@ async function declareHttpInterceptorTests(options: ClientTestOptionsByWorkerTyp
         expectTypeOf(listHandler.requests[0].body).toEqualTypeOf<null>();
         expect(listHandler.requests[0].body).toBe(null);
 
-        expectTypeOf(listHandler.requests[0].raw).toEqualTypeOf<HttpRequest<null>>();
+        expectTypeOf(listHandler.requests[0].raw).toEqualTypeOf<HttpRequest<null, never>>();
         expect(listHandler.requests[0].raw).toBeInstanceOf(Request);
         expectTypeOf(listHandler.requests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
         expect(await listHandler.requests[0].raw.text()).toBe('');
@@ -385,7 +399,9 @@ async function declareHttpInterceptorTests(options: ClientTestOptionsByWorkerTyp
         expectTypeOf(listHandler.requests[0].response.body).toEqualTypeOf<JSONSerialized<User>[]>();
         expect(listHandler.requests[0].response.body).toEqual([serializeUser(user)]);
 
-        expectTypeOf(listHandler.requests[0].response.raw).toEqualTypeOf<HttpResponse<JSONSerialized<User>[], 200>>();
+        expectTypeOf(listHandler.requests[0].response.raw).toEqualTypeOf<
+          HttpResponse<JSONSerialized<User>[], { 'content-type': 'application/json' }, 200>
+        >();
         expect(listHandler.requests[0].response.raw).toBeInstanceOf(Response);
         expectTypeOf(listHandler.requests[0].response.raw.json).toEqualTypeOf<() => Promise<JSONSerialized<User>[]>>();
         expect(await listHandler.requests[0].response.raw.json()).toEqual([serializeUser(user)]);
@@ -422,7 +438,7 @@ async function declareHttpInterceptorTests(options: ClientTestOptionsByWorkerTyp
         expectTypeOf(listHandler.requests[0].body).toEqualTypeOf<null>();
         expect(listHandler.requests[0].body).toBe(null);
 
-        expectTypeOf(listHandler.requests[0].raw).toEqualTypeOf<HttpRequest<null>>();
+        expectTypeOf(listHandler.requests[0].raw).toEqualTypeOf<HttpRequest<null, never>>();
         expect(listHandler.requests[0].raw).toBeInstanceOf(Request);
         expectTypeOf(listHandler.requests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
         expect(await listHandler.requests[0].raw.text()).toBe('');
@@ -430,7 +446,9 @@ async function declareHttpInterceptorTests(options: ClientTestOptionsByWorkerTyp
         expectTypeOf(listHandler.requests[0].response.body).toEqualTypeOf<JSONSerialized<User>[]>();
         expect(listHandler.requests[0].response.body).toEqual(usersSortedByDescendingEmail.map(serializeUser));
 
-        expectTypeOf(listHandler.requests[0].response.raw).toEqualTypeOf<HttpResponse<JSONSerialized<User>[], 200>>();
+        expectTypeOf(listHandler.requests[0].response.raw).toEqualTypeOf<
+          HttpResponse<JSONSerialized<User>[], { 'content-type': 'application/json' }, 200>
+        >();
         expect(listHandler.requests[0].response.raw).toBeInstanceOf(Response);
         expectTypeOf(listHandler.requests[0].response.raw.json).toEqualTypeOf<() => Promise<JSONSerialized<User>[]>>();
         expect(await listHandler.requests[0].response.raw.json()).toEqual(
@@ -468,7 +486,7 @@ async function declareHttpInterceptorTests(options: ClientTestOptionsByWorkerTyp
         expectTypeOf(getHandler.requests[0].body).toEqualTypeOf<null>();
         expect(getHandler.requests[0].body).toBe(null);
 
-        expectTypeOf(getHandler.requests[0].raw).toEqualTypeOf<HttpRequest<null>>();
+        expectTypeOf(getHandler.requests[0].raw).toEqualTypeOf<HttpRequest<null, never>>();
         expect(getHandler.requests[0].raw).toBeInstanceOf(Request);
         expectTypeOf(getHandler.requests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
         expect(await getHandler.requests[0].raw.text()).toBe('');
@@ -476,7 +494,9 @@ async function declareHttpInterceptorTests(options: ClientTestOptionsByWorkerTyp
         expectTypeOf(getHandler.requests[0].response.body).toEqualTypeOf<JSONSerialized<User>>();
         expect(getHandler.requests[0].response.body).toEqual(serializeUser(user));
 
-        expectTypeOf(getHandler.requests[0].response.raw).toEqualTypeOf<HttpResponse<JSONSerialized<User>, 200>>();
+        expectTypeOf(getHandler.requests[0].response.raw).toEqualTypeOf<
+          HttpResponse<JSONSerialized<User>, { 'content-type': 'application/json' }, 200>
+        >();
         expect(getHandler.requests[0].response.raw).toBeInstanceOf(Response);
         expectTypeOf(getHandler.requests[0].response.raw.json).toEqualTypeOf<() => Promise<JSONSerialized<User>>>();
         expect(await getHandler.requests[0].response.raw.json()).toEqual(serializeUser(user));
@@ -510,7 +530,7 @@ async function declareHttpInterceptorTests(options: ClientTestOptionsByWorkerTyp
         expectTypeOf(getHandler.requests[0].body).toEqualTypeOf<null>();
         expect(getHandler.requests[0].body).toBe(null);
 
-        expectTypeOf(getHandler.requests[0].raw).toEqualTypeOf<HttpRequest<null>>();
+        expectTypeOf(getHandler.requests[0].raw).toEqualTypeOf<HttpRequest<null, never>>();
         expect(getHandler.requests[0].raw).toBeInstanceOf(Request);
         expectTypeOf(getHandler.requests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
         expect(await getHandler.requests[0].raw.text()).toBe('');
@@ -518,7 +538,9 @@ async function declareHttpInterceptorTests(options: ClientTestOptionsByWorkerTyp
         expectTypeOf(getHandler.requests[0].response.body).toEqualTypeOf<NotFoundError>();
         expect(getHandler.requests[0].response.body).toEqual(notFoundError);
 
-        expectTypeOf(getHandler.requests[0].response.raw).toEqualTypeOf<HttpResponse<NotFoundError, 404>>();
+        expectTypeOf(getHandler.requests[0].response.raw).toEqualTypeOf<
+          HttpResponse<NotFoundError, { 'content-type': 'application/json' }, 404>
+        >();
         expect(getHandler.requests[0].response.raw).toBeInstanceOf(Response);
         expectTypeOf(getHandler.requests[0].response.raw.json).toEqualTypeOf<() => Promise<NotFoundError>>();
         expect(await getHandler.requests[0].response.raw.json()).toEqual(notFoundError);
@@ -551,7 +573,7 @@ async function declareHttpInterceptorTests(options: ClientTestOptionsByWorkerTyp
         expectTypeOf(deleteHandler.requests[0].body).toEqualTypeOf<null>();
         expect(deleteHandler.requests[0].body).toBe(null);
 
-        expectTypeOf(deleteHandler.requests[0].raw).toEqualTypeOf<HttpRequest<null>>();
+        expectTypeOf(deleteHandler.requests[0].raw).toEqualTypeOf<HttpRequest<null, never>>();
         expect(deleteHandler.requests[0].raw).toBeInstanceOf(Request);
         expectTypeOf(deleteHandler.requests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
         expect(await deleteHandler.requests[0].raw.text()).toBe('');
@@ -559,7 +581,7 @@ async function declareHttpInterceptorTests(options: ClientTestOptionsByWorkerTyp
         expectTypeOf(deleteHandler.requests[0].response.body).toEqualTypeOf<null>();
         expect(deleteHandler.requests[0].response.body).toBe(null);
 
-        expectTypeOf(deleteHandler.requests[0].response.raw).toEqualTypeOf<HttpResponse<null, 204>>();
+        expectTypeOf(deleteHandler.requests[0].response.raw).toEqualTypeOf<HttpResponse<null, never, 204>>();
         expect(deleteHandler.requests[0].response.raw).toBeInstanceOf(Response);
         expectTypeOf(deleteHandler.requests[0].response.raw.json).toEqualTypeOf<() => Promise<null>>();
         expect(await deleteHandler.requests[0].response.raw.text()).toBe('');
@@ -593,7 +615,7 @@ async function declareHttpInterceptorTests(options: ClientTestOptionsByWorkerTyp
         expectTypeOf(deleteHandler.requests[0].body).toEqualTypeOf<null>();
         expect(deleteHandler.requests[0].body).toBe(null);
 
-        expectTypeOf(deleteHandler.requests[0].raw).toEqualTypeOf<HttpRequest<null>>();
+        expectTypeOf(deleteHandler.requests[0].raw).toEqualTypeOf<HttpRequest<null, never>>();
         expect(deleteHandler.requests[0].raw).toBeInstanceOf(Request);
         expectTypeOf(deleteHandler.requests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
         expect(await deleteHandler.requests[0].raw.text()).toBe('');
@@ -601,7 +623,9 @@ async function declareHttpInterceptorTests(options: ClientTestOptionsByWorkerTyp
         expectTypeOf(deleteHandler.requests[0].response.body).toEqualTypeOf<NotFoundError>();
         expect(deleteHandler.requests[0].response.body).toEqual(notFoundError);
 
-        expectTypeOf(deleteHandler.requests[0].response.raw).toEqualTypeOf<HttpResponse<NotFoundError, 404>>();
+        expectTypeOf(deleteHandler.requests[0].response.raw).toEqualTypeOf<
+          HttpResponse<NotFoundError, { 'content-type': 'application/json' }, 404>
+        >();
         expect(deleteHandler.requests[0].response.raw).toBeInstanceOf(Response);
         expectTypeOf(deleteHandler.requests[0].response.raw.json).toEqualTypeOf<() => Promise<NotFoundError>>();
         expect(await deleteHandler.requests[0].response.raw.json()).toEqual(notFoundError);
@@ -657,7 +681,7 @@ async function declareHttpInterceptorTests(options: ClientTestOptionsByWorkerTyp
         expectTypeOf(listHandler.requests[0].body).toEqualTypeOf<null>();
         expect(listHandler.requests[0].body).toBe(null);
 
-        expectTypeOf(listHandler.requests[0].raw).toEqualTypeOf<HttpRequest<null>>();
+        expectTypeOf(listHandler.requests[0].raw).toEqualTypeOf<HttpRequest<null, never>>();
         expect(listHandler.requests[0].raw).toBeInstanceOf(Request);
         expectTypeOf(listHandler.requests[0].raw.json).toEqualTypeOf<() => Promise<null>>();
         expect(await listHandler.requests[0].raw.text()).toBe('');
@@ -665,7 +689,9 @@ async function declareHttpInterceptorTests(options: ClientTestOptionsByWorkerTyp
         expectTypeOf(listHandler.requests[0].response.body).toEqualTypeOf<Notification[]>();
         expect(listHandler.requests[0].response.body).toEqual([notification]);
 
-        expectTypeOf(listHandler.requests[0].response.raw).toEqualTypeOf<HttpResponse<Notification[], 200>>();
+        expectTypeOf(listHandler.requests[0].response.raw).toEqualTypeOf<
+          HttpResponse<Notification[], { 'content-type': 'application/json' }, 200>
+        >();
         expect(listHandler.requests[0].response.raw).toBeInstanceOf(Response);
         expectTypeOf(listHandler.requests[0].response.raw.json).toEqualTypeOf<() => Promise<Notification[]>>();
         expect(await listHandler.requests[0].response.raw.json()).toEqual([notification]);

--- a/apps/zimic-test-client/tests/interceptor/thirdParty/shared/httpInterceptor.ts
+++ b/apps/zimic-test-client/tests/interceptor/thirdParty/shared/httpInterceptor.ts
@@ -558,10 +558,7 @@ async function declareHttpInterceptorTests(options: ClientTestOptionsByWorkerTyp
       async function updateUser(userId: string, payload: UserUpdatePayload) {
         const request = new Request(`${authBaseURL}/users/${userId}`, {
           method: 'PATCH',
-          headers: {
-            'content-type': 'application/json',
-            authorization: 'Bearer token',
-          },
+          headers: { 'content-type': 'application/json' },
           body: JSON.stringify(payload),
         });
         return fetch(request);
@@ -571,7 +568,7 @@ async function declareHttpInterceptorTests(options: ClientTestOptionsByWorkerTyp
         const updateHandler = await authInterceptor
           .patch(`/users/${user.id}`)
           .with({
-            headers: { 'content-type': 'application/json', authorization: 'Bearer token' },
+            headers: { 'content-type': 'application/json' },
             body: updatePayload,
           })
           .respond((request) => {
@@ -599,7 +596,7 @@ async function declareHttpInterceptorTests(options: ClientTestOptionsByWorkerTyp
         expect(updateHandler.requests).toHaveLength(1);
 
         expectTypeOf(updateHandler.requests[0].headers).branded.toEqualTypeOf<
-          HttpHeaders<{ 'content-type': 'application/json'; authorization: string }>
+          HttpHeaders<{ 'content-type': string }>
         >();
 
         expectTypeOf(updateHandler.requests[0].searchParams).toEqualTypeOf<HttpSearchParams<never>>();

--- a/apps/zimic-test-client/tests/types/schema.ts
+++ b/apps/zimic-test-client/tests/types/schema.ts
@@ -91,7 +91,7 @@ type UserByIdPaths = HttpSchema<{
 
     PATCH: {
       request: {
-        headers: { authorization: string };
+        headers: { 'content-type': string };
         body: UserUpdatePayload;
       };
       response: {

--- a/apps/zimic-test-client/tests/types/schema.ts
+++ b/apps/zimic-test-client/tests/types/schema.ts
@@ -57,7 +57,6 @@ type UserPaths = HttpSchema<{
   '/users': {
     POST: {
       request: {
-        headers: { 'content-type': 'application/json' };
         body: UserCreationRequestBody;
       };
       response: {
@@ -78,6 +77,8 @@ type UserPaths = HttpSchema<{
   };
 }>;
 
+export type UserUpdatePayload = Partial<JSONSerialized<User>>;
+
 type UserByIdPaths = HttpSchema<{
   '/users/:userId': {
     GET: {
@@ -90,11 +91,12 @@ type UserByIdPaths = HttpSchema<{
 
     PATCH: {
       request: {
-        headers: { 'content-type': 'application/json' };
-        body: Partial<JSONSerialized<User>>;
+        headers: { authorization: string };
+        body: UserUpdatePayload;
       };
       response: {
         200: { body: JSONSerialized<User> };
+        400: { body: ValidationError };
         404: { body: NotFoundError };
         500: { body: InternalServerError };
       };

--- a/packages/zimic-fetch/src/client/FetchClient.ts
+++ b/packages/zimic-fetch/src/client/FetchClient.ts
@@ -121,7 +121,7 @@ class FetchClient<Schema extends HttpSchema> implements Omit<Fetch<Schema>, 'def
     const fetchResponse = response as FetchResponse<Schema, Method, Path>;
 
     Object.defineProperty(fetchResponse, 'request', {
-      value: fetchRequest satisfies FetchResponse.Loose['request'],
+      value: fetchRequest,
       writable: false,
       enumerable: true,
       configurable: false,

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.json.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.json.test.ts
@@ -63,7 +63,7 @@ describe('FetchClient > Bodies > JSON', () => {
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
       expect(response.headers).toBeInstanceOf(Headers);
-      expectTypeOf(response.headers).toEqualTypeOf<StrictHeaders<never>>();
+      expectTypeOf(response.headers).toEqualTypeOf<StrictHeaders<{ 'content-type': 'application/json' }>>();
 
       expectTypeOf(response.json).toEqualTypeOf<() => Promise<User>>();
       expectTypeOf(response.text).toEqualTypeOf<() => Promise<string>>();
@@ -130,7 +130,7 @@ describe('FetchClient > Bodies > JSON', () => {
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
       expect(response.headers).toBeInstanceOf(Headers);
-      expectTypeOf(response.headers).toEqualTypeOf<StrictHeaders<never>>();
+      expectTypeOf(response.headers).toEqualTypeOf<StrictHeaders<{ 'content-type': 'application/json' }>>();
 
       expectTypeOf(response.json).toEqualTypeOf<() => Promise<number>>();
       expectTypeOf(response.text).toEqualTypeOf<() => Promise<string>>();
@@ -197,7 +197,7 @@ describe('FetchClient > Bodies > JSON', () => {
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
       expect(response.headers).toBeInstanceOf(Headers);
-      expectTypeOf(response.headers).toEqualTypeOf<StrictHeaders<never>>();
+      expectTypeOf(response.headers).toEqualTypeOf<StrictHeaders<{ 'content-type': 'application/json' }>>();
 
       expectTypeOf(response.json).toEqualTypeOf<() => Promise<boolean>>();
       expectTypeOf(response.text).toEqualTypeOf<() => Promise<string>>();

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.test.ts
@@ -28,13 +28,28 @@ describe('FetchClient > Bodies', () => {
 
       const fetch = createFetch<Schema>({ baseURL });
 
+      // @ts-expect-error The content type was not declared
       await fetch('/users', {
         method: 'POST',
         body: JSON.stringify({ name: 'User 1' }),
       });
 
+      // @ts-expect-error The content type is incorrect
       await fetch('/users', {
         method: 'POST',
+        headers: { 'content-type': 'other' },
+        body: JSON.stringify({ name: 'User 1' }),
+      });
+
+      await fetch('/users', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ name: 'User 1' }),
+      });
+
+      await fetch('/users', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
         body: JSON.stringify({}),
       });
 

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.headers.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.headers.test.ts
@@ -1,4 +1,4 @@
-import { HttpSchema, StrictHeaders, HttpHeaders } from '@zimic/http';
+import { HttpSchema, StrictHeaders, HttpHeaders, HttpFormData, HttpSearchParams } from '@zimic/http';
 import joinURL from '@zimic/utils/url/joinURL';
 import { describe, expect, expectTypeOf, it } from 'vitest';
 
@@ -403,7 +403,7 @@ describe('FetchClient > Headers', () => {
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
       expect(response.headers).toBeInstanceOf(Headers);
-      expectTypeOf(response.headers).toEqualTypeOf<StrictHeaders<ResponseHeaders>>();
+      expectTypeOf(response.headers).toEqualTypeOf<StrictHeaders<{ 'content-type': string }>>();
 
       expect(response.request).toBeInstanceOf(Request);
       expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'GET', '/users'>>();
@@ -455,7 +455,7 @@ describe('FetchClient > Headers', () => {
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
       expect(response.headers).toBeInstanceOf(Headers);
-      expectTypeOf(response.headers).toEqualTypeOf<StrictHeaders<ResponseHeaders>>();
+      expectTypeOf(response.headers).toEqualTypeOf<StrictHeaders<{ 'content-type': string }>>();
 
       expect(response.request).toBeInstanceOf(Request);
       expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'GET', '/users'>>();
@@ -511,7 +511,9 @@ describe('FetchClient > Headers', () => {
       expect(response.url).toBe(joinURL(baseURL, '/users'));
 
       expect(response.headers).toBeInstanceOf(Headers);
-      expectTypeOf(response.headers).toEqualTypeOf<StrictHeaders<ResponseHeaders>>();
+      expectTypeOf(response.headers).branded.toEqualTypeOf<
+        StrictHeaders<ResponseHeaders & { 'content-type': string }>
+      >();
 
       expect(response.request).toBeInstanceOf(Request);
       expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'GET', '/users'>>();
@@ -606,7 +608,7 @@ describe('FetchClient > Headers', () => {
         expect(response.url).toBe(joinURL(baseURL, '/users'));
 
         expect(response.headers).toBeInstanceOf(Headers);
-        expectTypeOf(response.headers).toEqualTypeOf<StrictHeaders<never>>();
+        expectTypeOf(response.headers).toEqualTypeOf<StrictHeaders<{ 'content-type': 'application/json' }>>();
 
         expect(response.request).toBeInstanceOf(Request);
         expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'GET', '/users'>>();
@@ -616,6 +618,206 @@ describe('FetchClient > Headers', () => {
         expect(response.request.headers).toBeInstanceOf(Headers);
         expectTypeOf(response.request.headers).toEqualTypeOf<StrictHeaders<never>>();
       }
+    });
+  });
+
+  it('should infer the content type of requests with a JSON body if none is provided', async () => {
+    type Schema = HttpSchema<{
+      '/users': {
+        POST: {
+          request: { body: User };
+          response: { 201: { body: User } };
+        };
+      };
+    }>;
+
+    await usingHttpInterceptor<Schema>({ baseURL }, async (interceptor) => {
+      const user = users[0];
+
+      await interceptor
+        .post('/users')
+        .with({ body: user })
+        .respond({
+          status: 201,
+          body: user,
+        })
+        .times(1);
+
+      const fetch = createFetch<Schema>({ baseURL });
+
+      const response = await fetch('/users', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(user),
+      });
+
+      expectResponseStatus(response, 201);
+      expect(await response.json()).toEqual(user);
+
+      expect(response).toBeInstanceOf(Response);
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'POST', '/users'>>();
+
+      expect(response.url).toBe(joinURL(baseURL, '/users'));
+
+      expect(response.request).toBeInstanceOf(Request);
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'POST', '/users'>>();
+
+      expect(response.request.url).toBe(joinURL(baseURL, '/users'));
+
+      expect(response.request.path).toBe('/users');
+      expectTypeOf(response.request.path).toEqualTypeOf<'/users'>();
+
+      expect(response.request.method).toBe('POST');
+      expectTypeOf(response.request.method).toEqualTypeOf<'POST'>();
+
+      expect(response.request.headers).toBeInstanceOf(Headers);
+      expectTypeOf(response.request.headers).toEqualTypeOf<StrictHeaders<{ 'content-type': 'application/json' }>>();
+    });
+  });
+
+  it('should not infer the content type of requests with a non-JSON body', async () => {
+    type Schema = HttpSchema<{
+      '/users': {
+        POST: {
+          request: {
+            body: HttpSearchParams<{ value?: string }> | HttpFormData<{ value?: string }> | Blob | string;
+          };
+          response: { 201: { body: User } };
+        };
+      };
+    }>;
+
+    await usingHttpInterceptor<Schema>({ baseURL }, async (interceptor) => {
+      const user = users[0];
+
+      const requestSearchParams = new HttpSearchParams({
+        value: user.name,
+      });
+
+      await interceptor
+        .post('/users')
+        .with({ body: requestSearchParams })
+        .respond({
+          status: 201,
+          body: user,
+        })
+        .times(1);
+
+      const fetch = createFetch<Schema>({ baseURL });
+
+      const response = await fetch('/users', {
+        method: 'POST',
+        body: requestSearchParams,
+      });
+
+      expectResponseStatus(response, 201);
+      expect(await response.json()).toEqual(user);
+
+      expect(response).toBeInstanceOf(Response);
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'POST', '/users'>>();
+
+      expect(response.url).toBe(joinURL(baseURL, '/users'));
+
+      expect(response.request).toBeInstanceOf(Request);
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'POST', '/users'>>();
+
+      expect(response.request.url).toBe(joinURL(baseURL, '/users'));
+
+      expect(response.request.path).toBe('/users');
+      expectTypeOf(response.request.path).toEqualTypeOf<'/users'>();
+
+      expect(response.request.method).toBe('POST');
+      expectTypeOf(response.request.method).toEqualTypeOf<'POST'>();
+
+      expect(response.request.headers).toBeInstanceOf(Headers);
+      expectTypeOf(response.request.headers).toEqualTypeOf<StrictHeaders<never>>();
+    });
+  });
+
+  it('should infer the content type of responses with a JSON body if none is provided', async () => {
+    type Schema = HttpSchema<{
+      '/users': {
+        POST: {
+          response: { 201: { body: User } };
+        };
+      };
+    }>;
+
+    await usingHttpInterceptor<Schema>({ baseURL }, async (interceptor) => {
+      const user = users[0];
+
+      await interceptor
+        .post('/users')
+        .respond({
+          status: 201,
+          body: user,
+        })
+        .times(1);
+
+      const fetch = createFetch<Schema>({ baseURL });
+
+      const response = await fetch('/users', {
+        method: 'POST',
+      });
+
+      expectResponseStatus(response, 201);
+      expect(await response.json()).toEqual(user);
+
+      expect(response).toBeInstanceOf(Response);
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'POST', '/users'>>();
+
+      expect(response.url).toBe(joinURL(baseURL, '/users'));
+
+      expect(response.headers).toBeInstanceOf(Headers);
+      expectTypeOf(response.headers).toEqualTypeOf<StrictHeaders<{ 'content-type': 'application/json' }>>();
+    });
+  });
+
+  it('should not infer the content type of responses with a non-JSON body', async () => {
+    type Schema = HttpSchema<{
+      '/users': {
+        POST: {
+          response: {
+            201: {
+              body: HttpSearchParams<{ value?: string }> | HttpFormData<{ value?: string }> | Blob | string;
+            };
+          };
+        };
+      };
+    }>;
+
+    await usingHttpInterceptor<Schema>({ baseURL }, async (interceptor) => {
+      const user = users[0];
+
+      const responseSearchParams = new HttpSearchParams({
+        value: user.name,
+      });
+
+      await interceptor
+        .post('/users')
+        .respond({
+          status: 201,
+          body: responseSearchParams,
+        })
+        .times(1);
+
+      const fetch = createFetch<Schema>({ baseURL });
+
+      const response = await fetch('/users', {
+        method: 'POST',
+      });
+
+      expectResponseStatus(response, 201);
+      const responseFormData = await response.formData();
+      expect(responseFormData.get('value')).toEqual(responseSearchParams.get('value'));
+
+      expect(response).toBeInstanceOf(Response);
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'POST', '/users'>>();
+
+      expect(response.url).toBe(joinURL(baseURL, '/users'));
+
+      expect(response.headers).toBeInstanceOf(Headers);
+      expectTypeOf(response.headers).toEqualTypeOf<StrictHeaders<never>>();
     });
   });
 });

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.headers.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.headers.test.ts
@@ -680,7 +680,7 @@ describe('FetchClient > Headers', () => {
       '/users': {
         POST: {
           request: {
-            headers: { authorization: string; accept?: string };
+            headers: { accept?: string };
             body: User;
           };
           response: { 201: { body: User } };
@@ -694,7 +694,7 @@ describe('FetchClient > Headers', () => {
       await interceptor
         .post('/users')
         .with({
-          headers: { authorization: 'Bearer token' },
+          headers: { accept: 'application/json' },
           body: user,
         })
         .respond({
@@ -707,7 +707,7 @@ describe('FetchClient > Headers', () => {
 
       const response = await fetch('/users', {
         method: 'POST',
-        headers: { 'content-type': 'application/json', authorization: 'Bearer token' },
+        headers: { 'content-type': 'application/json', accept: 'application/json' },
         body: JSON.stringify(user),
       });
 
@@ -732,7 +732,7 @@ describe('FetchClient > Headers', () => {
 
       expect(response.request.headers).toBeInstanceOf(Headers);
       expectTypeOf(response.request.headers).branded.toEqualTypeOf<
-        StrictHeaders<{ 'content-type': 'application/json'; authorization: string; accept?: string }>
+        StrictHeaders<{ 'content-type': 'application/json'; accept?: string }>
       >();
     });
   });

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.headers.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.headers.test.ts
@@ -675,6 +675,127 @@ describe('FetchClient > Headers', () => {
     });
   });
 
+  it('should combine the inferred content type of requests with a JSON body with existing headers', async () => {
+    type Schema = HttpSchema<{
+      '/users': {
+        POST: {
+          request: {
+            headers: { authorization: string; accept?: string };
+            body: User;
+          };
+          response: { 201: { body: User } };
+        };
+      };
+    }>;
+
+    await usingHttpInterceptor<Schema>({ baseURL }, async (interceptor) => {
+      const user = users[0];
+
+      await interceptor
+        .post('/users')
+        .with({
+          headers: { authorization: 'Bearer token' },
+          body: user,
+        })
+        .respond({
+          status: 201,
+          body: user,
+        })
+        .times(1);
+
+      const fetch = createFetch<Schema>({ baseURL });
+
+      const response = await fetch('/users', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', authorization: 'Bearer token' },
+        body: JSON.stringify(user),
+      });
+
+      expectResponseStatus(response, 201);
+      expect(await response.json()).toEqual(user);
+
+      expect(response).toBeInstanceOf(Response);
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'POST', '/users'>>();
+
+      expect(response.url).toBe(joinURL(baseURL, '/users'));
+
+      expect(response.request).toBeInstanceOf(Request);
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'POST', '/users'>>();
+
+      expect(response.request.url).toBe(joinURL(baseURL, '/users'));
+
+      expect(response.request.path).toBe('/users');
+      expectTypeOf(response.request.path).toEqualTypeOf<'/users'>();
+
+      expect(response.request.method).toBe('POST');
+      expectTypeOf(response.request.method).toEqualTypeOf<'POST'>();
+
+      expect(response.request.headers).toBeInstanceOf(Headers);
+      expectTypeOf(response.request.headers).branded.toEqualTypeOf<
+        StrictHeaders<{ 'content-type': 'application/json'; authorization: string; accept?: string }>
+      >();
+    });
+  });
+
+  it('should not infer the content type of requests with a JSON body if a content type is already declared', async () => {
+    type Schema = HttpSchema<{
+      '/users': {
+        POST: {
+          request: {
+            headers: { 'content-type': `application/json;charset=${string}` };
+            body: User;
+          };
+          response: { 201: { body: User } };
+        };
+      };
+    }>;
+
+    await usingHttpInterceptor<Schema>({ baseURL }, async (interceptor) => {
+      const user = users[0];
+
+      await interceptor
+        .post('/users')
+        .with({ body: user })
+        .respond({
+          status: 201,
+          body: user,
+        })
+        .times(1);
+
+      const fetch = createFetch<Schema>({ baseURL });
+
+      const response = await fetch('/users', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json;charset=utf-8' },
+        body: JSON.stringify(user),
+      });
+
+      expectResponseStatus(response, 201);
+      expect(await response.json()).toEqual(user);
+
+      expect(response).toBeInstanceOf(Response);
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'POST', '/users'>>();
+
+      expect(response.url).toBe(joinURL(baseURL, '/users'));
+
+      expect(response.request).toBeInstanceOf(Request);
+      expectTypeOf(response.request satisfies Request).toEqualTypeOf<FetchRequest<Schema, 'POST', '/users'>>();
+
+      expect(response.request.url).toBe(joinURL(baseURL, '/users'));
+
+      expect(response.request.path).toBe('/users');
+      expectTypeOf(response.request.path).toEqualTypeOf<'/users'>();
+
+      expect(response.request.method).toBe('POST');
+      expectTypeOf(response.request.method).toEqualTypeOf<'POST'>();
+
+      expect(response.request.headers).toBeInstanceOf(Headers);
+      expectTypeOf(response.request.headers).toEqualTypeOf<
+        StrictHeaders<{ 'content-type': `application/json;charset=${string}` }>
+      >();
+    });
+  });
+
   it('should not infer the content type of requests with a non-JSON body', async () => {
     type Schema = HttpSchema<{
       '/users': {
@@ -770,6 +891,99 @@ describe('FetchClient > Headers', () => {
 
       expect(response.headers).toBeInstanceOf(Headers);
       expectTypeOf(response.headers).toEqualTypeOf<StrictHeaders<{ 'content-type': 'application/json' }>>();
+    });
+  });
+
+  it('should combine the inferred content type of responses with a JSON body with existing headers', async () => {
+    type Schema = HttpSchema<{
+      '/users': {
+        POST: {
+          response: {
+            201: {
+              headers: { 'content-language': string; 'x-custom'?: string };
+              body: User;
+            };
+          };
+        };
+      };
+    }>;
+
+    await usingHttpInterceptor<Schema>({ baseURL }, async (interceptor) => {
+      const user = users[0];
+
+      await interceptor
+        .post('/users')
+        .respond({
+          status: 201,
+          headers: { 'content-language': 'en', 'x-custom': 'custom-value' },
+          body: user,
+        })
+        .times(1);
+
+      const fetch = createFetch<Schema>({ baseURL });
+
+      const response = await fetch('/users', {
+        method: 'POST',
+      });
+
+      expectResponseStatus(response, 201);
+      expect(await response.json()).toEqual(user);
+
+      expect(response).toBeInstanceOf(Response);
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'POST', '/users'>>();
+
+      expect(response.url).toBe(joinURL(baseURL, '/users'));
+
+      expect(response.headers).toBeInstanceOf(Headers);
+      expectTypeOf(response.headers).branded.toEqualTypeOf<
+        StrictHeaders<{ 'content-type': 'application/json'; 'content-language': string; 'x-custom'?: string }>
+      >();
+    });
+  });
+
+  it('should not infer the content type of responses with a JSON body if a content type is already declared', async () => {
+    type Schema = HttpSchema<{
+      '/users': {
+        POST: {
+          response: {
+            201: {
+              headers: { 'content-type': `application/json;charset=${string}` };
+              body: User;
+            };
+          };
+        };
+      };
+    }>;
+
+    await usingHttpInterceptor<Schema>({ baseURL }, async (interceptor) => {
+      const user = users[0];
+
+      await interceptor
+        .post('/users')
+        .respond({
+          status: 201,
+          body: user,
+        })
+        .times(1);
+
+      const fetch = createFetch<Schema>({ baseURL });
+
+      const response = await fetch('/users', {
+        method: 'POST',
+      });
+
+      expectResponseStatus(response, 201);
+      expect(await response.json()).toEqual(user);
+
+      expect(response).toBeInstanceOf(Response);
+      expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'POST', '/users'>>();
+
+      expect(response.url).toBe(joinURL(baseURL, '/users'));
+
+      expect(response.headers).toBeInstanceOf(Headers);
+      expectTypeOf(response.headers).toEqualTypeOf<
+        StrictHeaders<{ 'content-type': `application/json;charset=${string}` }>
+      >();
     });
   });
 

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.listeners.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.listeners.test.ts
@@ -737,7 +737,9 @@ describe('FetchClient > Listeners', () => {
       expect(response.url).toBe('');
 
       expect(response.headers).toBeInstanceOf(Headers);
-      expectTypeOf(response.headers).toEqualTypeOf<StrictHeaders<{ 'content-language'?: string }>>();
+      expectTypeOf(response.headers).branded.toEqualTypeOf<
+        StrictHeaders<{ 'content-language'?: string; 'content-type': 'application/json' }>
+      >();
       expect(response.headers.get('content-language')).toBe('en');
 
       expect(response.request).toBeInstanceOf(Request);
@@ -917,7 +919,9 @@ describe('FetchClient > Listeners', () => {
       expect(response.url).toBe('');
 
       expect(response.headers).toBeInstanceOf(Headers);
-      expectTypeOf(response.headers).toEqualTypeOf<StrictHeaders<{ 'content-language'?: string }>>();
+      expectTypeOf(response.headers).branded.toEqualTypeOf<
+        StrictHeaders<{ 'content-language'?: string; 'content-type': 'application/json' }>
+      >();
       expect(response.headers.get('content-language')).toBe('en');
 
       expect(response.request).toBeInstanceOf(Request);

--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.methods.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.methods.test.ts
@@ -747,17 +747,25 @@ describe('FetchClient > Methods', () => {
     type Schema = HttpSchema<{
       '/users': {
         DELETE: {
+          request: {
+            headers: { 'content-type': 'application/json' };
+            body: User;
+          };
           response: { 204: {} };
         };
       };
     }>;
 
     await usingHttpInterceptor<Schema>({ baseURL }, async (interceptor) => {
-      await interceptor.delete('/users').respond({ status: 204 }).times(1);
+      await interceptor.delete('/users').with({ body: users[0] }).respond({ status: 204 }).times(1);
 
       const fetch = createFetch<Schema>({ baseURL });
 
-      const response = await fetch('/users', { method: 'DELETE' });
+      const response = await fetch('/users', {
+        method: 'DELETE',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(users[0]),
+      });
 
       expectResponseStatus(response, 204);
       expect(await response.text()).toBe('');
@@ -777,6 +785,9 @@ describe('FetchClient > Methods', () => {
 
       expect(response.request.method).toBe('DELETE');
       expectTypeOf(response.request.method).toEqualTypeOf<'DELETE'>();
+
+      expect(response.request.headers).toBeInstanceOf(Headers);
+      expectTypeOf(response.request.headers).toEqualTypeOf<StrictHeaders<{ 'content-type': 'application/json' }>>();
     });
   });
 
@@ -947,7 +958,7 @@ describe('FetchClient > Methods', () => {
     });
   });
 
-  it('should support making HEAD requests', async () => {
+  it('should support making HEAD requests with a Request instance', async () => {
     type Schema = HttpSchema<{
       '/users': {
         HEAD: {
@@ -1169,7 +1180,7 @@ describe('FetchClient > Methods', () => {
       expect(getResponse.url).toBe(joinURL(baseURL, '/users'));
 
       expect(getResponse.headers).toBeInstanceOf(Headers);
-      expectTypeOf(getResponse.headers).toEqualTypeOf<StrictHeaders<never>>();
+      expectTypeOf(getResponse.headers).toEqualTypeOf<StrictHeaders<{ 'content-type': 'application/json' }>>();
 
       expectTypeOf(getResponse.json).toEqualTypeOf<() => Promise<User[]>>();
       expectTypeOf(getResponse.formData).toEqualTypeOf<() => Promise<FormData>>();
@@ -1215,7 +1226,7 @@ describe('FetchClient > Methods', () => {
       expect(patchResponse.url).toBe(joinURL(baseURL, '/users'));
 
       expect(patchResponse.headers).toBeInstanceOf(Headers);
-      expectTypeOf(patchResponse.headers).toEqualTypeOf<StrictHeaders<never>>();
+      expectTypeOf(patchResponse.headers).toEqualTypeOf<StrictHeaders<{ 'content-type': 'application/json' }>>();
 
       expectTypeOf(patchResponse.json).toEqualTypeOf<() => Promise<User>>();
       expectTypeOf(patchResponse.formData).toEqualTypeOf<() => Promise<FormData>>();

--- a/packages/zimic-fetch/src/client/types/requests.ts
+++ b/packages/zimic-fetch/src/client/types/requests.ts
@@ -22,6 +22,8 @@ import {
   HttpBody,
   HttpRequestBodySchema,
   HttpRequestSearchParamsSchema,
+  HttpSearchParams,
+  HttpFormData,
 } from '@zimic/http';
 import { Default } from '@zimic/utils/types';
 
@@ -46,13 +48,13 @@ type FetchRequestInitWithSearchParams<SearchParamsSchema extends HttpSearchParam
 type FetchRequestBodySchema<RequestSchema extends HttpRequestSchema> = 'body' extends keyof RequestSchema
   ? [RequestSchema['body']] extends [never]
     ? null | undefined
-    : RequestSchema['body'] extends BodyInit
+    : [Extract<RequestSchema['body'], BodyInit | HttpSearchParams | HttpFormData>] extends [never]
       ? undefined extends RequestSchema['body']
-        ? RequestSchema['body'] | null
-        : RequestSchema['body']
-      : undefined extends RequestSchema['body']
         ? JSONStringified<Exclude<RequestSchema['body'], null | undefined>> | null | undefined
         : JSONStringified<Exclude<RequestSchema['body'], null>> | Extract<RequestSchema['body'], null>
+      : undefined extends RequestSchema['body']
+        ? RequestSchema['body'] | null
+        : RequestSchema['body']
   : null | undefined;
 
 type FetchRequestInitWithBody<BodySchema extends HttpBody> = [BodySchema] extends [never]
@@ -248,8 +250,8 @@ export interface FetchResponsePerStatusCode<
   StatusCode extends HttpStatusCode = HttpStatusCode,
 > extends HttpResponse<
     HttpResponseBodySchema<Default<Schema[Path][Method]>, StatusCode>,
-    StatusCode,
-    Default<HttpResponseHeadersSchema<Default<Schema[Path][Method]>, StatusCode>>
+    Default<HttpResponseHeadersSchema<Default<Schema[Path][Method]>, StatusCode>>,
+    StatusCode
   > {
   /** The request that originated the response. */
   request: FetchRequest<Schema, Method, Path>;

--- a/packages/zimic-http/README.md
+++ b/packages/zimic-http/README.md
@@ -144,7 +144,7 @@ Check our [getting started guide](https://github.com/zimicjs/zimic/wiki/gettingâ
      type UserListHeaders = Schema['/users']['GET']['request']['headers'];
 
      const headers = new HttpHeaders<UserListHeaders>({
-       authorization: 'Bearer token',
+       authorization: 'Bearer my-token',
      });
 
      type UserListSearchParams = Schema['/users']['GET']['request']['searchParams'];

--- a/packages/zimic-http/src/formData/HttpFormData.ts
+++ b/packages/zimic-http/src/formData/HttpFormData.ts
@@ -29,21 +29,20 @@ import { HttpFormDataSchema, HttpFormDataSchemaName, HttpFormDataSerialized } fr
  *
  * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐http#httpformdata `HttpFormData` API reference}
  */
-class HttpFormData<
-  LooseSchema extends HttpFormDataSchema.Loose = HttpFormDataSchema.Loose,
-  Schema extends HttpFormDataSchema = HttpFormDataSerialized<LooseSchema>,
-> extends FormData {
+class HttpFormData<LooseSchema extends HttpFormDataSchema.Loose = HttpFormDataSchema.Loose> extends FormData {
+  readonly _schema!: HttpFormDataSerialized<LooseSchema>;
+
   /** @see {@link https://developer.mozilla.org/docs/Web/API/FormData/set MDN Reference} */
-  set<Name extends HttpFormDataSchemaName<Schema>>(
+  set<Name extends HttpFormDataSchemaName<this['_schema']>>(
     name: Name,
     value: Exclude<ArrayItemIfArray<NonNullable<LooseSchema[Name]>>, Blob>,
   ): void;
-  set<Name extends HttpFormDataSchemaName<Schema>>(
+  set<Name extends HttpFormDataSchemaName<this['_schema']>>(
     name: Name,
     blob: Exclude<ArrayItemIfArray<NonNullable<LooseSchema[Name]>>, string>,
     fileName?: string,
   ): void;
-  set<Name extends HttpFormDataSchemaName<Schema>>(
+  set<Name extends HttpFormDataSchemaName<this['_schema']>>(
     name: Name,
     blobOrValue: ArrayItemIfArray<NonNullable<LooseSchema[Name]>>,
     fileName?: string,
@@ -56,16 +55,16 @@ class HttpFormData<
   }
 
   /** @see {@link https://developer.mozilla.org/docs/Web/API/FormData/append MDN Reference} */
-  append<Name extends HttpFormDataSchemaName<Schema>>(
+  append<Name extends HttpFormDataSchemaName<this['_schema']>>(
     name: Name,
     value: Exclude<ArrayItemIfArray<NonNullable<LooseSchema[Name]>>, Blob>,
   ): void;
-  append<Name extends HttpFormDataSchemaName<Schema>>(
+  append<Name extends HttpFormDataSchemaName<this['_schema']>>(
     name: Name,
     blob: Exclude<ArrayItemIfArray<NonNullable<LooseSchema[Name]>>, string>,
     fileName?: string,
   ): void;
-  append<Name extends HttpFormDataSchemaName<Schema>>(
+  append<Name extends HttpFormDataSchemaName<this['_schema']>>(
     name: Name,
     blobOrValue: ArrayItemIfArray<NonNullable<LooseSchema[Name]>>,
     fileName?: string,
@@ -86,10 +85,10 @@ class HttpFormData<
    * @returns The value associated with the key name, or `null` if the key does not exist.
    * @see {@link https://developer.mozilla.org/docs/Web/API/FormData/get MDN Reference}
    */
-  get<Name extends HttpFormDataSchemaName.NonArray<Schema>>(
+  get<Name extends HttpFormDataSchemaName.NonArray<this['_schema']>>(
     name: Name,
-  ): ReplaceBy<ReplaceBy<ArrayItemIfArray<Schema[Name]>, undefined, null>, Blob, File> {
-    return super.get(name) as ReplaceBy<ReplaceBy<ArrayItemIfArray<Schema[Name]>, undefined, null>, Blob, File>;
+  ): ReplaceBy<ReplaceBy<ArrayItemIfArray<this['_schema'][Name]>, undefined, null>, Blob, File> {
+    return super.get(name) as never;
   }
 
   /**
@@ -101,27 +100,27 @@ class HttpFormData<
    * @returns An array of values associated with the key name, or an empty array if the key does not exist.
    * @see {@link https://developer.mozilla.org/docs/Web/API/FormData/getAll MDN Reference}
    */
-  getAll<Name extends HttpFormDataSchemaName.Array<Schema>>(
+  getAll<Name extends HttpFormDataSchemaName.Array<this['_schema']>>(
     name: Name,
-  ): ReplaceBy<ArrayItemIfArray<NonNullable<Schema[Name]>>, Blob, File>[] {
-    return super.getAll(name) as ReplaceBy<ArrayItemIfArray<NonNullable<Schema[Name]>>, Blob, File>[];
+  ): ReplaceBy<ArrayItemIfArray<NonNullable<this['_schema'][Name]>>, Blob, File>[] {
+    return super.getAll(name) as never;
   }
 
   /** @see {@link https://developer.mozilla.org/docs/Web/API/FormData/has MDN Reference} */
-  has<Name extends HttpFormDataSchemaName<Schema>>(name: Name): boolean {
+  has<Name extends HttpFormDataSchemaName<this['_schema']>>(name: Name): boolean {
     return super.has(name);
   }
 
   /** @see {@link https://developer.mozilla.org/docs/Web/API/FormData/delete MDN Reference} */
-  delete<Name extends HttpFormDataSchemaName<Schema>>(name: Name): void {
+  delete<Name extends HttpFormDataSchemaName<this['_schema']>>(name: Name): void {
     super.delete(name);
   }
 
-  forEach<This extends HttpFormData<Schema>>(
-    callback: <Key extends HttpFormDataSchemaName<Schema>>(
-      value: ReplaceBy<ArrayItemIfArray<NonNullable<Schema[Key]>>, Blob, File>,
+  forEach<This extends HttpFormData<this['_schema']>>(
+    callback: <Key extends HttpFormDataSchemaName<this['_schema']>>(
+      value: ReplaceBy<ArrayItemIfArray<NonNullable<this['_schema'][Key]>>, Blob, File>,
       key: Key,
-      parent: HttpFormData<Schema>,
+      parent: HttpFormData<this['_schema']>,
     ) => void,
     thisArg?: This,
   ): void {
@@ -129,46 +128,34 @@ class HttpFormData<
   }
 
   /** @see {@link https://developer.mozilla.org/docs/Web/API/FormData/keys MDN Reference} */
-  keys(): FormDataIterator<HttpFormDataSchemaName<Schema>> {
-    return super.keys() as FormDataIterator<HttpFormDataSchemaName<Schema>>;
+  keys(): FormDataIterator<HttpFormDataSchemaName<this['_schema']>> {
+    return super.keys() as never;
   }
 
   /** @see {@link https://developer.mozilla.org/docs/Web/API/FormData/values MDN Reference} */
   values(): FormDataIterator<
-    ReplaceBy<ArrayItemIfArray<NonNullable<Schema[HttpFormDataSchemaName<Schema>]>>, Blob, File>
+    ReplaceBy<ArrayItemIfArray<NonNullable<this['_schema'][HttpFormDataSchemaName<this['_schema']>]>>, Blob, File>
   > {
-    return super.values() as FormDataIterator<
-      ReplaceBy<ArrayItemIfArray<NonNullable<Schema[HttpFormDataSchemaName<Schema>]>>, Blob, File>
-    >;
+    return super.values() as never;
   }
 
   /** @see {@link https://developer.mozilla.org/docs/Web/API/FormData/entries MDN Reference} */
   entries(): FormDataIterator<
     [
-      HttpFormDataSchemaName<Schema>,
-      ReplaceBy<ArrayItemIfArray<NonNullable<Schema[HttpFormDataSchemaName<Schema>]>>, Blob, File>,
+      HttpFormDataSchemaName<this['_schema']>,
+      ReplaceBy<ArrayItemIfArray<NonNullable<this['_schema'][HttpFormDataSchemaName<this['_schema']>]>>, Blob, File>,
     ]
   > {
-    return super.entries() as FormDataIterator<
-      [
-        HttpFormDataSchemaName<Schema>,
-        ReplaceBy<ArrayItemIfArray<NonNullable<Schema[HttpFormDataSchemaName<Schema>]>>, Blob, File>,
-      ]
-    >;
+    return super.entries() as never;
   }
 
   [Symbol.iterator](): FormDataIterator<
     [
-      HttpFormDataSchemaName<Schema>,
-      ReplaceBy<ArrayItemIfArray<NonNullable<Schema[HttpFormDataSchemaName<Schema>]>>, Blob, File>,
+      HttpFormDataSchemaName<this['_schema']>,
+      ReplaceBy<ArrayItemIfArray<NonNullable<this['_schema'][HttpFormDataSchemaName<this['_schema']>]>>, Blob, File>,
     ]
   > {
-    return super[Symbol.iterator]() as FormDataIterator<
-      [
-        HttpFormDataSchemaName<Schema>,
-        ReplaceBy<ArrayItemIfArray<NonNullable<Schema[HttpFormDataSchemaName<Schema>]>>, Blob, File>,
-      ]
-    >;
+    return super[Symbol.iterator]() as never;
   }
 
   /**
@@ -256,13 +243,13 @@ class HttpFormData<
    * @returns A plain object representation of this form data.
    */
   toObject() {
-    const object = {} as Schema;
+    const object = {} as this['_schema'];
 
-    type SchemaValue = Schema[HttpFormDataSchemaName<Schema>];
+    type SchemaValue = this['_schema'][HttpFormDataSchemaName<this['_schema']>];
 
     for (const [key, value] of this.entries()) {
       if (key in object) {
-        const existingValue = object[key];
+        const existingValue = object[key] as SchemaValue[];
 
         if (Array.isArray<SchemaValue>(existingValue)) {
           existingValue.push(value as SchemaValue);

--- a/packages/zimic-http/src/formData/__tests__/HttpFormData.test.ts
+++ b/packages/zimic-http/src/formData/__tests__/HttpFormData.test.ts
@@ -46,7 +46,7 @@ describe('HttpFormData', async () => {
     formData.set('enabled', true);
 
     const enabledField = formData.get('enabled');
-    expectTypeOf(enabledField).toEqualTypeOf<`${boolean}` | null>();
+    expectTypeOf(enabledField).toEqualTypeOf<`${boolean}` | 'null'>();
     expect(enabledField).toEqual('true');
 
     formData.set('file', file);
@@ -590,7 +590,7 @@ describe('HttpFormData', async () => {
 
         requiredEnum: 'value1' | 'value2';
         optionalEnum?: 'value1' | 'value2';
-        nullableString: string | null;
+        nullableNumber: number | null;
 
         blob: Blob;
         blobArray: Blob[];
@@ -622,7 +622,7 @@ describe('HttpFormData', async () => {
 
         requiredEnum: 'value1' | 'value2';
         optionalEnum?: 'value1' | 'value2';
-        nullableString: string | null;
+        nullableNumber: `${number}` | 'null';
 
         blob: Blob;
         blobArray: Blob[];
@@ -630,14 +630,15 @@ describe('HttpFormData', async () => {
         stringArray: string[];
         numberArray: `${number}`[];
         booleanArray: `${boolean}`[];
-      }>();
 
-      expectTypeOf<HttpFormDataSerialized<string[]>>().toEqualTypeOf<never>();
-      expectTypeOf<HttpFormDataSerialized<Date>>().toEqualTypeOf<never>();
-      expectTypeOf<HttpFormDataSerialized<() => void>>().toEqualTypeOf<never>();
-      expectTypeOf<HttpFormDataSerialized<symbol>>().toEqualTypeOf<never>();
-      expectTypeOf<HttpFormDataSerialized<Map<never, never>>>().toEqualTypeOf<never>();
-      expectTypeOf<HttpFormDataSerialized<Set<never>>>().toEqualTypeOf<never>();
+        object: string;
+
+        date: string;
+        method: string;
+        map: string;
+        set: string;
+        error: string;
+      }>();
     });
   });
 });

--- a/packages/zimic-http/src/formData/types.ts
+++ b/packages/zimic-http/src/formData/types.ts
@@ -50,61 +50,55 @@ export namespace HttpFormDataSchemaName {
  */
 export type HttpFormDataSchemaName<Schema extends HttpFormDataSchema> = IfNever<Schema, never, keyof Schema & string>;
 
-type PrimitiveHttpFormDataSerialized<Type> = Type extends HttpFormDataSchema[string]
-  ? Type
-  : Type extends (infer ArrayItem)[]
-    ? ArrayItem extends (infer _InternalArrayItem)[]
-      ? never
-      : PrimitiveHttpFormDataSerialized<ArrayItem>[]
-    : Type extends number
-      ? `${number}`
-      : Type extends boolean
-        ? `${boolean}`
-        : never;
+type PrimitiveHttpFormDataSerialized<Type> = [Type] extends [never]
+  ? never
+  : Type extends number
+    ? `${number}`
+    : Type extends boolean
+      ? `${boolean}`
+      : Type extends null
+        ? 'null'
+        : Type extends symbol
+          ? never
+          : Type extends HttpFormDataSchema[string]
+            ? Type
+            : Type extends (infer ArrayItem)[]
+              ? ArrayItem extends (infer _InternalArrayItem)[]
+                ? never
+                : PrimitiveHttpFormDataSerialized<ArrayItem>[]
+              : string;
 
 /**
  * Recursively converts a schema to its {@link https://developer.mozilla.org/docs/Web/API/FormData FormData}-serialized
- * version. Numbers and booleans are converted to `${number}` and `${boolean}` respectively, and not serializable values
- * are excluded, such as functions and dates.
+ * version. Numbers, booleans, and null are converted to `${number}`, `${boolean}`, and 'null' respectively, and other
+ * values become strings.
  *
  * @example
  *   import { type HttpFormDataSerialized } from '@zimic/http';
  *
  *   type Schema = HttpFormDataSerialized<{
- *     contentTitle: string | null;
- *     contentSize: number;
+ *     contentTitle: string;
+ *     contentSize: number | null;
  *     content: Blob;
  *     full?: boolean;
- *     date: Date;
- *     method: () => void;
  *   }>;
  *   // {
- *   //   contentTitle: string | null;
- *   //   contentSize? `${number}`;
+ *   //   contentTitle: string;
+ *   //   contentSize? `${number}` | 'null';
  *   //   content: Blob;
  *   //   full?: "false" | "true";
  *   // }
  */
-export type HttpFormDataSerialized<Type> = Type extends HttpFormDataSchema
-  ? Type
-  : Type extends (infer _ArrayItem)[]
-    ? never
-    : Type extends Date
-      ? never
-      : Type extends (...parameters: never[]) => unknown
-        ? never
-        : Type extends symbol
-          ? never
-          : Type extends Map<infer _Key, infer _Value>
-            ? never
-            : Type extends Set<infer _Value>
-              ? never
-              : Type extends object
-                ? {
-                    [Key in keyof Type as IfNever<
-                      PrimitiveHttpFormDataSerialized<Type[Key]>,
-                      never,
-                      Key
-                    >]: PrimitiveHttpFormDataSerialized<Type[Key]>;
-                  }
-                : never;
+export type HttpFormDataSerialized<Type> = [Type] extends [never]
+  ? never
+  : Type extends HttpFormDataSchema
+    ? Type
+    : Type extends object
+      ? {
+          [Key in keyof Type as IfNever<
+            PrimitiveHttpFormDataSerialized<Type[Key]>,
+            never,
+            Key
+          >]: PrimitiveHttpFormDataSerialized<Type[Key]>;
+        }
+      : never;

--- a/packages/zimic-http/src/headers/HttpHeaders.ts
+++ b/packages/zimic-http/src/headers/HttpHeaders.ts
@@ -31,10 +31,9 @@ function pickPrimitiveProperties<LooseSchema extends HttpHeadersSchema.Loose>(sc
  *
  * @see {@link https://github.com/zimicjs/zimic/wiki/api‐zimic‐http#httpheaders `HttpHeaders` API reference}
  */
-class HttpHeaders<
-  LooseSchema extends HttpHeadersSchema.Loose = HttpHeadersSchema.Loose,
-  Schema extends HttpHeadersSchema = HttpHeadersSerialized<LooseSchema>,
-> extends Headers {
+class HttpHeaders<LooseSchema extends HttpHeadersSchema.Loose = HttpHeadersSchema.Loose> extends Headers {
+  readonly _schema!: HttpHeadersSerialized<LooseSchema>;
+
   constructor(init?: HttpHeadersInit<LooseSchema>) {
     if (init instanceof Headers || Array.isArray(init) || !init) {
       super(init);
@@ -44,38 +43,40 @@ class HttpHeaders<
   }
 
   /** @see {@link https://developer.mozilla.org/docs/Web/API/Headers/set MDN Reference} */
-  set<Name extends HttpHeadersSchemaName<Schema>>(name: Name, value: NonNullable<LooseSchema[Name]>): void {
+  set<Name extends HttpHeadersSchemaName<this['_schema']>>(name: Name, value: NonNullable<LooseSchema[Name]>): void {
     super.set(name, value);
   }
 
   /** @see {@link https://developer.mozilla.org/docs/Web/API/Headers/append MDN Reference} */
-  append<Name extends HttpHeadersSchemaName<Schema>>(name: Name, value: NonNullable<LooseSchema[Name]>): void {
+  append<Name extends HttpHeadersSchemaName<this['_schema']>>(name: Name, value: NonNullable<LooseSchema[Name]>): void {
     super.append(name, value);
   }
 
   /** @see {@link https://developer.mozilla.org/docs/Web/API/Headers/get MDN Reference} */
-  get<Name extends HttpHeadersSchemaName<Schema>>(name: Name): ReplaceBy<Schema[Name], undefined, null> {
-    return super.get(name) as ReplaceBy<Schema[Name], undefined, null>;
+  get<Name extends HttpHeadersSchemaName<this['_schema']>>(
+    name: Name,
+  ): ReplaceBy<this['_schema'][Name], undefined, null> {
+    return super.get(name) as never;
   }
 
   /** @see {@link https://developer.mozilla.org/docs/Web/API/Headers/has MDN Reference} */
-  getSetCookie(): NonNullable<Default<Schema['Set-Cookie'], string>>[] {
-    return super.getSetCookie() as NonNullable<Default<Schema['Set-Cookie'], string>>[];
+  getSetCookie(): NonNullable<Default<this['_schema']['Set-Cookie'], string>>[] {
+    return super.getSetCookie() as never;
   }
 
   /** @see {@link https://developer.mozilla.org/docs/Web/API/Headers/has MDN Reference} */
-  has<Name extends HttpHeadersSchemaName<Schema>>(name: Name): boolean {
+  has<Name extends HttpHeadersSchemaName<this['_schema']>>(name: Name): boolean {
     return super.has(name);
   }
 
   /** @see {@link https://developer.mozilla.org/docs/Web/API/Headers/delete MDN Reference} */
-  delete<Name extends HttpHeadersSchemaName<Schema>>(name: Name): void {
+  delete<Name extends HttpHeadersSchemaName<this['_schema']>>(name: Name): void {
     super.delete(name);
   }
 
-  forEach<This extends HttpHeaders<Schema>>(
-    callback: <Key extends HttpHeadersSchemaName<Schema>>(
-      value: NonNullable<Schema[Key]> & string,
+  forEach<This extends HttpHeaders<this['_schema']>>(
+    callback: <Key extends HttpHeadersSchemaName<this['_schema']>>(
+      value: NonNullable<this['_schema'][Key]> & string,
       key: Key,
       parent: Headers,
     ) => void,
@@ -85,30 +86,32 @@ class HttpHeaders<
   }
 
   /** @see {@link https://developer.mozilla.org/docs/Web/API/Headers/keys MDN Reference} */
-  keys(): HeadersIterator<HttpHeadersSchemaName<Schema>> {
-    return super.keys() as HeadersIterator<HttpHeadersSchemaName<Schema>>;
+  keys(): HeadersIterator<HttpHeadersSchemaName<this['_schema']>> {
+    return super.keys() as never;
   }
 
   /** @see {@link https://developer.mozilla.org/docs/Web/API/Headers/values MDN Reference} */
-  values(): HeadersIterator<NonNullable<Schema[HttpHeadersSchemaName<Schema>]> & string> {
-    return super.values() as HeadersIterator<NonNullable<Schema[HttpHeadersSchemaName<Schema>]> & string>;
+  values(): HeadersIterator<NonNullable<this['_schema'][HttpHeadersSchemaName<this['_schema']>]> & string> {
+    return super.values() as never;
   }
 
   /** @see {@link https://developer.mozilla.org/docs/Web/API/Headers/entries MDN Reference} */
   entries(): HeadersIterator<
-    [HttpHeadersSchemaName<Schema>, NonNullable<Schema[HttpHeadersSchemaName<Schema>]> & string]
+    [
+      HttpHeadersSchemaName<this['_schema']>,
+      NonNullable<this['_schema'][HttpHeadersSchemaName<this['_schema']>]> & string,
+    ]
   > {
-    return super.entries() as HeadersIterator<
-      [HttpHeadersSchemaName<Schema>, NonNullable<Schema[HttpHeadersSchemaName<Schema>]> & string]
-    >;
+    return super.entries() as never;
   }
 
   [Symbol.iterator](): HeadersIterator<
-    [HttpHeadersSchemaName<Schema>, NonNullable<Schema[HttpHeadersSchemaName<Schema>]> & string]
+    [
+      HttpHeadersSchemaName<this['_schema']>,
+      NonNullable<this['_schema'][HttpHeadersSchemaName<this['_schema']>]> & string,
+    ]
   > {
-    return super[Symbol.iterator]() as HeadersIterator<
-      [HttpHeadersSchemaName<Schema>, NonNullable<Schema[HttpHeadersSchemaName<Schema>]> & string]
-    >;
+    return super[Symbol.iterator]() as never;
   }
 
   /**
@@ -180,8 +183,8 @@ class HttpHeaders<
    *
    * @returns A plain object representation of these headers.
    */
-  toObject(): Schema {
-    const object = {} as Schema;
+  toObject(): this['_schema'] {
+    const object = {} as this['_schema'];
 
     for (const [key, value] of this.entries()) {
       object[key] = value;

--- a/packages/zimic-http/src/headers/HttpHeaders.ts
+++ b/packages/zimic-http/src/headers/HttpHeaders.ts
@@ -15,9 +15,6 @@ function pickPrimitiveProperties<LooseSchema extends HttpHeadersSchema.Loose>(sc
  * An extended HTTP headers object with a strictly-typed schema. Fully compatible with the built-in
  * {@link https://developer.mozilla.org/docs/Web/API/Headers `Headers`} class.
  *
- * **IMPORTANT**: the input of `HttpHeaders` and all of its internal types must be declared inline or as a type aliases
- * (`type`). They cannot be interfaces.
- *
  * @example
  *   import { HttpHeaders } from '@zimic/http';
  *

--- a/packages/zimic-http/src/headers/__tests__/HttpHeaders.test.ts
+++ b/packages/zimic-http/src/headers/__tests__/HttpHeaders.test.ts
@@ -124,14 +124,18 @@ describe('HttpHeaders', () => {
   });
 
   it('should support being created with a loose schema', () => {
+    const rateLimitReset = new Date();
+
     const headers = new HttpHeaders<{
       accept?: string;
       'x-rate-limit': number;
       'x-rate-limit-enabled': boolean;
+      'x-rate-limit-reset': Date;
     }>({
       accept: '*/*',
       'x-rate-limit': 100,
       'x-rate-limit-enabled': true,
+      'x-rate-limit-reset': rateLimitReset,
     });
 
     let acceptHeader = headers.get('accept');
@@ -160,6 +164,18 @@ describe('HttpHeaders', () => {
     rateLimitEffectiveHeader = headers.get('x-rate-limit-enabled');
     expectTypeOf(rateLimitEffectiveHeader).toEqualTypeOf<`${boolean}`>();
     expect(rateLimitEffectiveHeader).toBe('false');
+
+    let rateLimitResetHeader = headers.get('x-rate-limit-reset');
+    expectTypeOf(rateLimitResetHeader).toEqualTypeOf<string>();
+    expect(rateLimitResetHeader).toBe(rateLimitReset.toString());
+
+    const otherRateLimitReset = new Date(rateLimitReset);
+    otherRateLimitReset.setDate(otherRateLimitReset.getDate() + 1);
+
+    headers.set('x-rate-limit-reset', otherRateLimitReset);
+    rateLimitResetHeader = headers.get('x-rate-limit-reset');
+    expectTypeOf(rateLimitResetHeader).toEqualTypeOf<string>();
+    expect(rateLimitResetHeader).toBe(otherRateLimitReset.toString());
   });
 
   it('should support setting headers', () => {
@@ -584,7 +600,7 @@ describe('HttpHeaders', () => {
 
         requiredEnum: 'value1' | 'value2';
         optionalEnum?: 'value1' | 'value2';
-        nullableString: string | null;
+        nullableNumber: number | null;
 
         stringArray: string[];
         numberArray: number[];
@@ -613,15 +629,20 @@ describe('HttpHeaders', () => {
 
         requiredEnum: 'value1' | 'value2';
         optionalEnum?: 'value1' | 'value2';
-        nullableString: string | undefined;
-      }>();
+        nullableNumber: `${number}` | 'null';
 
-      expectTypeOf<HttpHeadersSerialized<string[]>>().toEqualTypeOf<never>();
-      expectTypeOf<HttpHeadersSerialized<Date>>().toEqualTypeOf<never>();
-      expectTypeOf<HttpHeadersSerialized<() => void>>().toEqualTypeOf<never>();
-      expectTypeOf<HttpHeadersSerialized<symbol>>().toEqualTypeOf<never>();
-      expectTypeOf<HttpHeadersSerialized<Map<never, never>>>().toEqualTypeOf<never>();
-      expectTypeOf<HttpHeadersSerialized<Set<never>>>().toEqualTypeOf<never>();
+        stringArray: string;
+        numberArray: string;
+        booleanArray: string;
+
+        object: string;
+
+        date: string;
+        method: string;
+        map: string;
+        set: string;
+        error: string;
+      }>();
     });
   });
 });

--- a/packages/zimic-http/src/pathParams/__tests__/HttpPathParams.test.ts
+++ b/packages/zimic-http/src/pathParams/__tests__/HttpPathParams.test.ts
@@ -18,7 +18,7 @@ describe('HttpPathParams', () => {
 
         requiredEnum: 'value1' | 'value2';
         optionalEnum?: 'value1' | 'value2';
-        nullableString: string | null;
+        nullableNumber: number | null;
 
         stringArray: string[];
         numberArray: number[];
@@ -47,15 +47,20 @@ describe('HttpPathParams', () => {
 
         requiredEnum: 'value1' | 'value2';
         optionalEnum?: 'value1' | 'value2';
-        nullableString: string | undefined;
-      }>();
+        nullableNumber: `${number}` | 'null';
 
-      expectTypeOf<HttpPathParamsSerialized<string[]>>().toEqualTypeOf<never>();
-      expectTypeOf<HttpPathParamsSerialized<Date>>().toEqualTypeOf<never>();
-      expectTypeOf<HttpPathParamsSerialized<() => void>>().toEqualTypeOf<never>();
-      expectTypeOf<HttpPathParamsSerialized<symbol>>().toEqualTypeOf<never>();
-      expectTypeOf<HttpPathParamsSerialized<Map<never, never>>>().toEqualTypeOf<never>();
-      expectTypeOf<HttpPathParamsSerialized<Set<never>>>().toEqualTypeOf<never>();
+        stringArray: string;
+        numberArray: string;
+        booleanArray: string;
+
+        object: string;
+
+        date: string;
+        method: string;
+        map: string;
+        set: string;
+        error: string;
+      }>();
     });
   });
 });

--- a/packages/zimic-http/src/searchParams/HttpSearchParams.ts
+++ b/packages/zimic-http/src/searchParams/HttpSearchParams.ts
@@ -45,8 +45,9 @@ function pickPrimitiveProperties<Schema extends HttpSearchParamsSchema.Loose>(sc
  */
 class HttpSearchParams<
   LooseSchema extends HttpSearchParamsSchema.Loose = HttpSearchParamsSchema.Loose,
-  Schema extends HttpSearchParamsSchema = HttpSearchParamsSerialized<LooseSchema>,
 > extends URLSearchParams {
+  readonly _schema!: HttpSearchParamsSerialized<LooseSchema>;
+
   constructor(init?: HttpSearchParamsInit<LooseSchema>) {
     if (init instanceof URLSearchParams || Array.isArray(init) || typeof init === 'string' || !init) {
       super(init);
@@ -67,7 +68,7 @@ class HttpSearchParams<
   }
 
   /** @see {@link https://developer.mozilla.org/docs/Web/API/URLSearchParams/set MDN Reference} */
-  set<Name extends HttpSearchParamsSchemaName<Schema>>(
+  set<Name extends HttpSearchParamsSchemaName<this['_schema']>>(
     name: Name,
     value: ArrayItemIfArray<NonNullable<LooseSchema[Name]>>,
   ): void {
@@ -75,7 +76,7 @@ class HttpSearchParams<
   }
 
   /** @see {@link https://developer.mozilla.org/docs/Web/API/URLSearchParams/append MDN Reference} */
-  append<Name extends HttpSearchParamsSchemaName<Schema>>(
+  append<Name extends HttpSearchParamsSchemaName<this['_schema']>>(
     name: Name,
     value: ArrayItemIfArray<NonNullable<LooseSchema[Name]>>,
   ): void {
@@ -91,10 +92,10 @@ class HttpSearchParams<
    * @returns The value associated with the key name, or `null` if the key does not exist.
    * @see {@link https://developer.mozilla.org/docs/Web/API/URLSearchParams/get MDN Reference}
    */
-  get<Name extends HttpSearchParamsSchemaName.NonArray<Schema>>(
+  get<Name extends HttpSearchParamsSchemaName.NonArray<this['_schema']>>(
     name: Name,
-  ): ReplaceBy<ArrayItemIfArray<Schema[Name]>, undefined, null> {
-    return super.get(name) as ReplaceBy<ArrayItemIfArray<Schema[Name]>, undefined, null>;
+  ): ReplaceBy<ArrayItemIfArray<this['_schema'][Name]>, undefined, null> {
+    return super.get(name) as never;
   }
 
   /**
@@ -106,14 +107,14 @@ class HttpSearchParams<
    * @returns An array of values associated with the key name, or an empty array if the key does not exist.
    * @see {@link https://developer.mozilla.org/docs/Web/API/URLSearchParams/getAll MDN Reference}
    */
-  getAll<Name extends HttpSearchParamsSchemaName.Array<Schema>>(
+  getAll<Name extends HttpSearchParamsSchemaName.Array<this['_schema']>>(
     name: Name,
-  ): ArrayItemIfArray<NonNullable<Schema[Name]>>[] {
-    return super.getAll(name) as ArrayItemIfArray<NonNullable<Schema[Name]>>[];
+  ): ArrayItemIfArray<NonNullable<this['_schema'][Name]>>[] {
+    return super.getAll(name) as never;
   }
 
   /** @see {@link https://developer.mozilla.org/docs/Web/API/URLSearchParams/has MDN Reference} */
-  has<Name extends HttpSearchParamsSchemaName<Schema>>(
+  has<Name extends HttpSearchParamsSchemaName<this['_schema']>>(
     name: Name,
     value?: ArrayItemIfArray<NonNullable<LooseSchema[Name]>>,
   ): boolean {
@@ -121,18 +122,18 @@ class HttpSearchParams<
   }
 
   /** @see {@link https://developer.mozilla.org/docs/Web/API/URLSearchParams/delete MDN Reference} */
-  delete<Name extends HttpSearchParamsSchemaName<Schema>>(
+  delete<Name extends HttpSearchParamsSchemaName<this['_schema']>>(
     name: Name,
     value?: ArrayItemIfArray<NonNullable<LooseSchema[Name]>>,
   ): void {
     super.delete(name, value);
   }
 
-  forEach<This extends HttpSearchParams<Schema>>(
-    callback: <Key extends HttpSearchParamsSchemaName<Schema>>(
-      value: ArrayItemIfArray<NonNullable<Schema[Key]>>,
+  forEach<This extends HttpSearchParams<this['_schema']>>(
+    callback: <Key extends HttpSearchParamsSchemaName<this['_schema']>>(
+      value: ArrayItemIfArray<NonNullable<this['_schema'][Key]>>,
       key: Key,
-      parent: HttpSearchParams<Schema>,
+      parent: HttpSearchParams<this['_schema']>,
     ) => void,
     thisArg?: This,
   ): void {
@@ -140,32 +141,34 @@ class HttpSearchParams<
   }
 
   /** @see {@link https://developer.mozilla.org/docs/Web/API/URLSearchParams/keys MDN Reference} */
-  keys(): URLSearchParamsIterator<HttpSearchParamsSchemaName<Schema>> {
-    return super.keys() as URLSearchParamsIterator<HttpSearchParamsSchemaName<Schema>>;
+  keys(): URLSearchParamsIterator<HttpSearchParamsSchemaName<this['_schema']>> {
+    return super.keys() as never;
   }
 
   /** @see {@link https://developer.mozilla.org/docs/Web/API/URLSearchParams/values MDN Reference} */
-  values(): URLSearchParamsIterator<ArrayItemIfArray<NonNullable<Schema[HttpSearchParamsSchemaName<Schema>]>>> {
-    return super.values() as URLSearchParamsIterator<
-      ArrayItemIfArray<NonNullable<Schema[HttpSearchParamsSchemaName<Schema>]>>
-    >;
+  values(): URLSearchParamsIterator<
+    ArrayItemIfArray<NonNullable<this['_schema'][HttpSearchParamsSchemaName<this['_schema']>]>>
+  > {
+    return super.values() as never;
   }
 
   /** @see {@link https://developer.mozilla.org/docs/Web/API/URLSearchParams/entries MDN Reference} */
   entries(): URLSearchParamsIterator<
-    [HttpSearchParamsSchemaName<Schema>, ArrayItemIfArray<NonNullable<Schema[HttpSearchParamsSchemaName<Schema>]>>]
+    [
+      HttpSearchParamsSchemaName<this['_schema']>,
+      ArrayItemIfArray<NonNullable<this['_schema'][HttpSearchParamsSchemaName<this['_schema']>]>>,
+    ]
   > {
-    return super.entries() as URLSearchParamsIterator<
-      [HttpSearchParamsSchemaName<Schema>, ArrayItemIfArray<NonNullable<Schema[HttpSearchParamsSchemaName<Schema>]>>]
-    >;
+    return super.entries() as never;
   }
 
   [Symbol.iterator](): URLSearchParamsIterator<
-    [HttpSearchParamsSchemaName<Schema>, ArrayItemIfArray<NonNullable<Schema[HttpSearchParamsSchemaName<Schema>]>>]
+    [
+      HttpSearchParamsSchemaName<this['_schema']>,
+      ArrayItemIfArray<NonNullable<this['_schema'][HttpSearchParamsSchemaName<this['_schema']>]>>,
+    ]
   > {
-    return super[Symbol.iterator]() as URLSearchParamsIterator<
-      [HttpSearchParamsSchemaName<Schema>, ArrayItemIfArray<NonNullable<Schema[HttpSearchParamsSchemaName<Schema>]>>]
-    >;
+    return super[Symbol.iterator]() as never;
   }
 
   /**
@@ -224,13 +227,13 @@ class HttpSearchParams<
    * @returns A plain object representation of these search params.
    */
   toObject() {
-    const object = {} as Schema;
+    const object = {} as this['_schema'];
 
-    type SchemaValue = Schema[HttpSearchParamsSchemaName<Schema>];
+    type SchemaValue = this['_schema'][HttpSearchParamsSchemaName<this['_schema']>];
 
     for (const [key, value] of this.entries()) {
       if (key in object) {
-        const existingValue = object[key];
+        const existingValue = object[key] as SchemaValue[];
 
         if (Array.isArray<SchemaValue>(existingValue)) {
           existingValue.push(value as SchemaValue);

--- a/packages/zimic-http/src/searchParams/HttpSearchParams.ts
+++ b/packages/zimic-http/src/searchParams/HttpSearchParams.ts
@@ -24,9 +24,6 @@ function pickPrimitiveProperties<Schema extends HttpSearchParamsSchema.Loose>(sc
  * An extended HTTP search params object with a strictly-typed schema. Fully compatible with the built-in
  * {@link https://developer.mozilla.org/docs/Web/API/URLSearchParams `URLSearchParams`} class.
  *
- * **IMPORTANT**: the input of `HttpSearchParams` and all of its internal types must be declared inline or as a type
- * aliases (`type`). They cannot be interfaces.
- *
  * @example
  *   import { HttpSearchParams } from '@zimic/http';
  *

--- a/packages/zimic-http/src/searchParams/__tests__/HttpSearchParams.test.ts
+++ b/packages/zimic-http/src/searchParams/__tests__/HttpSearchParams.test.ts
@@ -612,7 +612,7 @@ describe('HttpSearchParams', () => {
 
         requiredEnum: 'value1' | 'value2';
         optionalEnum?: 'value1' | 'value2';
-        nullableString: string | null;
+        nullableNumber: number | null;
 
         stringArray: string[];
         numberArray: number[];
@@ -641,19 +641,20 @@ describe('HttpSearchParams', () => {
 
         requiredEnum: 'value1' | 'value2';
         optionalEnum?: 'value1' | 'value2';
-        nullableString: string | undefined;
+        nullableNumber: `${number}` | 'null';
 
         stringArray: string[];
         numberArray: `${number}`[];
         booleanArray: `${boolean}`[];
-      }>();
 
-      expectTypeOf<HttpSearchParamsSerialized<string[]>>().toEqualTypeOf<never>();
-      expectTypeOf<HttpSearchParamsSerialized<Date>>().toEqualTypeOf<never>();
-      expectTypeOf<HttpSearchParamsSerialized<() => void>>().toEqualTypeOf<never>();
-      expectTypeOf<HttpSearchParamsSerialized<symbol>>().toEqualTypeOf<never>();
-      expectTypeOf<HttpSearchParamsSerialized<Map<never, never>>>().toEqualTypeOf<never>();
-      expectTypeOf<HttpSearchParamsSerialized<Set<never>>>().toEqualTypeOf<never>();
+        object: string;
+
+        date: string;
+        method: string;
+        map: string;
+        set: string;
+        error: string;
+      }>();
     });
   });
 });

--- a/packages/zimic-http/src/types/requests.ts
+++ b/packages/zimic-http/src/types/requests.ts
@@ -1,7 +1,7 @@
 import { Default, DefaultNoExclude, IfNever, ReplaceBy } from '@zimic/utils/types';
 import { JSONValue } from '@zimic/utils/types/json';
 
-import { HttpMethodSchema, HttpStatusCode } from '@/types/schema';
+import { HttpMethodSchema, HttpRequestSchema, HttpResponseSchema, HttpStatusCode } from '@/types/schema';
 
 import HttpFormData from '../formData/HttpFormData';
 import { HttpFormDataSchema } from '../formData/types';
@@ -73,8 +73,8 @@ export interface HttpRequest<
  */
 export interface HttpResponse<
   StrictBody extends HttpBody.Loose = HttpBody.Loose,
-  StatusCode extends number = number,
   StrictHeadersSchema extends HttpHeadersSchema.Loose = HttpHeadersSchema.Loose,
+  StatusCode extends number = number,
 > extends Response {
   ok: StatusCode extends HttpStatusCode.Information | HttpStatusCode.Success | HttpStatusCode.Redirection
     ? true

--- a/packages/zimic-http/src/types/requests.ts
+++ b/packages/zimic-http/src/types/requests.ts
@@ -99,15 +99,15 @@ type HttpRequestHeadersSchemaFromBody<
 > = 'body' extends keyof RequestSchema
   ? [RequestSchema['body']] extends [never]
     ? DefaultHeadersSchema
-    : RequestSchema['body'] extends BodyInit | undefined
-      ? DefaultHeadersSchema
-      : 'headers' extends keyof RequestSchema
+    : [Extract<RequestSchema['body'], BodyInit | HttpFormData | HttpSearchParams>] extends [never]
+      ? 'headers' extends keyof RequestSchema
         ? [RequestSchema['headers']] extends [never]
           ? DefaultHeadersSchema
           : 'content-type' extends keyof Default<RequestSchema['headers']>
             ? DefaultHeadersSchema
             : { 'content-type': 'application/json' }
         : { 'content-type': 'application/json' }
+      : DefaultHeadersSchema
   : DefaultHeadersSchema;
 
 export type HttpRequestHeadersSchema<MethodSchema extends HttpMethodSchema> =
@@ -135,15 +135,15 @@ type HttpResponseHeadersSchemaFromBody<
 > = 'body' extends keyof ResponseSchema
   ? [ResponseSchema['body']] extends [never]
     ? DefaultHeadersSchema
-    : ResponseSchema['body'] extends BodyInit | undefined
-      ? DefaultHeadersSchema
-      : 'headers' extends keyof ResponseSchema
+    : [Extract<ResponseSchema['body'], BodyInit | HttpSearchParams | HttpFormData>] extends [never]
+      ? 'headers' extends keyof ResponseSchema
         ? [ResponseSchema['headers']] extends [never]
           ? DefaultHeadersSchema
           : 'content-type' extends keyof Default<ResponseSchema['headers']>
             ? DefaultHeadersSchema
             : { 'content-type': 'application/json' }
         : { 'content-type': 'application/json' }
+      : DefaultHeadersSchema
   : DefaultHeadersSchema;
 
 export type HttpResponseHeadersSchema<

--- a/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/bodies/blob.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/bodies/blob.ts
@@ -151,7 +151,7 @@ export async function declareBlobBodyHttpInterceptorTests(options: RuntimeShared
         expect(request.response.body.size).toBe(responseFile.size);
         expect(await request.response.body.text()).toEqual(await responseFile.text());
 
-        expectTypeOf(request.raw).toEqualTypeOf<HttpRequest<Blob>>();
+        expectTypeOf(request.raw).toEqualTypeOf<HttpRequest<Blob, { 'content-type': string }>>();
         expect(request.raw).toBeInstanceOf(Request);
         expect(request.raw.url).toBe(request.url);
         expect(request.raw.method).toBe(method);
@@ -161,7 +161,7 @@ export async function declareBlobBodyHttpInterceptorTests(options: RuntimeShared
         expectTypeOf(request.raw.json).toEqualTypeOf<() => Promise<never>>();
         expectTypeOf(request.raw.formData).toEqualTypeOf<() => Promise<FormData>>();
 
-        expectTypeOf(request.response.raw).toEqualTypeOf<HttpResponse<Blob, 200>>();
+        expectTypeOf(request.response.raw).toEqualTypeOf<HttpResponse<Blob, { 'content-type'?: string }, 200>>();
         expect(request.response.raw).toBeInstanceOf(Response);
         expectTypeOf(request.response.raw.status).toEqualTypeOf<200>();
         expect(request.response.raw.status).toBe(200);
@@ -320,7 +320,7 @@ export async function declareBlobBodyHttpInterceptorTests(options: RuntimeShared
         expect(request.response.body.size).toBe(2);
         expect(await request.response.body.arrayBuffer()).toEqual(responseBuffer);
 
-        expectTypeOf(request.raw).toEqualTypeOf<HttpRequest<Blob>>();
+        expectTypeOf(request.raw).toEqualTypeOf<HttpRequest<Blob, { 'content-type': string }>>();
         expect(request.raw).toBeInstanceOf(Request);
         expect(request.raw.url).toBe(request.url);
         expect(request.raw.method).toBe(method);
@@ -330,7 +330,7 @@ export async function declareBlobBodyHttpInterceptorTests(options: RuntimeShared
         expectTypeOf(request.raw.json).toEqualTypeOf<() => Promise<never>>();
         expectTypeOf(request.raw.formData).toEqualTypeOf<() => Promise<FormData>>();
 
-        expectTypeOf(request.response.raw).toEqualTypeOf<HttpResponse<Blob, 200>>();
+        expectTypeOf(request.response.raw).toEqualTypeOf<HttpResponse<Blob, { 'content-type'?: string }, 200>>();
         expect(request.response.raw).toBeInstanceOf(Response);
         expectTypeOf(request.response.raw.status).toEqualTypeOf<200>();
         expect(request.response.raw.status).toBe(200);

--- a/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/bodies/formData.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/bodies/formData.ts
@@ -137,7 +137,9 @@ export async function declareFormDataBodyHttpInterceptorTests(options: RuntimeSh
         expect(interceptedResponseTagFile.type).toBe(responseTagFile.type);
         expect(await interceptedResponseTagFile.text()).toEqual(await responseTagFile.text());
 
-        expectTypeOf(request.raw).toEqualTypeOf<HttpRequest<HttpFormData<UserFormDataSchema>>>();
+        expectTypeOf(request.raw).toEqualTypeOf<
+          HttpRequest<HttpFormData<UserFormDataSchema>, { 'content-type': string }>
+        >();
         expect(request.raw).toBeInstanceOf(Request);
         expect(request.raw.url).toBe(request.url);
         expect(request.raw.method).toBe(method);
@@ -148,7 +150,9 @@ export async function declareFormDataBodyHttpInterceptorTests(options: RuntimeSh
         expectTypeOf(request.raw.formData).toEqualTypeOf<() => Promise<StrictFormData<UserFormDataSchema>>>();
         expect(Object.fromEntries(await request.raw.formData())).toEqual(Object.fromEntries(formData));
 
-        expectTypeOf(request.response.raw).toEqualTypeOf<HttpResponse<HttpFormData<UserFormDataSchema>, 200>>();
+        expectTypeOf(request.response.raw).toEqualTypeOf<
+          HttpResponse<HttpFormData<UserFormDataSchema>, { 'content-type'?: string }, 200>
+        >();
         expect(request.response.raw).toBeInstanceOf(Response);
         expectTypeOf(request.response.raw.status).toEqualTypeOf<200>();
         expect(request.response.raw.status).toBe(200);

--- a/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/bodies/json.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/bodies/json.ts
@@ -58,7 +58,7 @@ export async function declareJSONBodyHttpInterceptorTests(options: RuntimeShared
         };
         response: {
           200: {
-            headers?: { 'content-type'?: string };
+            headers?: { 'content-type'?: 'application/json; charset=utf-8' };
             body: UserAsType;
           };
         };
@@ -108,7 +108,7 @@ export async function declareJSONBodyHttpInterceptorTests(options: RuntimeShared
         expectTypeOf(request.response.body).toEqualTypeOf<UserAsType>();
         expect(request.response.body).toEqual(users[0]);
 
-        expectTypeOf(request.raw).toEqualTypeOf<HttpRequest<UserAsType>>();
+        expectTypeOf(request.raw).toEqualTypeOf<HttpRequest<UserAsType, { 'content-type': string }>>();
         expect(request.raw).toBeInstanceOf(Request);
         expect(request.raw.url).toBe(request.url);
         expect(request.raw.method).toBe(method);
@@ -119,7 +119,9 @@ export async function declareJSONBodyHttpInterceptorTests(options: RuntimeShared
         expect(await request.raw.json()).toEqual<UserAsType>(users[0]);
         expectTypeOf(request.raw.formData).toEqualTypeOf<() => Promise<FormData>>();
 
-        expectTypeOf(request.response.raw).toEqualTypeOf<HttpResponse<UserAsType, 200>>();
+        expectTypeOf(request.response.raw).toEqualTypeOf<
+          HttpResponse<UserAsType, { 'content-type'?: 'application/json; charset=utf-8' }, 200>
+        >();
         expect(request.response.raw).toBeInstanceOf(Response);
         expectTypeOf(request.response.raw.status).toEqualTypeOf<200>();
         expect(request.response.raw.status).toBe(200);
@@ -140,7 +142,7 @@ export async function declareJSONBodyHttpInterceptorTests(options: RuntimeShared
         };
         response: {
           200: {
-            headers?: { 'content-type'?: string };
+            headers?: { 'content-type'?: 'application/json; charset=utf-8' };
             body: UserAsInterface;
           };
         };
@@ -190,7 +192,7 @@ export async function declareJSONBodyHttpInterceptorTests(options: RuntimeShared
         expectTypeOf(request.response.body).toEqualTypeOf<UserAsInterface>();
         expect(request.response.body).toEqual(users[0]);
 
-        expectTypeOf(request.raw).toEqualTypeOf<HttpRequest<UserAsInterface>>();
+        expectTypeOf(request.raw).toEqualTypeOf<HttpRequest<UserAsInterface, { 'content-type': string }>>();
         expect(request.raw).toBeInstanceOf(Request);
         expect(request.raw.url).toBe(request.url);
         expect(request.raw.method).toBe(method);
@@ -201,7 +203,9 @@ export async function declareJSONBodyHttpInterceptorTests(options: RuntimeShared
         expect(await request.raw.json()).toEqual<UserAsInterface>(users[0]);
         expectTypeOf(request.raw.formData).toEqualTypeOf<() => Promise<FormData>>();
 
-        expectTypeOf(request.response.raw).toEqualTypeOf<HttpResponse<UserAsInterface, 200>>();
+        expectTypeOf(request.response.raw).toEqualTypeOf<
+          HttpResponse<UserAsInterface, { 'content-type'?: 'application/json; charset=utf-8' }, 200>
+        >();
         expect(request.response.raw).toBeInstanceOf(Response);
         expectTypeOf(request.response.raw.status).toEqualTypeOf<200>();
         expect(request.response.raw.status).toBe(200);
@@ -282,7 +286,7 @@ export async function declareJSONBodyHttpInterceptorTests(options: RuntimeShared
         expectTypeOf(request.response.body).toEqualTypeOf<UserAsNonJSONType>();
         expect(request.response.body).toEqual(users[0]);
 
-        expectTypeOf(request.raw).branded.toEqualTypeOf<HttpRequest<UserAsNonJSONInterface>>();
+        expectTypeOf(request.raw).toEqualTypeOf<HttpRequest<UserAsNonJSONInterface, { 'content-type': string }>>();
         expect(request.raw).toBeInstanceOf(Request);
         expect(request.raw.url).toBe(request.url);
         expect(request.raw.method).toBe(method);
@@ -293,7 +297,9 @@ export async function declareJSONBodyHttpInterceptorTests(options: RuntimeShared
         expect(await request.raw.json()).toEqual<JSONSerialized<UserAsNonJSONInterface>>(users[0]);
         expectTypeOf(request.raw.formData).toEqualTypeOf<() => Promise<FormData>>();
 
-        expectTypeOf(request.response.raw).branded.toEqualTypeOf<HttpResponse<UserAsNonJSONType, 200>>();
+        expectTypeOf(request.response.raw).toEqualTypeOf<
+          HttpResponse<UserAsNonJSONType, { 'content-type'?: string }, 200>
+        >();
         expect(request.response.raw).toBeInstanceOf(Response);
         expectTypeOf(request.response.raw.status).toEqualTypeOf<200>();
         expect(request.response.raw.status).toBe(200);
@@ -364,7 +370,7 @@ export async function declareJSONBodyHttpInterceptorTests(options: RuntimeShared
         expectTypeOf(request.response.body).toEqualTypeOf<number>();
         expect(request.response.body).toBe(2);
 
-        expectTypeOf(request.raw).toEqualTypeOf<HttpRequest<number>>();
+        expectTypeOf(request.raw).toEqualTypeOf<HttpRequest<number, { 'content-type': string }>>();
         expect(request.raw).toBeInstanceOf(Request);
         expect(request.raw.url).toBe(request.url);
         expect(request.raw.method).toBe(method);
@@ -375,7 +381,7 @@ export async function declareJSONBodyHttpInterceptorTests(options: RuntimeShared
         expect(await request.raw.json()).toEqual<number>(1);
         expectTypeOf(request.raw.formData).toEqualTypeOf<() => Promise<FormData>>();
 
-        expectTypeOf(request.response.raw).toEqualTypeOf<HttpResponse<number, 200>>();
+        expectTypeOf(request.response.raw).toEqualTypeOf<HttpResponse<number, { 'content-type'?: string }, 200>>();
         expect(request.response.raw).toBeInstanceOf(Response);
         expectTypeOf(request.response.raw.status).toEqualTypeOf<200>();
         expect(request.response.raw.status).toBe(200);
@@ -446,7 +452,7 @@ export async function declareJSONBodyHttpInterceptorTests(options: RuntimeShared
         expectTypeOf(request.response.body).toEqualTypeOf<boolean>();
         expect(request.response.body).toBe(false);
 
-        expectTypeOf(request.raw).toEqualTypeOf<HttpRequest<boolean>>();
+        expectTypeOf(request.raw).toEqualTypeOf<HttpRequest<boolean, { 'content-type': string }>>();
         expect(request.raw).toBeInstanceOf(Request);
         expect(request.raw.url).toBe(request.url);
         expect(request.raw.method).toBe(method);
@@ -457,7 +463,7 @@ export async function declareJSONBodyHttpInterceptorTests(options: RuntimeShared
         expect(await request.raw.json()).toEqual<boolean>(true);
         expectTypeOf(request.raw.formData).toEqualTypeOf<() => Promise<FormData>>();
 
-        expectTypeOf(request.response.raw).toEqualTypeOf<HttpResponse<boolean, 200>>();
+        expectTypeOf(request.response.raw).toEqualTypeOf<HttpResponse<boolean, { 'content-type'?: string }, 200>>();
         expect(request.response.raw).toBeInstanceOf(Response);
         expectTypeOf(request.response.raw.status).toEqualTypeOf<200>();
         expect(request.response.raw.status).toBe(200);

--- a/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/bodies/plainText.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/bodies/plainText.ts
@@ -97,7 +97,7 @@ export async function declarePlainTextBodyHttpInterceptorTests(options: RuntimeS
         expectTypeOf(request.response.body).toEqualTypeOf<string>();
         expect(request.response.body).toBe('content-response');
 
-        expectTypeOf(request.raw).toEqualTypeOf<HttpRequest<string>>();
+        expectTypeOf(request.raw).toEqualTypeOf<HttpRequest<string, { 'content-type': string }>>();
         expect(request.raw).toBeInstanceOf(Request);
         expect(request.raw.url).toBe(request.url);
         expect(request.raw.method).toBe(method);
@@ -107,7 +107,7 @@ export async function declarePlainTextBodyHttpInterceptorTests(options: RuntimeS
         expectTypeOf(request.raw.json).toEqualTypeOf<() => Promise<never>>();
         expectTypeOf(request.raw.formData).toEqualTypeOf<() => Promise<FormData>>();
 
-        expectTypeOf(request.response.raw).toEqualTypeOf<HttpResponse<string, 200>>();
+        expectTypeOf(request.response.raw).toEqualTypeOf<HttpResponse<string, { 'content-type'?: string }, 200>>();
         expect(request.response.raw).toBeInstanceOf(Response);
         expectTypeOf(request.response.raw.status).toEqualTypeOf<200>();
         expect(request.response.raw.status).toBe(200);

--- a/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/bodies/searchParams.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/bodies/searchParams.ts
@@ -116,7 +116,9 @@ export async function declareSearchParamsBodyHttpInterceptorTests(options: Runti
         expect(request.response.body).toBeInstanceOf(HttpSearchParams);
         expect(request.response.body).toEqual(responseSearchParams);
 
-        expectTypeOf(request.raw).toEqualTypeOf<HttpRequest<HttpSearchParams<UserSearchParamsSchema>>>();
+        expectTypeOf(request.raw).toEqualTypeOf<
+          HttpRequest<HttpSearchParams<UserSearchParamsSchema>, { 'content-type': string }>
+        >();
         expect(request.raw).toBeInstanceOf(Request);
         expect(request.raw.url).toBe(request.url);
         expect(request.raw.method).toBe(method);
@@ -126,7 +128,9 @@ export async function declareSearchParamsBodyHttpInterceptorTests(options: Runti
         expectTypeOf(request.raw.json).toEqualTypeOf<() => Promise<never>>();
         expectTypeOf(request.raw.formData).toEqualTypeOf<() => Promise<StrictFormData<UserSearchParamsSchema>>>();
 
-        expectTypeOf(request.response.raw).toEqualTypeOf<HttpResponse<HttpSearchParams<UserSearchParamsSchema>, 200>>();
+        expectTypeOf(request.response.raw).toEqualTypeOf<
+          HttpResponse<HttpSearchParams<UserSearchParamsSchema>, { 'content-type'?: string }, 200>
+        >();
         expect(request.response.raw).toBeInstanceOf(Response);
         expectTypeOf(request.response.raw.status).toEqualTypeOf<200>();
         expect(request.response.raw.status).toBe(200);

--- a/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/types.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/types.ts
@@ -392,7 +392,11 @@ export function declareTypeHttpInterceptorTests(
       expectTypeOf<ResponseBody>().toEqualTypeOf<User[] | { message: string } | null>();
 
       type ResponseHeaders = (typeof _handler.requests)[number]['response']['headers'];
-      expectTypeOf<ResponseHeaders>().toEqualTypeOf<HttpHeaders<{ 'content-type': string }> | HttpHeaders<never>>();
+      expectTypeOf<ResponseHeaders>().toEqualTypeOf<
+        | HttpHeaders<{ 'content-type': string }>
+        | HttpHeaders<{ 'content-type': 'application/json' }>
+        | HttpHeaders<never>
+      >();
 
       type ResponseStatus = (typeof _handler.requests)[number]['response']['status'];
       expectTypeOf<ResponseStatus>().toEqualTypeOf<200 | 400 | 404>();
@@ -506,7 +510,11 @@ export function declareTypeHttpInterceptorTests(
       expectTypeOf<ResponseBody>().toEqualTypeOf<User[] | { message: string } | '2xx' | '4xx' | 'default' | null>();
 
       type ResponseHeaders = (typeof _handler.requests)[number]['response']['headers'];
-      expectTypeOf<ResponseHeaders>().toEqualTypeOf<HttpHeaders<{ 'content-type': string }> | HttpHeaders<never>>();
+      expectTypeOf<ResponseHeaders>().toEqualTypeOf<
+        | HttpHeaders<{ 'content-type': string }>
+        | HttpHeaders<{ 'content-type': 'application/json' }>
+        | HttpHeaders<never>
+      >();
 
       type ResponseStatus = (typeof _handler.requests)[number]['response']['status'];
       expectTypeOf<ResponseStatus>().toEqualTypeOf<200 | 201 | 204 | 400 | 401 | 404 | 500>();
@@ -580,7 +588,9 @@ export function declareTypeHttpInterceptorTests(
       });
 
       type ResponseHeaders = (typeof _listHandler.requests)[number]['response']['headers'];
-      expectTypeOf<ResponseHeaders>().toEqualTypeOf<HttpHeaders<UserListHeaders>>();
+      expectTypeOf<ResponseHeaders>().toEqualTypeOf<
+        HttpHeaders<UserListHeaders & { 'content-type': 'application/json' }>
+      >();
     });
   });
 
@@ -612,7 +622,9 @@ export function declareTypeHttpInterceptorTests(
       });
 
       type ResponseHeaders = (typeof _listHandler.requests)[number]['response']['headers'];
-      expectTypeOf<ResponseHeaders>().toEqualTypeOf<HttpHeaders<UserListHeaders>>();
+      expectTypeOf<ResponseHeaders>().toEqualTypeOf<
+        HttpHeaders<UserListHeaders & { 'content-type': 'application/json' }>
+      >();
     });
   });
 
@@ -620,7 +632,7 @@ export function declareTypeHttpInterceptorTests(
     // If only content type is specified, the headers should be optional. This is because the content type is
     // automatically set by the interceptor before returning a response, unless overridden.
     type UserListHeaders = HttpSchema.Headers<{
-      'content-type': string;
+      'content-type': 'application/json; charset=utf-8';
     }>;
 
     await usingHttpInterceptor<{
@@ -654,7 +666,7 @@ export function declareTypeHttpInterceptorTests(
 
       _listHandler = await interceptor.get('/users').respond({
         status: 200,
-        headers: { 'content-type': 'application/json' },
+        headers: { 'content-type': 'application/json; charset=utf-8' },
         body: users[0],
       });
 
@@ -667,7 +679,7 @@ export function declareTypeHttpInterceptorTests(
     // If additional headers existing, beyond content type, only the `content-type` key should be optional. The
     // additional headers should be kept as defined.
     type UserListHeaders = HttpSchema.Headers<{
-      'content-type': string;
+      'content-type': 'application/json; charset=utf-8';
       accept: string;
     }>;
 
@@ -712,7 +724,7 @@ export function declareTypeHttpInterceptorTests(
 
       _listHandler = await interceptor.get('/users').respond({
         status: 200,
-        headers: { 'content-type': 'application/json', accept: '*/*' },
+        headers: { 'content-type': 'application/json; charset=utf-8', accept: '*/*' },
         body: users[0],
       });
 
@@ -725,7 +737,7 @@ export function declareTypeHttpInterceptorTests(
     // If additional headers existing, beyond content type, only the `content-type` key should be optional. The
     // additional headers should be kept as defined.
     type UserListHeaders = HttpSchema.Headers<{
-      'content-type': string;
+      'content-type': 'application/json; charset=utf-8';
       accept?: string;
     }>;
 
@@ -761,13 +773,13 @@ export function declareTypeHttpInterceptorTests(
 
       _listHandler = await interceptor.get('/users').respond({
         status: 200,
-        headers: { 'content-type': 'application/json' },
+        headers: { 'content-type': 'application/json; charset=utf-8' },
         body: users[0],
       });
 
       _listHandler = await interceptor.get('/users').respond({
         status: 200,
-        headers: { 'content-type': 'application/json', accept: '*/*' },
+        headers: { 'content-type': 'application/json; charset=utf-8', accept: '*/*' },
         body: users[0],
       });
 

--- a/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/utils.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/utils.ts
@@ -86,7 +86,7 @@ export function verifyUnhandledRequest(request: UnhandledHttpInterceptorRequest,
   expectTypeOf(request.body).toEqualTypeOf<BodySchema>();
   expect(request).toHaveProperty('body');
 
-  expectTypeOf(request.raw).toEqualTypeOf<HttpRequest<BodySchema>>();
+  expectTypeOf(request.raw).toEqualTypeOf<HttpRequest<BodySchema, Record<string, string>>>();
   expect(request.raw).toBeInstanceOf(Request);
   expect(request.raw.url).toBe(request.url);
   expect(request.raw.method).toBe(method);

--- a/packages/zimic-interceptor/src/http/requestHandler/HttpRequestHandlerClient.ts
+++ b/packages/zimic-interceptor/src/http/requestHandler/HttpRequestHandlerClient.ts
@@ -224,7 +224,8 @@ class HttpRequestHandlerClient<
   private matchesRequestHeadersRestrictions(
     request: HttpInterceptorRequest<Path, Default<Schema[Path][Method]>>,
     restriction: HttpRequestHandlerStaticRestriction<Schema, Method, Path>,
-  ): RestrictionMatchResult<RestrictionDiff<HttpHeaders<never>>> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ): RestrictionMatchResult<RestrictionDiff<HttpHeaders<any>>> {
     if (restriction.headers === undefined) {
       return { value: true };
     }
@@ -248,7 +249,8 @@ class HttpRequestHandlerClient<
   private matchesRequestSearchParamsRestrictions(
     request: HttpInterceptorRequest<Path, Default<Schema[Path][Method]>>,
     restriction: HttpRequestHandlerStaticRestriction<Schema, Method, Path>,
-  ): RestrictionMatchResult<RestrictionDiff<HttpSearchParams<never>>> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ): RestrictionMatchResult<RestrictionDiff<HttpSearchParams<any>>> {
     if (restriction.searchParams === undefined) {
       return { value: true };
     }

--- a/packages/zimic-interceptor/src/http/requestHandler/__tests__/shared/default.ts
+++ b/packages/zimic-interceptor/src/http/requestHandler/__tests__/shared/default.ts
@@ -21,7 +21,7 @@ import {
   HTTP_INTERCEPTOR_REQUEST_HIDDEN_PROPERTIES,
   HTTP_INTERCEPTOR_RESPONSE_HIDDEN_PROPERTIES,
 } from '../../types/requests';
-import { SharedHttpRequestHandlerTestOptions, Schema, MethodSchema } from './types';
+import { SharedHttpRequestHandlerTestOptions, Schema, MethodSchema, HeadersSchema } from './types';
 
 export function declareDefaultHttpRequestHandlerTests(
   options: SharedHttpRequestHandlerTestOptions & {
@@ -285,7 +285,7 @@ export function declareDefaultHttpRequestHandlerTests(
 
     expect(handler.requests[0]).toEqual(parsedRequest);
 
-    expectTypeOf(handler.requests[0].raw).toEqualTypeOf<HttpRequest<MethodSchema['request']['body']>>();
+    expectTypeOf(handler.requests[0].raw).toEqualTypeOf<HttpRequest<MethodSchema['request']['body'], HeadersSchema>>();
     expect(handler.requests[0].raw).toBeInstanceOf(Request);
     expect(handler.requests[0].raw.url).toBe(request.url);
     expect(handler.requests[0].raw.method).toBe('POST');
@@ -298,7 +298,10 @@ export function declareDefaultHttpRequestHandlerTests(
 
     expect(handler.requests[0].response).toEqual(parsedResponse);
 
-    expectTypeOf(handler.requests[0].response.raw).toEqualTypeOf<HttpResponse<{ success: true }, 200>>();
+    expectTypeOf(handler.requests[0].response.raw).toEqualTypeOf<
+      HttpResponse<{ success: true }, { 'content-type': 'application/json' }, 200>
+    >();
+
     expect(handler.requests[0].response.raw).toBeInstanceOf(Response);
     expectTypeOf(handler.requests[0].response.raw.status).toEqualTypeOf<200>();
     expect(handler.requests[0].response.raw.status).toBe(200);

--- a/packages/zimic-interceptor/src/http/requestHandler/types/requests.ts
+++ b/packages/zimic-interceptor/src/http/requestHandler/types/requests.ts
@@ -82,7 +82,7 @@ export interface HttpInterceptorRequest<Path extends string, MethodSchema extend
   /** The body of the request. It is already parsed by default. */
   body: HttpRequestBodySchema<MethodSchema>;
   /** The raw request object. */
-  raw: HttpRequest<HttpRequestBodySchema<MethodSchema>>;
+  raw: HttpRequest<HttpRequestBodySchema<MethodSchema>, Default<HttpRequestHeadersSchema<MethodSchema>>>;
 }
 
 /**
@@ -98,7 +98,11 @@ export interface HttpInterceptorResponse<MethodSchema extends HttpMethodSchema, 
   /** The body of the response. It is already parsed by default. */
   body: HttpResponseBodySchema<MethodSchema, StatusCode>;
   /** The raw response object. */
-  raw: HttpResponse<HttpResponseBodySchema<MethodSchema, StatusCode>, StatusCode>;
+  raw: HttpResponse<
+    HttpResponseBodySchema<MethodSchema, StatusCode>,
+    Default<HttpResponseHeadersSchema<MethodSchema, StatusCode>>,
+    StatusCode
+  >;
 }
 
 export const HTTP_INTERCEPTOR_REQUEST_HIDDEN_PROPERTIES = Object.freeze(

--- a/packages/zimic-interceptor/src/http/requestHandler/types/restrictions.ts
+++ b/packages/zimic-interceptor/src/http/requestHandler/types/restrictions.ts
@@ -138,8 +138,8 @@ export type RestrictionMatchResult<Value> = { value: true; diff?: undefined } | 
 
 export interface RestrictionDiffs {
   computed?: RestrictionDiff<boolean>;
-  headers?: RestrictionDiff<HttpHeaders<never>>;
-  searchParams?: RestrictionDiff<HttpSearchParams<never>>;
+  headers?: RestrictionDiff<HttpHeaders<any>>; // eslint-disable-line @typescript-eslint/no-explicit-any
+  searchParams?: RestrictionDiff<HttpSearchParams<any>>; // eslint-disable-line @typescript-eslint/no-explicit-any
   body?: RestrictionDiff<unknown>;
 }
 


### PR DESCRIPTION
### Features
- [http] Added support to infer the `content-type` header as `application/json` when the body is a JSON object. If a content type is declared, it is used instead, keeping backward compatibility.
- [http] Improved the serialization types of headers, search params, path params, form data, now considering unserializable types as `string` instead of `never`. This is more aligned with the real-word behavior. For example, trying to add a Map as a search param value saves it as a string.

### Refactoring
- [http] Moved the strict schema of `HttpHeaders`, `HttpSearchParams`, and `HttpFormData` to an attribute instead of a generic parameter. This is an optimization to keep the strict schema internal.

Closes #750.