### PR TITLE
fix(interceptor): add default `onUnhandledRequest` type to `HttpInterceptor`

### DIFF
--- a/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/types.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/types.ts
@@ -1478,18 +1478,15 @@ export function declareTypeHttpInterceptorTests(
   });
 
   describe('Unhandled requests', () => {
-    it('should correctly type the unhandled request strategy', async () => {
-      await usingHttpInterceptor<{}>({ type, baseURL }, (interceptor: HttpInterceptor<{}>) => {
-        expectTypeOf(interceptor.onUnhandledRequest).toEqualTypeOf<UnhandledRequestStrategy | undefined>();
-      });
+    it('should correctly type the unhandled request strategy', () => {
+      const interceptor: HttpInterceptor<{}> = createHttpInterceptor<{}>({ type, baseURL });
+      expectTypeOf(interceptor.onUnhandledRequest).toEqualTypeOf<UnhandledRequestStrategy | undefined>();
 
-      await usingHttpInterceptor<{}>({ type: 'local', baseURL }, (interceptor) => {
-        expectTypeOf(interceptor.onUnhandledRequest).toEqualTypeOf<UnhandledRequestStrategy.Local | undefined>();
-      });
+      const localInterceptor = createHttpInterceptor<{}>({ type: 'local', baseURL });
+      expectTypeOf(localInterceptor.onUnhandledRequest).toEqualTypeOf<UnhandledRequestStrategy.Local | undefined>();
 
-      await usingHttpInterceptor<{}>({ type: 'remote', baseURL }, (interceptor) => {
-        expectTypeOf(interceptor.onUnhandledRequest).toEqualTypeOf<UnhandledRequestStrategy.Remote | undefined>();
-      });
+      const remoteInterceptor = createHttpInterceptor<{}>({ type: 'remote', baseURL });
+      expectTypeOf(remoteInterceptor.onUnhandledRequest).toEqualTypeOf<UnhandledRequestStrategy.Remote | undefined>();
     });
   });
 }

--- a/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/types.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/types.ts
@@ -5,6 +5,8 @@ import { HttpRequestHandlerPath } from '@/http/requestHandler/types/utils';
 import { usingHttpInterceptor } from '@tests/utils/interceptors';
 
 import { createHttpInterceptor } from '../../factory';
+import { UnhandledRequestStrategy } from '../../types/options';
+import { HttpInterceptor } from '../../types/public';
 import { InferHttpInterceptorSchema } from '../../types/schema';
 import { RuntimeSharedHttpInterceptorTestsOptions } from './utils';
 
@@ -23,29 +25,6 @@ export function declareTypeHttpInterceptorTests(
 
   beforeEach(() => {
     baseURL = getBaseURL();
-  });
-
-  it('should correctly type local interceptors (type: )', async () => {
-    await usingHttpInterceptor<{
-      '/users': {
-        POST: {
-          request: { body: User };
-          response: { 201: { body: User } };
-        };
-      };
-    }>({ type, baseURL }, async (interceptor) => {
-      const _creationHandler = await interceptor.post('/users').respond((request) => {
-        expectTypeOf(request.body).toEqualTypeOf<User>();
-
-        return {
-          status: 201,
-          body: users[0],
-        };
-      });
-
-      type RequestBody = (typeof _creationHandler.requests)[number]['body'];
-      expectTypeOf<RequestBody>().toEqualTypeOf<User>();
-    });
   });
 
   it('should correctly type requests', async () => {
@@ -1494,6 +1473,22 @@ export function declareTypeHttpInterceptorTests(
 
         type FailedSpecificResponseBody = (typeof _failedSpecificListHandler.requests)[number]['response']['body'];
         expectTypeOf<FailedSpecificResponseBody>().toEqualTypeOf<{ message: string }>();
+      });
+    });
+  });
+
+  describe('Unhandled requests', () => {
+    it('should correctly type the unhandled request strategy', async () => {
+      await usingHttpInterceptor<{}>({ type, baseURL }, (interceptor: HttpInterceptor<{}>) => {
+        expectTypeOf(interceptor.onUnhandledRequest).toEqualTypeOf<UnhandledRequestStrategy | undefined>();
+      });
+
+      await usingHttpInterceptor<{}>({ type: 'local', baseURL }, (interceptor) => {
+        expectTypeOf(interceptor.onUnhandledRequest).toEqualTypeOf<UnhandledRequestStrategy.Local | undefined>();
+      });
+
+      await usingHttpInterceptor<{}>({ type: 'remote', baseURL }, (interceptor) => {
+        expectTypeOf(interceptor.onUnhandledRequest).toEqualTypeOf<UnhandledRequestStrategy.Remote | undefined>();
       });
     });
   });

--- a/packages/zimic-interceptor/src/http/interceptor/types/public.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/types/public.ts
@@ -36,6 +36,15 @@ export interface HttpInterceptor<_Schema extends HttpSchema> {
   requestSaving: HttpInterceptorRequestSaving;
 
   /**
+   * The strategy to use for unhandled requests. If a request starts with the base URL of the interceptor, but no
+   * matching handler exists, this strategy will be used. If a function is provided, it will be called with the
+   * unhandled request.
+   *
+   * @see {@link https://zimic.dev/docs/interceptor/guides/http/unhandled-requests Unhandled requests}
+   */
+  onUnhandledRequest?: UnhandledRequestStrategy;
+
+  /**
    * The platform the interceptor is running on.
    *
    * @readonly
@@ -123,13 +132,6 @@ export interface LocalHttpInterceptor<Schema extends HttpSchema> extends HttpInt
   /** @readonly */
   get type(): 'local';
 
-  /**
-   * The strategy to use for unhandled requests. If a request starts with the base URL of the interceptor, but no
-   * matching handler exists, this strategy will be used. If a function is provided, it will be called with the
-   * unhandled request.
-   *
-   * @see {@link https://zimic.dev/docs/interceptor/guides/http/unhandled-requests Unhandled requests}
-   */
   onUnhandledRequest?: UnhandledRequestStrategy.Local;
 
   /**
@@ -320,13 +322,6 @@ export interface RemoteHttpInterceptor<Schema extends HttpSchema> extends HttpIn
    */
   auth?: RemoteHttpInterceptorOptions['auth'];
 
-  /**
-   * The strategy to use for unhandled requests. If a request starts with the base URL of the interceptor, but no
-   * matching handler exists, this strategy will be used. If a function is provided, it will be called with the
-   * unhandled request.
-   *
-   * @see {@link https://zimic.dev/docs/interceptor/guides/http/unhandled-requests Unhandled requests}
-   */
   onUnhandledRequest?: UnhandledRequestStrategy.Remote;
 
   /**


### PR DESCRIPTION
The type `HttpInterceptor`, which serves as base for `LocalHttpInterceptor` and `RemoteHttpInterceptor`, had no default `onUnhandledRequest` property. This pull request adds it as a union of `UnhandledRequestStrategy.Local` and `UnhandledRequestStrategy.Remote`.