### PR TITLE
chore(root): deprecate support to `typescript` < 5.0 (#787)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -152,8 +152,6 @@ jobs:
       fail-fast: false
       matrix:
         typescript-version:
-          - '4.8'
-          - '4.9'
           - '5.0'
           - '5.1'
           - '5.2'
@@ -190,10 +188,9 @@ jobs:
 
       - name: Check types
         run: |
-          filterOptionsOfPackagesUsingNext=(
+          filterOptionsOfPackagesUsingServerComponents=(
             '--filter !zimic-example-with-playwright'
             '--filter !zimic-example-with-next-js-app'
-            '--filter !zimic-example-with-next-js-pages'
           )
 
           pnpm turbo \
@@ -202,5 +199,5 @@ jobs:
             --concurrency 100% \
             --filter !@zimic/* \
             --filter !zimic-web \
-            $([[ '${{ matrix.typescript-version }}' =~ ^(4\.|5\.0) ]] && echo ${filterOptionsOfPackagesUsingNext[@]}) \
+            $([[ '${{ matrix.typescript-version }}' =~ ^(5\.0) ]] && echo ${filterOptionsOfPackagesUsingServerComponents[@]}) \
             ${{ env.TURBO_FILTERS }}

--- a/apps/zimic-test-client/tsconfig.json
+++ b/apps/zimic-test-client/tsconfig.json
@@ -1,26 +1,6 @@
 {
-  // Our base config is not compatible with TypeScript <5.0 due to `"moduleResolution": "bundler"`.
-  // "extends": "@zimic/tsconfig/tsconfig.node.json",
+  "extends": "@zimic/tsconfig/tsconfig.node.json",
   "compilerOptions": {
-    "target": "es6",
-    "composite": false,
-    "declaration": true,
-    "declarationMap": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "inlineSources": false,
-    "isolatedModules": true,
-    "module": "nodenext",
-    "moduleResolution": "nodenext",
-    "resolveJsonModule": true,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "preserveWatchOutput": true,
-    "incremental": true,
-    "skipLibCheck": true,
-    "pretty": true,
-    "strict": true,
-    "lib": ["esnext", "webworker"],
     "tsBuildInfoFile": "tsconfig.tsbuildinfo",
     "baseUrl": ".",
     "paths": {

--- a/apps/zimic-web/docs/zimic-fetch/2-getting-started.mdx
+++ b/apps/zimic-web/docs/zimic-fetch/2-getting-started.mdx
@@ -32,7 +32,7 @@ different browsers.
 
 #### TypeScript
 
-`@zimic/fetch` requires [TypeScript](https://www.typescriptlang.org) >= 4.8.
+`@zimic/fetch` requires [TypeScript](https://www.typescriptlang.org) >= 5.0.
 
 We recommend enabling `strict` in your `tsconfig.json`:
 

--- a/apps/zimic-web/docs/zimic-http/2-getting-started.mdx
+++ b/apps/zimic-web/docs/zimic-http/2-getting-started.mdx
@@ -32,8 +32,7 @@ different browsers.
 
 #### TypeScript
 
-`@zimic/http` requires [TypeScript](https://www.typescriptlang.org) >= 4.8. If you plan on using
-[`zimic-http typegen`](/docs/http/cli/typegen), we recommend at least TypeScript 5.0.
+`@zimic/http` requires [TypeScript](https://www.typescriptlang.org) >= 5.0.
 
 We recommend enabling `strict` in your `tsconfig.json`:
 

--- a/apps/zimic-web/docs/zimic-interceptor/2-getting-started.mdx
+++ b/apps/zimic-web/docs/zimic-interceptor/2-getting-started.mdx
@@ -32,7 +32,7 @@ different browsers.
 
 #### TypeScript
 
-`@zimic/interceptor` requires [TypeScript](https://www.typescriptlang.org) >= 4.8.
+`@zimic/interceptor` requires [TypeScript](https://www.typescriptlang.org) >= 5.0.
 
 We recommend enabling `strict` in your `tsconfig.json`:
 

--- a/packages/eslint-config-node/package.json
+++ b/packages/eslint-config-node/package.json
@@ -16,6 +16,6 @@
   },
   "peerDependencies": {
     "eslint": ">=9.0.0",
-    "typescript": ">=4.8.0"
+    "typescript": ">=5.0.0"
   }
 }

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -18,6 +18,6 @@
   },
   "peerDependencies": {
     "eslint": ">=9.0.0",
-    "typescript": ">=4.8.0"
+    "typescript": ">=5.0.0"
   }
 }

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -3,6 +3,6 @@
   "version": "0.0.0",
   "private": false,
   "peerDependencies": {
-    "typescript": ">=4.8.0"
+    "typescript": ">=5.0.0"
   }
 }

--- a/packages/zimic-fetch/package.json
+++ b/packages/zimic-fetch/package.json
@@ -88,5 +88,10 @@
   "peerDependencies": {
     "@zimic/http": "^0.4.0 || workspace:*",
     "typescript": ">=5.0.0"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
   }
 }

--- a/packages/zimic-fetch/package.json
+++ b/packages/zimic-fetch/package.json
@@ -87,6 +87,6 @@
   },
   "peerDependencies": {
     "@zimic/http": "^0.4.0 || workspace:*",
-    "typescript": ">=4.8.0"
+    "typescript": ">=5.0.0"
   }
 }

--- a/packages/zimic-http/package.json
+++ b/packages/zimic-http/package.json
@@ -109,5 +109,10 @@
   },
   "peerDependencies": {
     "typescript": ">=5.0.0"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
   }
 }

--- a/packages/zimic-http/package.json
+++ b/packages/zimic-http/package.json
@@ -108,6 +108,6 @@
     "vitest": "^3.1.2"
   },
   "peerDependencies": {
-    "typescript": ">=4.8.0"
+    "typescript": ">=5.0.0"
   }
 }

--- a/packages/zimic-interceptor/package.json
+++ b/packages/zimic-interceptor/package.json
@@ -123,7 +123,7 @@
   },
   "peerDependencies": {
     "@zimic/http": "^0.4.0 || workspace:*",
-    "typescript": ">=4.8.0"
+    "typescript": ">=5.0.0"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -539,15 +539,15 @@ importers:
         version: 9.27.0(jiti@2.4.2)
       eslint-import-resolver-typescript:
         specifier: ^4.3.4
-        version: 4.3.4(eslint-plugin-import@2.31.0)(eslint@9.27.0(jiti@2.4.2))
+        version: 4.3.5(eslint-plugin-import@2.31.0)(eslint@9.27.0(jiti@2.4.2))
       eslint-plugin-import:
         specifier: ^2.31.0
-        version: 2.31.0(@typescript-eslint/parser@8.32.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@4.3.4)(eslint@9.27.0(jiti@2.4.2))
+        version: 2.31.0(@typescript-eslint/parser@8.32.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@4.3.5)(eslint@9.27.0(jiti@2.4.2))
       eslint-plugin-import-helpers:
         specifier: ^2.0.1
         version: 2.0.1(eslint@9.27.0(jiti@2.4.2))
       typescript:
-        specifier: '>=4.8.0'
+        specifier: '>=5.0.0'
         version: 5.8.3
 
   packages/eslint-config-node:
@@ -563,9 +563,9 @@ importers:
         version: 9.27.0(jiti@2.4.2)
       eslint-plugin-import:
         specifier: ^2.31.0
-        version: 2.31.0(@typescript-eslint/parser@8.32.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@4.3.4)(eslint@9.27.0(jiti@2.4.2))
+        version: 2.31.0(@typescript-eslint/parser@8.32.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@4.3.5)(eslint@9.27.0(jiti@2.4.2))
       typescript:
-        specifier: '>=4.8.0'
+        specifier: '>=5.0.0'
         version: 5.8.3
 
   packages/eslint-config-react:
@@ -581,7 +581,7 @@ importers:
         version: 9.27.0(jiti@2.4.2)
       eslint-plugin-import:
         specifier: ^2.31.0
-        version: 2.31.0(@typescript-eslint/parser@8.32.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@4.3.4)(eslint@9.27.0(jiti@2.4.2))
+        version: 2.31.0(@typescript-eslint/parser@8.32.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@4.3.5)(eslint@9.27.0(jiti@2.4.2))
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.2
         version: 6.10.2(eslint@9.27.0(jiti@2.4.2))
@@ -604,7 +604,7 @@ importers:
   packages/tsconfig:
     dependencies:
       typescript:
-        specifier: '>=4.8.0'
+        specifier: '>=5.0.0'
         version: 5.8.3
 
   packages/zimic-fetch:
@@ -5223,8 +5223,8 @@ packages:
   eslint-import-resolver-node@0.3.9:
     resolution: {integrity: sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==}
 
-  eslint-import-resolver-typescript@4.3.4:
-    resolution: {integrity: sha512-buzw5z5VtiQMysYLH9iW9BV04YyZebsw+gPi+c4FCjfS9i6COYOrEWw9t3m3wA9PFBfqcBCqWf32qrXLbwafDw==}
+  eslint-import-resolver-typescript@4.3.5:
+    resolution: {integrity: sha512-QGwhLrwn/WGOsdrWvjhm9n8BvKN/Wr41SQERMV7DQ2hm9+Ozas39CyQUxum///l2G2vefQVr7VbIaCFS5h9g5g==}
     engines: {node: ^16.17.0 || >=18.6.0}
     peerDependencies:
       eslint: '*'
@@ -15010,7 +15010,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@4.3.4(eslint-plugin-import@2.31.0)(eslint@9.27.0(jiti@2.4.2)):
+  eslint-import-resolver-typescript@4.3.5(eslint-plugin-import@2.31.0)(eslint@9.27.0(jiti@2.4.2)):
     dependencies:
       debug: 4.4.0
       eslint: 9.27.0(jiti@2.4.2)
@@ -15020,18 +15020,18 @@ snapshots:
       tinyglobby: 0.2.13
       unrs-resolver: 1.7.1
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.32.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@4.3.4)(eslint@9.27.0(jiti@2.4.2))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.32.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@4.3.5)(eslint@9.27.0(jiti@2.4.2))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.32.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.3.4)(eslint@9.27.0(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.32.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.3.5)(eslint@9.27.0(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.32.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.3)
       eslint: 9.27.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 4.3.4(eslint-plugin-import@2.31.0)(eslint@9.27.0(jiti@2.4.2))
+      eslint-import-resolver-typescript: 4.3.5(eslint-plugin-import@2.31.0)(eslint@9.27.0(jiti@2.4.2))
     transitivePeerDependencies:
       - supports-color
 
@@ -15039,7 +15039,7 @@ snapshots:
     dependencies:
       eslint: 9.27.0(jiti@2.4.2)
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.32.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@4.3.4)(eslint@9.27.0(jiti@2.4.2)):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.32.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@4.3.5)(eslint@9.27.0(jiti@2.4.2)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -15050,7 +15050,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.27.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.32.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.3.4)(eslint@9.27.0(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.32.1(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.3.5)(eslint@9.27.0(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3


### PR DESCRIPTION
- chore(root): deprecate support to `typescript` < 5.0
- chore(http): mark typescript as an optional peer dependency
- chore(fetch): mark typescript as an optional peer dependency

Closes #787.