### PR TITLE
fix(web): rewrite paths to static html files

### DIFF
--- a/apps/zimic-web/vercel.json
+++ b/apps/zimic-web/vercel.json
@@ -1,7 +1,8 @@
 {
   "framework": "docusaurus-2",
-  "installCommand": "sed -i 's/\"postinstall\": \".+\"/\"postinstall\": \"echo postinstall skipped.\"/' ../../apps/*/package.json ../../examples/*/package.json && pnpm install --frozen-lockfile --filter zimic-root --filter zimic-web...",
+  "installCommand": "sed -i 's/\"postinstall\": \".+\"/\"postinstall\": \"echo postinstall skipped.\"/' ../../apps/zimic-test-client/package.json ../../examples/*/package.json && pnpm install --frozen-lockfile --filter zimic-root --filter zimic-web...",
   "buildCommand": "pnpm turbo build --filter zimic-web",
   "outputDirectory": "build",
-  "trailingSlash": false
+  "trailingSlash": false,
+  "rewrites": [{ "source": "/:path*", "destination": "/:path*.html" }]
 }


### PR DESCRIPTION
### Fixes
- [web] Added `"rewrites": [{ "source": "/:path*", "destination": "/:path*.html" }]` to `vercel.json`. Vercel was not automatically rewriting the paths to their static HTML files, which was causing hydration and "Page not found" errors when accessing a page for the first time or refreshing it.