### PR TITLE
chore(interceptor): remove msw undefined patch

### DIFF
--- a/packages/zimic-interceptor/package.json
+++ b/packages/zimic-interceptor/package.json
@@ -95,7 +95,7 @@
     "@whatwg-node/server": "0.10.10",
     "execa": "9.6.0",
     "isomorphic-ws": "5.0.0",
-    "msw": "2.8.7",
+    "msw": "2.9.0",
     "picocolors": "^1.1.1",
     "ws": "8.18.2",
     "yargs": "17.7.2",

--- a/packages/zimic-interceptor/scripts/__tests__/postinstall.node.test.ts
+++ b/packages/zimic-interceptor/scripts/__tests__/postinstall.node.test.ts
@@ -2,13 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { describe, expect, it } from 'vitest';
 
-import {
-  MSW_PACKAGE_PATH,
-  MSW_CORE_DIRECTORY,
-  MSW_BROWSER_DIRECTORY,
-  MSWPackage,
-  postinstallPromise,
-} from '../postinstall';
+import { MSW_PACKAGE_PATH, MSW_CORE_DIRECTORY, MSWPackage, postinstallPromise } from '../postinstall';
 
 describe('Post-install script', () => {
   it('should patch msw/package.json exports', async () => {
@@ -22,18 +16,6 @@ describe('Post-install script', () => {
     expect(exports['./browser'].node).toEqual(exports['./node'].node);
     expect(exports['./node'].browser).toEqual(exports['./browser'].browser);
   });
-
-  it.each(['index.js', 'index.mjs'])(
-    'should patch a missing undefined check in msw/browser/%s',
-    async (indexFileName) => {
-      await postinstallPromise;
-
-      const mswBrowserPath = path.join(MSW_BROWSER_DIRECTORY, indexFileName);
-      const mswBrowserContent = await fs.promises.readFile(mswBrowserPath, 'utf-8');
-
-      expect(mswBrowserContent).toContain('if (!request || responseJson.type?.includes("opaque")) {');
-    },
-  );
 
   it.each(['ws.js', 'ws.mjs'])(
     'should patch the web socket channel to be created lazily in msw/core/%s',

--- a/packages/zimic-interceptor/scripts/postinstall.ts
+++ b/packages/zimic-interceptor/scripts/postinstall.ts
@@ -11,7 +11,6 @@ export const MSW_ROOT_DIRECTORY = path.join(require.resolve('msw'), '..', '..', 
 export const MSW_PACKAGE_PATH = path.join(MSW_ROOT_DIRECTORY, 'package.json');
 
 export const MSW_CORE_DIRECTORY = path.join(MSW_ROOT_DIRECTORY, 'lib', 'core');
-export const MSW_BROWSER_DIRECTORY = path.join(MSW_ROOT_DIRECTORY, 'lib', 'browser');
 
 async function patchMSWExports() {
   const mswPackageContentAsString = await fs.promises.readFile(MSW_PACKAGE_PATH, 'utf-8');
@@ -32,23 +31,6 @@ async function patchMSWExports() {
 
   const patchedMSWPackageContentAsString = JSON.stringify(mswPackageContent, null, 2);
   await fs.promises.writeFile(MSW_PACKAGE_PATH, patchedMSWPackageContentAsString);
-}
-
-// This is a temporary workaround. Once https://github.com/mswjs/msw/issues/2146 is fixed, we should remove it.
-async function patchMSWBrowserEntry() {
-  await Promise.all(
-    ['index.js', 'index.mjs'].map(async (indexFileName) => {
-      const mswBrowserPath = path.join(MSW_BROWSER_DIRECTORY, indexFileName);
-      const mswBrowserContent = await fs.promises.readFile(mswBrowserPath, 'utf-8');
-
-      const patchedMSWBrowserContent = mswBrowserContent.replace(
-        ['    if (responseJson.type?.includes("opaque")) {', '      return;', '    }'].join('\n'),
-        ['    if (!request || responseJson.type?.includes("opaque")) {', '      return;', '    }'].join('\n'),
-      );
-
-      await fs.promises.writeFile(mswBrowserPath, patchedMSWBrowserContent);
-    }),
-  );
 }
 
 // This is a temporary workaround. Once https://github.com/stackblitz/core/issues/3323 is fixed, we should remove it.
@@ -104,7 +86,7 @@ async function patchMSWWebSocketBroadcastChannel() {
 }
 
 async function postinstall() {
-  await Promise.all([patchMSWExports(), patchMSWBrowserEntry(), patchMSWWebSocketBroadcastChannel()]);
+  await Promise.all([patchMSWExports(), patchMSWWebSocketBroadcastChannel()]);
 }
 
 export const postinstallPromise = postinstall();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,7 +49,7 @@ importers:
         version: 8.1.9
       '@vitest/browser':
         specifier: ^3.2.1
-        version: 3.2.1(bufferutil@4.0.9)(msw@2.8.7(@types/node@22.15.29)(typescript@5.8.3))(playwright@1.52.0)(vite@6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0))(vitest@3.2.1)
+        version: 3.2.1(bufferutil@4.0.9)(msw@2.9.0(@types/node@22.15.29)(typescript@5.8.3))(playwright@1.52.0)(vite@6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0))(vitest@3.2.1)
       '@vitest/coverage-istanbul':
         specifier: ^3.2.1
         version: 3.2.1(vitest@3.2.1)
@@ -103,7 +103,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^3.2.1
-        version: 3.2.1(@types/debug@4.1.12)(@types/node@22.15.29)(@vitest/browser@3.2.1)(jiti@2.4.2)(jsdom@26.1.0(bufferutil@4.0.9))(lightningcss@1.30.1)(msw@2.8.7(@types/node@22.15.29)(typescript@5.8.3))(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0)
+        version: 3.2.1(@types/debug@4.1.12)(@types/node@22.15.29)(@vitest/browser@3.2.1)(jiti@2.4.2)(jsdom@26.1.0(bufferutil@4.0.9))(lightningcss@1.30.1)(msw@2.9.0(@types/node@22.15.29)(typescript@5.8.3))(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0)
 
   apps/zimic-web:
     dependencies:
@@ -394,7 +394,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^3.2.1
-        version: 3.2.1(@types/debug@4.1.12)(@types/node@22.15.29)(@vitest/browser@3.2.1)(jiti@2.4.2)(jsdom@26.1.0(bufferutil@4.0.9))(lightningcss@1.30.1)(msw@2.8.7(@types/node@22.15.29)(typescript@5.8.3))(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0)
+        version: 3.2.1(@types/debug@4.1.12)(@types/node@22.15.29)(@vitest/browser@3.2.1)(jiti@2.4.2)(jsdom@26.1.0(bufferutil@4.0.9))(lightningcss@1.30.1)(msw@2.9.0(@types/node@22.15.29)(typescript@5.8.3))(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0)
 
   examples/zimic-with-playwright:
     dependencies:
@@ -459,7 +459,7 @@ importers:
     devDependencies:
       '@vitest/browser':
         specifier: ^3.2.1
-        version: 3.2.1(bufferutil@4.0.9)(msw@2.8.7(@types/node@22.15.29)(typescript@5.8.3))(playwright@1.52.0)(vite@6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0))(vitest@3.2.1)
+        version: 3.2.1(bufferutil@4.0.9)(msw@2.9.0(@types/node@22.15.29)(typescript@5.8.3))(playwright@1.52.0)(vite@6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0))(vitest@3.2.1)
       '@zimic/interceptor':
         specifier: latest
         version: link:../../packages/zimic-interceptor
@@ -477,7 +477,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^3.2.1
-        version: 3.2.1(@types/debug@4.1.12)(@types/node@22.15.29)(@vitest/browser@3.2.1)(jiti@2.4.2)(jsdom@26.1.0(bufferutil@4.0.9))(lightningcss@1.30.1)(msw@2.8.7(@types/node@22.15.29)(typescript@5.8.3))(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0)
+        version: 3.2.1(@types/debug@4.1.12)(@types/node@22.15.29)(@vitest/browser@3.2.1)(jiti@2.4.2)(jsdom@26.1.0(bufferutil@4.0.9))(lightningcss@1.30.1)(msw@2.9.0(@types/node@22.15.29)(typescript@5.8.3))(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0)
 
   examples/zimic-with-vitest-jsdom:
     dependencies:
@@ -502,7 +502,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^3.2.1
-        version: 3.2.1(@types/debug@4.1.12)(@types/node@22.15.29)(@vitest/browser@3.2.1)(jiti@2.4.2)(jsdom@26.1.0(bufferutil@4.0.9))(lightningcss@1.30.1)(msw@2.8.7(@types/node@22.15.29)(typescript@5.8.3))(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0)
+        version: 3.2.1(@types/debug@4.1.12)(@types/node@22.15.29)(@vitest/browser@3.2.1)(jiti@2.4.2)(jsdom@26.1.0(bufferutil@4.0.9))(lightningcss@1.30.1)(msw@2.9.0(@types/node@22.15.29)(typescript@5.8.3))(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0)
 
   examples/zimic-with-vitest-node:
     dependencies:
@@ -524,7 +524,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^3.2.1
-        version: 3.2.1(@types/debug@4.1.12)(@types/node@22.15.29)(@vitest/browser@3.2.1)(jiti@2.4.2)(jsdom@26.1.0(bufferutil@4.0.9))(lightningcss@1.30.1)(msw@2.8.7(@types/node@22.15.29)(typescript@5.8.3))(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0)
+        version: 3.2.1(@types/debug@4.1.12)(@types/node@22.15.29)(@vitest/browser@3.2.1)(jiti@2.4.2)(jsdom@26.1.0(bufferutil@4.0.9))(lightningcss@1.30.1)(msw@2.9.0(@types/node@22.15.29)(typescript@5.8.3))(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0)
 
   packages/eslint-config:
     dependencies:
@@ -618,7 +618,7 @@ importers:
         version: 22.15.29
       '@vitest/browser':
         specifier: ^3.2.1
-        version: 3.2.1(bufferutil@4.0.9)(msw@2.8.7(@types/node@22.15.29)(typescript@5.8.3))(playwright@1.52.0)(vite@6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0))(vitest@3.2.1)
+        version: 3.2.1(bufferutil@4.0.9)(msw@2.9.0(@types/node@22.15.29)(typescript@5.8.3))(playwright@1.52.0)(vite@6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0))(vitest@3.2.1)
       '@vitest/coverage-istanbul':
         specifier: ^3.2.1
         version: 3.2.1(vitest@3.2.1)
@@ -654,7 +654,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^3.2.1
-        version: 3.2.1(@types/debug@4.1.12)(@types/node@22.15.29)(@vitest/browser@3.2.1)(jiti@2.4.2)(jsdom@26.1.0(bufferutil@4.0.9))(lightningcss@1.30.1)(msw@2.8.7(@types/node@22.15.29)(typescript@5.8.3))(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0)
+        version: 3.2.1(@types/debug@4.1.12)(@types/node@22.15.29)(@vitest/browser@3.2.1)(jiti@2.4.2)(jsdom@26.1.0(bufferutil@4.0.9))(lightningcss@1.30.1)(msw@2.9.0(@types/node@22.15.29)(typescript@5.8.3))(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0)
 
   packages/zimic-http:
     dependencies:
@@ -679,7 +679,7 @@ importers:
         version: 17.0.33
       '@vitest/browser':
         specifier: ^3.2.1
-        version: 3.2.1(bufferutil@4.0.9)(msw@2.8.7(@types/node@22.15.29)(typescript@5.8.3))(playwright@1.52.0)(vite@6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0))(vitest@3.2.1)
+        version: 3.2.1(bufferutil@4.0.9)(msw@2.9.0(@types/node@22.15.29)(typescript@5.8.3))(playwright@1.52.0)(vite@6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0))(vitest@3.2.1)
       '@vitest/coverage-istanbul':
         specifier: ^3.2.1
         version: 3.2.1(vitest@3.2.1)
@@ -727,7 +727,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^3.2.1
-        version: 3.2.1(@types/debug@4.1.12)(@types/node@22.15.29)(@vitest/browser@3.2.1)(jiti@2.4.2)(jsdom@26.1.0(bufferutil@4.0.9))(lightningcss@1.30.1)(msw@2.8.7(@types/node@22.15.29)(typescript@5.8.3))(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0)
+        version: 3.2.1(@types/debug@4.1.12)(@types/node@22.15.29)(@vitest/browser@3.2.1)(jiti@2.4.2)(jsdom@26.1.0(bufferutil@4.0.9))(lightningcss@1.30.1)(msw@2.9.0(@types/node@22.15.29)(typescript@5.8.3))(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0)
 
   packages/zimic-interceptor:
     dependencies:
@@ -744,8 +744,8 @@ importers:
         specifier: 5.0.0
         version: 5.0.0(ws@8.18.2(bufferutil@4.0.9))
       msw:
-        specifier: 2.8.7
-        version: 2.8.7(@types/node@22.15.29)(typescript@5.8.3)
+        specifier: 2.9.0
+        version: 2.9.0(@types/node@22.15.29)(typescript@5.8.3)
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
@@ -770,7 +770,7 @@ importers:
         version: 17.0.33
       '@vitest/browser':
         specifier: ^3.2.1
-        version: 3.2.1(bufferutil@4.0.9)(msw@2.8.7(@types/node@22.15.29)(typescript@5.8.3))(playwright@1.52.0)(vite@6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0))(vitest@3.2.1)
+        version: 3.2.1(bufferutil@4.0.9)(msw@2.9.0(@types/node@22.15.29)(typescript@5.8.3))(playwright@1.52.0)(vite@6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0))(vitest@3.2.1)
       '@vitest/coverage-istanbul':
         specifier: ^3.2.1
         version: 3.2.1(vitest@3.2.1)
@@ -803,7 +803,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^3.2.1
-        version: 3.2.1(@types/debug@4.1.12)(@types/node@22.15.29)(@vitest/browser@3.2.1)(jiti@2.4.2)(jsdom@26.1.0(bufferutil@4.0.9))(lightningcss@1.30.1)(msw@2.8.7(@types/node@22.15.29)(typescript@5.8.3))(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0)
+        version: 3.2.1(@types/debug@4.1.12)(@types/node@22.15.29)(@vitest/browser@3.2.1)(jiti@2.4.2)(jsdom@26.1.0(bufferutil@4.0.9))(lightningcss@1.30.1)(msw@2.9.0(@types/node@22.15.29)(typescript@5.8.3))(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0)
     optionalDependencies:
       bufferutil:
         specifier: 4.0.9
@@ -816,7 +816,7 @@ importers:
         version: 22.15.29
       '@vitest/browser':
         specifier: ^3.2.1
-        version: 3.2.1(bufferutil@4.0.9)(msw@2.8.7(@types/node@22.15.29)(typescript@5.8.3))(playwright@1.52.0)(vite@6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0))(vitest@3.2.1)
+        version: 3.2.1(bufferutil@4.0.9)(msw@2.9.0(@types/node@22.15.29)(typescript@5.8.3))(playwright@1.52.0)(vite@6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0))(vitest@3.2.1)
       '@zimic/eslint-config-node':
         specifier: workspace:*
         version: link:../eslint-config-node
@@ -840,7 +840,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^3.2.1
-        version: 3.2.1(@types/debug@4.1.12)(@types/node@22.15.29)(@vitest/browser@3.2.1)(jiti@2.4.2)(jsdom@26.1.0(bufferutil@4.0.9))(lightningcss@1.30.1)(msw@2.8.7(@types/node@22.15.29)(typescript@5.8.3))(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0)
+        version: 3.2.1(@types/debug@4.1.12)(@types/node@22.15.29)(@vitest/browser@3.2.1)(jiti@2.4.2)(jsdom@26.1.0(bufferutil@4.0.9))(lightningcss@1.30.1)(msw@2.9.0(@types/node@22.15.29)(typescript@5.8.3))(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0)
 
 packages:
 
@@ -1976,6 +1976,10 @@ packages:
 
   '@babel/runtime@7.27.4':
     resolution: {integrity: sha512-t3yaEOuGu9NlIZ+hIeGbBjFtZT7j2cb2tg0fuaJKeGotchRjjLfrBA9Kwf8quhpP1EUuxModQg04q/mBwyg8uA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.27.6':
+    resolution: {integrity: sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/template@7.27.0':
@@ -7912,8 +7916,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  msw@2.8.7:
-    resolution: {integrity: sha512-0TGfV4oQiKpa3pDsQBDf0xvFP+sRrqEOnh2n1JWpHVKHJHLv6ZmY1HCZpCi7uDiJTeIHJMBpmBiRmBJN+ETPSQ==}
+  msw@2.9.0:
+    resolution: {integrity: sha512-fNyrJ11YNbe2zl64EwtxM5OFkInFPAw5vipOljMsf9lY2ep9B2BslqQrS8EC9pB9961K61FqTUi0wsdqk6hwow==}
     engines: {node: '>=18'}
     hasBin: true
     peerDependencies:
@@ -9473,6 +9477,10 @@ packages:
 
   statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
+    engines: {node: '>= 0.8'}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
   std-env@3.9.0:
@@ -12017,6 +12025,8 @@ snapshots:
 
   '@babel/runtime@7.27.4': {}
 
+  '@babel/runtime@7.27.6': {}
+
   '@babel/template@7.27.0':
     dependencies:
       '@babel/code-frame': 7.27.1
@@ -12071,7 +12081,7 @@ snapshots:
 
   '@bundled-es-modules/statuses@1.0.1':
     dependencies:
-      statuses: 2.0.1
+      statuses: 2.0.2
 
   '@bundled-es-modules/tough-cookie@0.1.6':
     dependencies:
@@ -14027,7 +14037,7 @@ snapshots:
 
   '@slorber/react-helmet-async@1.3.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.27.4
+      '@babel/runtime': 7.27.6
       invariant: 2.2.4
       prop-types: 15.8.1
       react: 19.1.0
@@ -14744,16 +14754,16 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.7.8':
     optional: true
 
-  '@vitest/browser@3.2.1(bufferutil@4.0.9)(msw@2.8.7(@types/node@22.15.29)(typescript@5.8.3))(playwright@1.52.0)(vite@6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0))(vitest@3.2.1)':
+  '@vitest/browser@3.2.1(bufferutil@4.0.9)(msw@2.9.0(@types/node@22.15.29)(typescript@5.8.3))(playwright@1.52.0)(vite@6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0))(vitest@3.2.1)':
     dependencies:
       '@testing-library/dom': 10.4.0
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
-      '@vitest/mocker': 3.2.1(msw@2.8.7(@types/node@22.15.29)(typescript@5.8.3))(vite@6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0))
+      '@vitest/mocker': 3.2.1(msw@2.9.0(@types/node@22.15.29)(typescript@5.8.3))(vite@6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0))
       '@vitest/utils': 3.2.1
       magic-string: 0.30.17
       sirv: 3.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.1(@types/debug@4.1.12)(@types/node@22.15.29)(@vitest/browser@3.2.1)(jiti@2.4.2)(jsdom@26.1.0(bufferutil@4.0.9))(lightningcss@1.30.1)(msw@2.8.7(@types/node@22.15.29)(typescript@5.8.3))(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0)
+      vitest: 3.2.1(@types/debug@4.1.12)(@types/node@22.15.29)(@vitest/browser@3.2.1)(jiti@2.4.2)(jsdom@26.1.0(bufferutil@4.0.9))(lightningcss@1.30.1)(msw@2.9.0(@types/node@22.15.29)(typescript@5.8.3))(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0)
       ws: 8.18.2(bufferutil@4.0.9)
     optionalDependencies:
       playwright: 1.52.0
@@ -14775,7 +14785,7 @@ snapshots:
       magicast: 0.3.5
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.1(@types/debug@4.1.12)(@types/node@22.15.29)(@vitest/browser@3.2.1)(jiti@2.4.2)(jsdom@26.1.0(bufferutil@4.0.9))(lightningcss@1.30.1)(msw@2.8.7(@types/node@22.15.29)(typescript@5.8.3))(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0)
+      vitest: 3.2.1(@types/debug@4.1.12)(@types/node@22.15.29)(@vitest/browser@3.2.1)(jiti@2.4.2)(jsdom@26.1.0(bufferutil@4.0.9))(lightningcss@1.30.1)(msw@2.9.0(@types/node@22.15.29)(typescript@5.8.3))(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -14787,13 +14797,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.1(msw@2.8.7(@types/node@22.15.29)(typescript@5.8.3))(vite@6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0))':
+  '@vitest/mocker@3.2.1(msw@2.9.0(@types/node@22.15.29)(typescript@5.8.3))(vite@6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0))':
     dependencies:
       '@vitest/spy': 3.2.1
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      msw: 2.8.7(@types/node@22.15.29)(typescript@5.8.3)
+      msw: 2.9.0(@types/node@22.15.29)(typescript@5.8.3)
       vite: 6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0)
 
   '@vitest/pretty-format@3.2.1':
@@ -19292,7 +19302,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@2.8.7(@types/node@22.15.29)(typescript@5.8.3):
+  msw@2.9.0(@types/node@22.15.29)(typescript@5.8.3):
     dependencies:
       '@bundled-es-modules/cookie': 2.0.1
       '@bundled-es-modules/statuses': 1.0.1
@@ -20435,7 +20445,7 @@ snapshots:
 
   regenerator-transform@0.15.2:
     dependencies:
-      '@babel/runtime': 7.27.4
+      '@babel/runtime': 7.27.6
 
   regexp.prototype.flags@1.5.2:
     dependencies:
@@ -21057,6 +21067,8 @@ snapshots:
   statuses@1.5.0: {}
 
   statuses@2.0.1: {}
+
+  statuses@2.0.2: {}
 
   std-env@3.9.0: {}
 
@@ -21797,11 +21809,11 @@ snapshots:
       tsx: 4.19.4
       yaml: 2.8.0
 
-  vitest@3.2.1(@types/debug@4.1.12)(@types/node@22.15.29)(@vitest/browser@3.2.1)(jiti@2.4.2)(jsdom@26.1.0(bufferutil@4.0.9))(lightningcss@1.30.1)(msw@2.8.7(@types/node@22.15.29)(typescript@5.8.3))(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0):
+  vitest@3.2.1(@types/debug@4.1.12)(@types/node@22.15.29)(@vitest/browser@3.2.1)(jiti@2.4.2)(jsdom@26.1.0(bufferutil@4.0.9))(lightningcss@1.30.1)(msw@2.9.0(@types/node@22.15.29)(typescript@5.8.3))(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.1
-      '@vitest/mocker': 3.2.1(msw@2.8.7(@types/node@22.15.29)(typescript@5.8.3))(vite@6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0))
+      '@vitest/mocker': 3.2.1(msw@2.9.0(@types/node@22.15.29)(typescript@5.8.3))(vite@6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0))
       '@vitest/pretty-format': 3.2.1
       '@vitest/runner': 3.2.1
       '@vitest/snapshot': 3.2.1
@@ -21825,7 +21837,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 22.15.29
-      '@vitest/browser': 3.2.1(bufferutil@4.0.9)(msw@2.8.7(@types/node@22.15.29)(typescript@5.8.3))(playwright@1.52.0)(vite@6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0))(vitest@3.2.1)
+      '@vitest/browser': 3.2.1(bufferutil@4.0.9)(msw@2.9.0(@types/node@22.15.29)(typescript@5.8.3))(playwright@1.52.0)(vite@6.3.5(@types/node@22.15.29)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.40.0)(tsx@4.19.4)(yaml@2.8.0))(vitest@3.2.1)
       jsdom: 26.1.0(bufferutil@4.0.9)
     transitivePeerDependencies:
       - jiti


### PR DESCRIPTION
This PR removes the patch we declared [here](https://github.com/zimicjs/zimic/pull/423#issuecomment-2614118618) after the upgrade to msw@2.7.0. https://github.com/mswjs/msw/issues/2146 was causing our browser tests to be highly flaky when running in parallel, but it appears to be fixed now.