### PR TITLE
fix(http): correctly infer literal paths considering escaped colons

### DIFF
--- a/packages/zimic-http/src/types/schema.ts
+++ b/packages/zimic-http/src/types/schema.ts
@@ -328,13 +328,13 @@ export namespace HttpSchemaPath {
   export type Literal<
     Schema extends HttpSchema,
     Method extends HttpSchemaMethod<Schema> = HttpSchemaMethod<Schema>,
-  > = WithoutEscapedColons<LooseLiteral<Schema, Method>>;
+  > = LooseLiteral<Schema, Method>;
 
   /** @see {@link https://zimic.dev/docs/http/api/http-schema#httpschemapathnonliteral `HttpSchemaPath.NonLiteral` API reference} */
   export type NonLiteral<
     Schema extends HttpSchema,
     Method extends HttpSchemaMethod<Schema> = HttpSchemaMethod<Schema>,
-  > = AllowAnyStringInPathParams<LooseLiteral<Schema, Method>>;
+  > = WithoutEscapedColons<AllowAnyStringInPathParams<LooseLiteral<Schema, Method>>>;
 }
 
 export type HttpSchemaPath<


### PR DESCRIPTION
Literal paths were not being inferred correctly from their non-literal counterparts in some cases with escaped colons, such as:

```
/v1.0/drives/:driveId/items/:driveItemId\\:/:fileName\\:/createUploadSession
```