### PR TITLE
docs(web): improve code highlight styles

### DIFF
--- a/apps/zimic-web/src/styles/custom.css
+++ b/apps/zimic-web/src/styles/custom.css
@@ -51,11 +51,11 @@
 
   --ifm-hover-overlay: color-mix(in oklab, var(--color-primary-600) 5%, transparent);
 
-  --highlighted-code-background-color: color-mix(in oklab, var(--color-primary-600) 6%, transparent);
-  --highlighted-code-border-color: color-mix(in oklab, var(--color-primary-500) 40%, transparent);
+  --highlighted-code-background-color: #eaeff9;
+  --highlighted-code-border-color: #9dbdf7;
 
-  --error-code-background-color: rgba(250, 56, 62, 0.06);
-  --error-code-border-color: rgba(250, 56, 62, 0.4);
+  --error-code-background-color: #f7ecef;
+  --error-code-border-color: #f8a6aa;
 
   --ifm-font-family-base:
     'Noto Sans', system-ui, -apple-system, 'Segoe UI', Roboto, Ubuntu, Cantarell, 'Noto Sans', sans-serif,
@@ -85,11 +85,11 @@
 
   --ifm-hover-overlay: color-mix(in oklab, var(--color-primary-600) 20%, transparent);
 
-  --highlighted-code-background-color: color-mix(in oklab, var(--color-primary-400) 15%, transparent);
-  --highlighted-code-border-color: color-mix(in oklab, var(--color-primary-400) 50%, transparent);
+  --highlighted-code-background-color: #0c2745;
+  --highlighted-code-border-color: #2a579d;
 
-  --error-code-background-color: rgba(250, 56, 62, 0.25);
-  --error-code-border-color: rgba(250, 56, 62, 0.5);
+  --error-code-background-color: #3f1f2d;
+  --error-code-border-color: #9c2d37;
 
   .navbar {
     border-bottom: 1px solid var(--ifm-color-gray-800);
@@ -215,19 +215,53 @@ textarea {
 }
 
 .code-block-highlighted-line {
-  display: block;
-  margin: 0 calc(var(--ifm-pre-padding) * -1);
-  padding: 0 var(--ifm-pre-padding);
-  background-color: var(--highlighted-code-background-color);
-  box-shadow: inset 0.2rem 0 0 0 var(--highlighted-code-border-color);
+  code[class*='codeBlockLinesWithNumbering'] & {
+    display: table-row;
+
+    [class*='codeLineNumber'] {
+      background-color: var(--highlighted-code-background-color);
+      box-shadow: inset 0.2rem 0 0 0 var(--highlighted-code-border-color);
+    }
+
+    [class*='codeLineContent'] {
+      display: inline-block;
+      width: 100%;
+      background-color: var(--highlighted-code-background-color);
+    }
+  }
+
+  code:not([class*='codeBlockLinesWithNumbering']) & {
+    display: block;
+    margin: 0 calc(var(--ifm-pre-padding) * -1);
+    padding: 0 var(--ifm-pre-padding);
+    background-color: var(--highlighted-code-background-color);
+    box-shadow: inset 0.2rem 0 0 0 var(--highlighted-code-border-color);
+  }
 }
 
 .code-block-error-line {
-  display: block;
-  margin: 0 calc(var(--ifm-pre-padding) * -1);
-  padding: 0 var(--ifm-pre-padding);
-  background-color: var(--error-code-background-color);
-  box-shadow: inset 0.2rem 0 0 0 var(--error-code-border-color);
+  code[class*='codeBlockLinesWithNumbering'] & {
+    display: table-row;
+
+    [class*='codeLineNumber'] {
+      background-color: var(--error-code-background-color);
+      box-shadow: inset 0.2rem 0 0 0 var(--error-code-border-color);
+    }
+
+    [class*='codeLineContent'] {
+      display: inline-block;
+      width: 100%;
+      background-color: var(--error-code-background-color);
+    }
+  }
+
+  code:not([class*='codeBlockLinesWithNumbering']) & {
+    display: block;
+    margin: 0 calc(var(--ifm-pre-padding) * -1);
+    padding: 0 var(--ifm-pre-padding);
+    background-color: var(--error-code-background-color);
+    box-shadow: inset 0.2rem 0 0 0 var(--error-code-border-color);
+  }
 }
 
 .menu__link,


### PR DESCRIPTION
This improves the code highlight styles to work well when there are line numbers. Previously, we used `display: block` for all highlighted blocks, which causes styling problems as `display: table-row` is needed if line numbers are enabled.