### PR TITLE
fix(interceptor): count matched requests even if no response declaration exists (#952)

### DIFF
--- a/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/times.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/times.ts
@@ -80,7 +80,7 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
               message: `Expected exactly ${
                 numberOfRequestsIncludingPreflight
               } request${numberOfRequestsIncludingPreflight === 1 ? '' : 's'}, but got 0.`,
-              numberOfRequests: numberOfRequestsIncludingPreflight,
+              expectedNumberOfRequests: numberOfRequestsIncludingPreflight,
             },
           );
 
@@ -139,7 +139,7 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
             },
             {
               message: `Expected exactly ${numberOfRequestsIncludingPreflight * 2} requests, but got 0.`,
-              numberOfRequests: numberOfRequestsIncludingPreflight * 2,
+              expectedNumberOfRequests: numberOfRequestsIncludingPreflight * 2,
             },
           );
 
@@ -156,7 +156,7 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
               message: `Expected exactly ${
                 numberOfRequestsIncludingPreflight * 2
               } requests, but got ${numberOfRequestsIncludingPreflight}.`,
-              numberOfRequests: numberOfRequestsIncludingPreflight * 2,
+              expectedNumberOfRequests: numberOfRequestsIncludingPreflight * 2,
             },
           );
 
@@ -182,7 +182,7 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
               message: `Expected exactly ${
                 numberOfRequestsIncludingPreflight * 4
               } requests, but got ${numberOfRequestsIncludingPreflight * 3}.`,
-              numberOfRequests: numberOfRequestsIncludingPreflight * 4,
+              expectedNumberOfRequests: numberOfRequestsIncludingPreflight * 4,
             },
           );
         });
@@ -218,7 +218,7 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
               message: `Expected exactly ${
                 numberOfRequestsIncludingPreflight
               } request${numberOfRequestsIncludingPreflight === 1 ? '' : 's'}, but got 0.`,
-              numberOfRequests: numberOfRequestsIncludingPreflight,
+              expectedNumberOfRequests: numberOfRequestsIncludingPreflight,
             },
           );
 
@@ -252,7 +252,7 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
               } request${numberOfRequestsIncludingPreflight === 1 ? '' : 's'}, but got ${
                 numberOfRequestsIncludingPreflight * 2
               }.`,
-              numberOfRequests: numberOfRequestsIncludingPreflight,
+              expectedNumberOfRequests: numberOfRequestsIncludingPreflight,
             },
           );
 
@@ -276,7 +276,7 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
               } request${numberOfRequestsIncludingPreflight === 1 ? '' : 's'}, but got ${
                 numberOfRequestsIncludingPreflight * 3
               }.`,
-              numberOfRequests: numberOfRequestsIncludingPreflight,
+              expectedNumberOfRequests: numberOfRequestsIncludingPreflight,
             },
           );
         });
@@ -361,8 +361,11 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
               message: `Expected at least ${
                 numberOfRequestsIncludingPreflight * 2
               } and at most ${numberOfRequestsIncludingPreflight * 3} requests, but got 0.`,
-              minNumberOfRequests: numberOfRequestsIncludingPreflight * 2,
-              maxNumberOfRequests: numberOfRequestsIncludingPreflight * 3,
+
+              expectedNumberOfRequests: {
+                min: numberOfRequestsIncludingPreflight * 2,
+                max: numberOfRequestsIncludingPreflight * 3,
+              },
             },
           );
 
@@ -381,8 +384,11 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
               } and at most ${numberOfRequestsIncludingPreflight * 3} requests, but got ${
                 numberOfRequestsIncludingPreflight
               }.`,
-              minNumberOfRequests: numberOfRequestsIncludingPreflight * 2,
-              maxNumberOfRequests: numberOfRequestsIncludingPreflight * 3,
+
+              expectedNumberOfRequests: {
+                min: numberOfRequestsIncludingPreflight * 2,
+                max: numberOfRequestsIncludingPreflight * 3,
+              },
             },
           );
 
@@ -486,8 +492,11 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
               } and at most ${numberOfRequestsIncludingPreflight * 3} requests, but got ${
                 numberOfRequestsIncludingPreflight * 4
               }.`,
-              minNumberOfRequests: numberOfRequestsIncludingPreflight * 2,
-              maxNumberOfRequests: numberOfRequestsIncludingPreflight * 3,
+
+              expectedNumberOfRequests: {
+                min: numberOfRequestsIncludingPreflight * 2,
+                max: numberOfRequestsIncludingPreflight * 3,
+              },
             },
           );
         });
@@ -521,8 +530,11 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
               message: `Expected exactly ${numberOfRequestsIncludingPreflight} request${
                 numberOfRequestsIncludingPreflight === 1 ? '' : 's'
               }, but got 0.`,
-              minNumberOfRequests: numberOfRequestsIncludingPreflight,
-              maxNumberOfRequests: numberOfRequestsIncludingPreflight,
+
+              expectedNumberOfRequests: {
+                min: numberOfRequestsIncludingPreflight,
+                max: numberOfRequestsIncludingPreflight,
+              },
             },
           );
 
@@ -554,8 +566,11 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
               message: `Expected exactly ${numberOfRequestsIncludingPreflight} request${
                 numberOfRequestsIncludingPreflight === 1 ? '' : 's'
               }, but got ${numberOfRequestsIncludingPreflight * 2}.`,
-              minNumberOfRequests: numberOfRequestsIncludingPreflight,
-              maxNumberOfRequests: numberOfRequestsIncludingPreflight,
+
+              expectedNumberOfRequests: {
+                min: numberOfRequestsIncludingPreflight,
+                max: numberOfRequestsIncludingPreflight,
+              },
             },
           );
         });
@@ -590,7 +605,7 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
             async () => {
               await promiseIfRemote(interceptor.checkTimes(), interceptor);
             },
-            { message: 'Expected exactly 1 matching request, but got 0.', numberOfRequests: 1 },
+            { message: 'Expected exactly 1 matching request, but got 0.', expectedNumberOfRequests: 1 },
           );
 
           const responsePromise = fetch(joinURL(baseURL, '/users'), {
@@ -633,13 +648,13 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
             },
             {
               message: contentLines.join('\n'),
-              numberOfRequests: 1,
+              expectedNumberOfRequests: 1,
             },
           );
         });
       });
 
-      it('should not consider requests unmatched due to missing response declarations in time checks', async () => {
+      it('should consider requests unmatched due to missing response declarations in time checks', async () => {
         await usingHttpInterceptor<{
           '/users': {
             GET: MethodSchema;
@@ -651,7 +666,10 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
             OPTIONS: MethodSchema;
           };
         }>(interceptorOptions, async (interceptor) => {
-          const handler = await promiseIfRemote(interceptor[lowerMethod]('/users').times(1), interceptor);
+          const handler = await promiseIfRemote(
+            interceptor[lowerMethod]('/users').times(numberOfRequestsIncludingPreflight),
+            interceptor,
+          );
           expect(handler).toBeInstanceOf(Handler);
 
           expect(handler.requests).toHaveLength(0);
@@ -660,10 +678,27 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
             async () => {
               await promiseIfRemote(interceptor.checkTimes(), interceptor);
             },
-            { message: 'Expected exactly 1 request, but got 0.', numberOfRequests: 1 },
+            {
+              message: `Expected exactly ${numberOfRequestsIncludingPreflight} request${
+                numberOfRequestsIncludingPreflight === 1 ? '' : 's'
+              }, but got 0.`,
+              expectedNumberOfRequests: numberOfRequestsIncludingPreflight,
+            },
           );
 
-          const responsePromise = fetch(joinURL(baseURL, '/users'), { method });
+          let responsePromise = fetch(joinURL(baseURL, '/users'), { method });
+
+          if (overridesPreflightResponse) {
+            await expectPreflightResponse(responsePromise);
+          } else {
+            await expectFetchError(responsePromise);
+          }
+
+          expect(handler.requests).toHaveLength(0);
+
+          await promiseIfRemote(interceptor.checkTimes(), interceptor);
+
+          responsePromise = fetch(joinURL(baseURL, '/users'), { method });
 
           if (overridesPreflightResponse) {
             await expectPreflightResponse(responsePromise);
@@ -677,7 +712,13 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
             async () => {
               await promiseIfRemote(interceptor.checkTimes(), interceptor);
             },
-            { message: 'Expected exactly 1 request, but got 0.', numberOfRequests: 1 },
+            {
+              message: `Expected exactly ${numberOfRequestsIncludingPreflight} request${
+                numberOfRequestsIncludingPreflight === 1 ? '' : 's'
+              }, but got ${numberOfRequestsIncludingPreflight * 2}.`,
+
+              expectedNumberOfRequests: numberOfRequestsIncludingPreflight,
+            },
           );
         });
       });
@@ -709,7 +750,7 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
             async () => {
               await promiseIfRemote(interceptor.checkTimes(), interceptor);
             },
-            { message: 'Expected exactly 1 matching request, but got 0.', numberOfRequests: 1 },
+            { message: 'Expected exactly 1 matching request, but got 0.', expectedNumberOfRequests: 1 },
           );
 
           const responsePromise = fetch(joinURL(baseURL, '/users/other'), { method });
@@ -726,7 +767,7 @@ export async function declareTimesHttpInterceptorTests(options: RuntimeSharedHtt
             async () => {
               await promiseIfRemote(interceptor.checkTimes(), interceptor);
             },
-            { message: 'Expected exactly 1 matching request, but got 0.', numberOfRequests: 1 },
+            { message: 'Expected exactly 1 matching request, but got 0.', expectedNumberOfRequests: 1 },
           );
         });
       });

--- a/packages/zimic-interceptor/src/http/requestHandler/HttpRequestHandlerClient.ts
+++ b/packages/zimic-interceptor/src/http/requestHandler/HttpRequestHandlerClient.ts
@@ -161,10 +161,6 @@ class HttpRequestHandlerClient<
   async matchesRequest(request: HttpInterceptorRequest<Path, Default<Schema[Path][Method]>>): Promise<boolean> {
     const hasDeclaredResponse = this.createResponseDeclaration !== undefined;
 
-    if (!hasDeclaredResponse) {
-      return false;
-    }
-
     const restrictionsMatch = await this.matchesRequestRestrictions(request);
 
     if (restrictionsMatch.value) {
@@ -178,6 +174,10 @@ class HttpRequestHandlerClient<
       if (shouldSaveUnmatchedGroup) {
         this.unmatchedRequestGroups.push({ request, diff: restrictionsMatch.diff });
       }
+    }
+
+    if (!hasDeclaredResponse) {
+      return false;
     }
 
     const isWithinLimits = this.numberOfMatchedRequests <= this.limits.numberOfRequests.max;

--- a/packages/zimic-interceptor/src/http/requestHandler/__tests__/shared/times.ts
+++ b/packages/zimic-interceptor/src/http/requestHandler/__tests__/shared/times.ts
@@ -65,7 +65,7 @@ export function declareTimesHttpRequestHandlerTests(
         async () => {
           await promiseIfRemote(handler.checkTimes(), handler);
         },
-        { message: 'Expected exactly 1 request, but got 0.', numberOfRequests: 1 },
+        { message: 'Expected exactly 1 request, but got 0.', expectedNumberOfRequests: 1 },
       );
 
       const request = new Request(joinURL(baseURL, '/users'), { method: 'POST' });
@@ -92,7 +92,7 @@ export function declareTimesHttpRequestHandlerTests(
         async () => {
           await promiseIfRemote(handler.checkTimes(), handler);
         },
-        { message: 'Expected exactly 2 requests, but got 0.', minNumberOfRequests: 2 },
+        { message: 'Expected exactly 2 requests, but got 0.', expectedNumberOfRequests: 2 },
       );
 
       const request = new Request(joinURL(baseURL, '/users'), { method: 'POST' });
@@ -104,7 +104,7 @@ export function declareTimesHttpRequestHandlerTests(
         async () => {
           await promiseIfRemote(handler.checkTimes(), handler);
         },
-        { message: 'Expected exactly 2 requests, but got 1.', minNumberOfRequests: 2 },
+        { message: 'Expected exactly 2 requests, but got 1.', expectedNumberOfRequests: 2 },
       );
 
       expect(await handler.matchesRequest(parsedRequest)).toBe(true);
@@ -117,7 +117,7 @@ export function declareTimesHttpRequestHandlerTests(
         async () => {
           await promiseIfRemote(handler.checkTimes(), handler);
         },
-        { message: 'Expected exactly 4 requests, but got 3.', minNumberOfRequests: 4 },
+        { message: 'Expected exactly 4 requests, but got 3.', expectedNumberOfRequests: 4 },
       );
     });
 
@@ -130,7 +130,7 @@ export function declareTimesHttpRequestHandlerTests(
         async () => {
           await promiseIfRemote(handler.checkTimes(), handler);
         },
-        { message: 'Expected exactly 1 request, but got 0.', numberOfRequests: 1 },
+        { message: 'Expected exactly 1 request, but got 0.', expectedNumberOfRequests: 1 },
       );
 
       const request = new Request(joinURL(baseURL, '/users'), { method: 'POST' });
@@ -145,7 +145,7 @@ export function declareTimesHttpRequestHandlerTests(
         async () => {
           await promiseIfRemote(handler.checkTimes(), handler);
         },
-        { message: 'Expected exactly 1 request, but got 2.', numberOfRequests: 1 },
+        { message: 'Expected exactly 1 request, but got 2.', expectedNumberOfRequests: 1 },
       );
 
       expect(await handler.matchesRequest(parsedRequest)).toBe(false);
@@ -154,7 +154,7 @@ export function declareTimesHttpRequestHandlerTests(
         async () => {
           await promiseIfRemote(handler.checkTimes(), handler);
         },
-        { message: 'Expected exactly 1 request, but got 3.', numberOfRequests: 1 },
+        { message: 'Expected exactly 1 request, but got 3.', expectedNumberOfRequests: 1 },
       );
     });
   });
@@ -191,8 +191,7 @@ export function declareTimesHttpRequestHandlerTests(
         },
         {
           message: 'Expected at least 2 and at most 3 requests, but got 0.',
-          minNumberOfRequests: 2,
-          maxNumberOfRequests: 3,
+          expectedNumberOfRequests: { min: 2, max: 3 },
         },
       );
 
@@ -207,8 +206,7 @@ export function declareTimesHttpRequestHandlerTests(
         },
         {
           message: 'Expected at least 2 and at most 3 requests, but got 1.',
-          minNumberOfRequests: 2,
-          maxNumberOfRequests: 3,
+          expectedNumberOfRequests: { min: 2, max: 3 },
         },
       );
 
@@ -251,8 +249,7 @@ export function declareTimesHttpRequestHandlerTests(
         },
         {
           message: 'Expected at least 2 and at most 3 requests, but got 4.',
-          minNumberOfRequests: 2,
-          maxNumberOfRequests: 3,
+          expectedNumberOfRequests: { min: 2, max: 3 },
         },
       );
     });
@@ -278,8 +275,7 @@ export function declareTimesHttpRequestHandlerTests(
         },
         {
           message: 'Expected at least 0 and at most 1 request, but got 2.',
-          minNumberOfRequests: 0,
-          maxNumberOfRequests: 1,
+          expectedNumberOfRequests: { min: 0, max: 1 },
         },
       );
     });
@@ -293,7 +289,7 @@ export function declareTimesHttpRequestHandlerTests(
         async () => {
           await promiseIfRemote(handler.checkTimes(), handler);
         },
-        { message: 'Expected exactly 1 request, but got 0.', minNumberOfRequests: 1, maxNumberOfRequests: 1 },
+        { message: 'Expected exactly 1 request, but got 0.', expectedNumberOfRequests: { min: 1, max: 1 } },
       );
 
       const request = new Request(joinURL(baseURL, '/users'), { method: 'POST' });
@@ -308,7 +304,7 @@ export function declareTimesHttpRequestHandlerTests(
         async () => {
           await promiseIfRemote(handler.checkTimes(), handler);
         },
-        { message: 'Expected exactly 1 request, but got 2.', minNumberOfRequests: 1, maxNumberOfRequests: 1 },
+        { message: 'Expected exactly 1 request, but got 2.', expectedNumberOfRequests: { min: 1, max: 1 } },
       );
     });
 
@@ -321,7 +317,7 @@ export function declareTimesHttpRequestHandlerTests(
         async () => {
           await promiseIfRemote(handler.checkTimes(), handler);
         },
-        { message: 'Expected exactly 2 requests, but got 0.', minNumberOfRequests: 2, maxNumberOfRequests: 2 },
+        { message: 'Expected exactly 2 requests, but got 0.', expectedNumberOfRequests: { min: 2, max: 2 } },
       );
 
       const request = new Request(joinURL(baseURL, '/users'), { method: 'POST' });
@@ -333,7 +329,7 @@ export function declareTimesHttpRequestHandlerTests(
         async () => {
           await promiseIfRemote(handler.checkTimes(), handler);
         },
-        { message: 'Expected exactly 2 requests, but got 1.', minNumberOfRequests: 2, maxNumberOfRequests: 2 },
+        { message: 'Expected exactly 2 requests, but got 1.', expectedNumberOfRequests: { min: 2, max: 2 } },
       );
 
       expect(await handler.matchesRequest(parsedRequest)).toBe(true);
@@ -345,7 +341,7 @@ export function declareTimesHttpRequestHandlerTests(
         async () => {
           await promiseIfRemote(handler.checkTimes(), handler);
         },
-        { message: 'Expected exactly 2 requests, but got 3.', minNumberOfRequests: 2, maxNumberOfRequests: 2 },
+        { message: 'Expected exactly 2 requests, but got 3.', expectedNumberOfRequests: { min: 2, max: 2 } },
       );
     });
   });
@@ -377,7 +373,7 @@ export function declareTimesHttpRequestHandlerTests(
                   '',
                   'Tip: use `requestSaving.enabled: true` in your interceptor for more details about the unmatched requests.',
                 ].join('\n'),
-                numberOfRequests: 1,
+                expectedNumberOfRequests: 1,
               },
             );
 
@@ -396,7 +392,7 @@ export function declareTimesHttpRequestHandlerTests(
                   '',
                   'Tip: use `requestSaving.enabled: true` in your interceptor for more details about the unmatched requests.',
                 ].join('\n'),
-                numberOfRequests: 1,
+                expectedNumberOfRequests: 1,
               },
             );
           },
@@ -413,7 +409,7 @@ export function declareTimesHttpRequestHandlerTests(
           async () => {
             await promiseIfRemote(handler.checkTimes(), handler);
           },
-          { message: 'Expected exactly 1 matching request, but got 0.', numberOfRequests: 1 },
+          { message: 'Expected exactly 1 matching request, but got 0.', expectedNumberOfRequests: 1 },
         );
 
         const request = new Request(joinURL(baseURL, '/users'), { method: 'POST' });
@@ -439,7 +435,7 @@ export function declareTimesHttpRequestHandlerTests(
               `       ${color.green('- return true')}`,
               `       ${color.red('+ return false')}`,
             ].join('\n'),
-            numberOfRequests: 1,
+            expectedNumberOfRequests: 1,
           },
         );
       });
@@ -454,7 +450,7 @@ export function declareTimesHttpRequestHandlerTests(
           async () => {
             await promiseIfRemote(handler.checkTimes(), handler);
           },
-          { message: 'Expected exactly 1 matching request, but got 0.', numberOfRequests: 1 },
+          { message: 'Expected exactly 1 matching request, but got 0.', expectedNumberOfRequests: 1 },
         );
 
         let request = new Request(joinURL(baseURL, '/users'), { method: 'POST' });
@@ -480,7 +476,7 @@ export function declareTimesHttpRequestHandlerTests(
               `       ${color.green('- { "accept": "application/json" }')}`,
               `       ${color.red('+ {}')}`,
             ].join('\n'),
-            numberOfRequests: 1,
+            expectedNumberOfRequests: 1,
           },
         );
 
@@ -515,7 +511,7 @@ export function declareTimesHttpRequestHandlerTests(
               `       ${color.green('- { "accept": "application/json" }')}`,
               `       ${color.red('+ { "accept": "text/html", "content-type": "text/plain" }')}`,
             ].join('\n'),
-            numberOfRequests: 1,
+            expectedNumberOfRequests: 1,
           },
         );
       });
@@ -530,7 +526,7 @@ export function declareTimesHttpRequestHandlerTests(
           async () => {
             await promiseIfRemote(handler.checkTimes(), handler);
           },
-          { message: 'Expected exactly 1 matching request, but got 0.', numberOfRequests: 1 },
+          { message: 'Expected exactly 1 matching request, but got 0.', expectedNumberOfRequests: 1 },
         );
 
         let request = new Request(joinURL(baseURL, '/users'), { method: 'POST' });
@@ -556,7 +552,7 @@ export function declareTimesHttpRequestHandlerTests(
               `       ${color.green('- { "value": "1" }')}`,
               `       ${color.red('+ {}')}`,
             ].join('\n'),
-            numberOfRequests: 1,
+            expectedNumberOfRequests: 1,
           },
         );
 
@@ -589,7 +585,7 @@ export function declareTimesHttpRequestHandlerTests(
               `       ${color.green('- { "value": "1" }')}`,
               `       ${color.red('+ { "name": "1", "value": "2" }')}`,
             ].join('\n'),
-            numberOfRequests: 1,
+            expectedNumberOfRequests: 1,
           },
         );
       });
@@ -604,7 +600,7 @@ export function declareTimesHttpRequestHandlerTests(
           async () => {
             await promiseIfRemote(handler.checkTimes(), handler);
           },
-          { message: 'Expected exactly 1 matching request, but got 0.', numberOfRequests: 1 },
+          { message: 'Expected exactly 1 matching request, but got 0.', expectedNumberOfRequests: 1 },
         );
 
         let request = new Request(joinURL(baseURL, '/users'), { method: 'POST' });
@@ -630,7 +626,7 @@ export function declareTimesHttpRequestHandlerTests(
               `       ${color.green('- { "name": "1" }')}`,
               `       ${color.red('+ null')}`,
             ].join('\n'),
-            numberOfRequests: 1,
+            expectedNumberOfRequests: 1,
           },
         );
 
@@ -666,7 +662,7 @@ export function declareTimesHttpRequestHandlerTests(
               `       ${color.green('- { "name": "1" }')}`,
               `       ${color.red('+ { "name": "2" }')}`,
             ].join('\n'),
-            numberOfRequests: 1,
+            expectedNumberOfRequests: 1,
           },
         );
       });
@@ -681,7 +677,7 @@ export function declareTimesHttpRequestHandlerTests(
           async () => {
             await promiseIfRemote(handler.checkTimes(), handler);
           },
-          { message: 'Expected exactly 1 matching request, but got 0.', numberOfRequests: 1 },
+          { message: 'Expected exactly 1 matching request, but got 0.', expectedNumberOfRequests: 1 },
         );
 
         let request = new Request(joinURL(baseURL, '/users'), { method: 'POST' });
@@ -707,7 +703,7 @@ export function declareTimesHttpRequestHandlerTests(
               `       ${color.green('- URLSearchParams { "name": "1" }')}`,
               `       ${color.red('+ null')}`,
             ].join('\n'),
-            numberOfRequests: 1,
+            expectedNumberOfRequests: 1,
           },
         );
 
@@ -743,7 +739,7 @@ export function declareTimesHttpRequestHandlerTests(
               `       ${color.green('- URLSearchParams { "name": "1" }')}`,
               `       ${color.red('+ URLSearchParams { "name": "2" }')}`,
             ].join('\n'),
-            numberOfRequests: 1,
+            expectedNumberOfRequests: 1,
           },
         );
       });
@@ -761,7 +757,7 @@ export function declareTimesHttpRequestHandlerTests(
           async () => {
             await promiseIfRemote(handler.checkTimes(), handler);
           },
-          { message: 'Expected exactly 1 matching request, but got 0.', numberOfRequests: 1 },
+          { message: 'Expected exactly 1 matching request, but got 0.', expectedNumberOfRequests: 1 },
         );
 
         let request = new Request(joinURL(baseURL, '/users'), { method: 'POST' });
@@ -787,7 +783,7 @@ export function declareTimesHttpRequestHandlerTests(
               `       ${color.green('- FormData { "name": "1" }')}`,
               `       ${color.red('+ null')}`,
             ].join('\n'),
-            numberOfRequests: 1,
+            expectedNumberOfRequests: 1,
           },
         );
 
@@ -847,7 +843,7 @@ export function declareTimesHttpRequestHandlerTests(
                 } }`,
               )}`,
             ].join('\n'),
-            numberOfRequests: 1,
+            expectedNumberOfRequests: 1,
           },
         );
       });
@@ -862,7 +858,7 @@ export function declareTimesHttpRequestHandlerTests(
           async () => {
             await promiseIfRemote(handler.checkTimes(), handler);
           },
-          { message: 'Expected exactly 1 matching request, but got 0.', numberOfRequests: 1 },
+          { message: 'Expected exactly 1 matching request, but got 0.', expectedNumberOfRequests: 1 },
         );
 
         let request = new Request(joinURL(baseURL, '/users'), { method: 'POST' });
@@ -888,7 +884,7 @@ export function declareTimesHttpRequestHandlerTests(
               `       ${color.green("- Blob { type: 'application/octet-stream', size: 1 }")}`,
               `       ${color.red('+ null')}`,
             ].join('\n'),
-            numberOfRequests: 1,
+            expectedNumberOfRequests: 1,
           },
         );
 
@@ -923,7 +919,7 @@ export function declareTimesHttpRequestHandlerTests(
               `       ${color.green("- Blob { type: 'application/octet-stream', size: 1 }")}`,
               `       ${color.red("+ Blob { type: 'application/octet-stream', size: 4 }")}`,
             ].join('\n'),
-            numberOfRequests: 1,
+            expectedNumberOfRequests: 1,
           },
         );
       });
@@ -938,7 +934,7 @@ export function declareTimesHttpRequestHandlerTests(
           async () => {
             await promiseIfRemote(handler.checkTimes(), handler);
           },
-          { message: 'Expected exactly 1 matching request, but got 0.', numberOfRequests: 1 },
+          { message: 'Expected exactly 1 matching request, but got 0.', expectedNumberOfRequests: 1 },
         );
 
         let request = new Request(joinURL(baseURL, '/users'), { method: 'POST' });
@@ -964,7 +960,7 @@ export function declareTimesHttpRequestHandlerTests(
               `       ${color.green('- example')}`,
               `       ${color.red('+ null')}`,
             ].join('\n'),
-            numberOfRequests: 1,
+            expectedNumberOfRequests: 1,
           },
         );
 
@@ -1000,7 +996,7 @@ export function declareTimesHttpRequestHandlerTests(
               `       ${color.green('- example')}`,
               `       ${color.red('+ text')}`,
             ].join('\n'),
-            numberOfRequests: 1,
+            expectedNumberOfRequests: 1,
           },
         );
       });
@@ -1014,7 +1010,7 @@ export function declareTimesHttpRequestHandlerTests(
           async () => {
             await promiseIfRemote(handler.checkTimes(), handler);
           },
-          { message: 'Expected exactly 1 request, but got 0.', numberOfRequests: 1 },
+          { message: 'Expected exactly 1 request, but got 0.', expectedNumberOfRequests: 1 },
         );
 
         const request = new Request(joinURL(baseURL, '/users'), { method: 'POST' });
@@ -1022,11 +1018,15 @@ export function declareTimesHttpRequestHandlerTests(
 
         expect(await handler.matchesRequest(parsedRequest)).toBe(false);
 
+        await promiseIfRemote(handler.checkTimes(), handler);
+
+        expect(await handler.matchesRequest(parsedRequest)).toBe(false);
+
         await expectTimesCheckError(
           async () => {
             await promiseIfRemote(handler.checkTimes(), handler);
           },
-          { message: 'Expected exactly 1 request, but got 0.', numberOfRequests: 1 },
+          { message: 'Expected exactly 1 request, but got 2.', expectedNumberOfRequests: 1 },
         );
       });
     });
@@ -1042,7 +1042,7 @@ export function declareTimesHttpRequestHandlerTests(
         async () => {
           await promiseIfRemote(handler.checkTimes(), handler);
         },
-        { message: 'Expected exactly 1 request, but got 0.', numberOfRequests: 1 },
+        { message: 'Expected exactly 1 request, but got 0.', expectedNumberOfRequests: 1 },
       );
 
       handler.clear();
@@ -1076,8 +1076,7 @@ export function declareTimesHttpRequestHandlerTests(
         },
         {
           message: 'Expected at least 1 and at most 3 requests, but got 0.',
-          minNumberOfRequests: 1,
-          maxNumberOfRequests: 3,
+          expectedNumberOfRequests: { min: 1, max: 3 },
         },
       );
 

--- a/packages/zimic-interceptor/src/http/requestHandler/__tests__/shared/utils.ts
+++ b/packages/zimic-interceptor/src/http/requestHandler/__tests__/shared/utils.ts
@@ -7,15 +7,8 @@ export async function expectTimesCheckError(
   callback: () => Promise<void> | void,
   options: {
     message: string;
-  } & (
-    | {
-        numberOfRequests: number;
-      }
-    | {
-        minNumberOfRequests: number;
-        maxNumberOfRequests?: number;
-      }
-  ),
+    expectedNumberOfRequests: number | { min: number; max: number };
+  },
 ) {
   const { message } = options;
 
@@ -48,13 +41,11 @@ export async function expectTimesCheckError(
   const timesDeclarationPointer = timesCheckError!.cause! as TimesDeclarationPointer;
   expect(timesDeclarationPointer).toBeInstanceOf(TimesDeclarationPointer);
 
-  if ('numberOfRequests' in options) {
-    expect(timesDeclarationPointer.name).toBe(`handler.times(${options.numberOfRequests})`);
-  } else if (options.maxNumberOfRequests === undefined) {
-    expect(timesDeclarationPointer.name).toBe(`handler.times(${options.minNumberOfRequests})`);
+  if (typeof options.expectedNumberOfRequests === 'number') {
+    expect(timesDeclarationPointer.name).toBe(`handler.times(${options.expectedNumberOfRequests})`);
   } else {
     expect(timesDeclarationPointer.name).toBe(
-      `handler.times(${options.minNumberOfRequests}, ${options.maxNumberOfRequests})`,
+      `handler.times(${options.expectedNumberOfRequests.min}, ${options.expectedNumberOfRequests.max})`,
     );
   }
 


### PR DESCRIPTION
Closes #952.
