### PR TITLE
chore(ci): improve documentation release comments

### DIFF
--- a/.github/actions/zimic-release-comments/action.yaml
+++ b/.github/actions/zimic-release-comments/action.yaml
@@ -24,10 +24,10 @@ runs:
 
           const projectName = '${{ inputs.project-name }}';
           const tag = '${{ inputs.ref-name }}';
-          const version = tag.replace(/^@[^@]+@|^v/, '');
+          const version = tag.replace(/^@?[^@]*@|^v/, '');
 
           const isStable = !version.includes('-');
-          const isCanary = version.includes('-canary');
+          const isCanary = version.includes('-canary.');
 
           const githubOwner = 'zimicjs';
           const githubRepository = 'zimic';


### PR DESCRIPTION
This pull request fixes the [regex to determine if the released version is stable](https://github.com/zimicjs/zimic/pull/838/commits/c6a04ca9658981834fda67b8b8831a0602e02463#diff-fe90602007c397c4c3a907c65defece8adba713f0f755f39580d2a203e473b97L27) (i.e. has no prerelease id). It was considering any `zimic-web@<version>` release as not stable.