### PR TITLE
docs(examples): set stackblitz compile trigger to `save`

### DIFF
--- a/examples/zimic-with-jest-jsdom/.stackblitzrc
+++ b/examples/zimic-with-jest-jsdom/.stackblitzrc
@@ -1,4 +1,5 @@
 {
+  "startCommand": "pnpm install && (cd node_modules/@zimic/interceptor && pnpm postinstall && cd ../../msw && pnpm postinstall)",
   "installDependencies": false,
-  "startCommand": "pnpm install && (cd node_modules/@zimic/interceptor && pnpm postinstall && cd ../../msw && pnpm postinstall)"
+  "compileTrigger": "save"
 }

--- a/examples/zimic-with-jest-node/.stackblitzrc
+++ b/examples/zimic-with-jest-node/.stackblitzrc
@@ -1,4 +1,5 @@
 {
+  "startCommand": "pnpm install && (cd node_modules/@zimic/interceptor && pnpm postinstall && cd ../../msw && pnpm postinstall)",
   "installDependencies": false,
-  "startCommand": "pnpm install && (cd node_modules/@zimic/interceptor && pnpm postinstall && cd ../../msw && pnpm postinstall)"
+  "compileTrigger": "save"
 }

--- a/examples/zimic-with-next-js-app/.stackblitzrc
+++ b/examples/zimic-with-next-js-app/.stackblitzrc
@@ -1,4 +1,5 @@
 {
+  "startCommand": "pnpm install && (cd node_modules/@zimic/interceptor && pnpm postinstall && cd ../../msw && pnpm postinstall)",
   "installDependencies": false,
-  "startCommand": "pnpm install && (cd node_modules/@zimic/interceptor && pnpm postinstall && cd ../../msw && pnpm postinstall)"
+  "compileTrigger": "save"
 }

--- a/examples/zimic-with-next-js-pages/.stackblitzrc
+++ b/examples/zimic-with-next-js-pages/.stackblitzrc
@@ -1,4 +1,5 @@
 {
+  "startCommand": "pnpm install && (cd node_modules/@zimic/interceptor && pnpm postinstall && cd ../../msw && pnpm postinstall)",
   "installDependencies": false,
-  "startCommand": "pnpm install && (cd node_modules/@zimic/interceptor && pnpm postinstall && cd ../../msw && pnpm postinstall)"
+  "compileTrigger": "save"
 }

--- a/examples/zimic-with-openapi-typegen/.stackblitzrc
+++ b/examples/zimic-with-openapi-typegen/.stackblitzrc
@@ -1,4 +1,5 @@
 {
+  "startCommand": "pnpm install && (cd node_modules/@zimic/interceptor && pnpm postinstall && cd ../../msw && pnpm postinstall)",
   "installDependencies": false,
-  "startCommand": "pnpm install && (cd node_modules/@zimic/interceptor && pnpm postinstall && cd ../../msw && pnpm postinstall)"
+  "compileTrigger": "save"
 }

--- a/examples/zimic-with-playwright/.stackblitzrc
+++ b/examples/zimic-with-playwright/.stackblitzrc
@@ -1,4 +1,5 @@
 {
+  "startCommand": "pnpm install && (cd node_modules/@zimic/interceptor && pnpm postinstall && cd ../../msw && pnpm postinstall)",
   "installDependencies": false,
-  "startCommand": "pnpm install && (cd node_modules/@zimic/interceptor && pnpm postinstall && cd ../../msw && pnpm postinstall)"
+  "compileTrigger": "save"
 }

--- a/examples/zimic-with-vitest-browser/.stackblitzrc
+++ b/examples/zimic-with-vitest-browser/.stackblitzrc
@@ -1,4 +1,5 @@
 {
+  "startCommand": "pnpm install && (cd node_modules/@zimic/interceptor && pnpm postinstall && cd ../../msw && pnpm postinstall)",
   "installDependencies": false,
-  "startCommand": "pnpm install && (cd node_modules/@zimic/interceptor && pnpm postinstall && cd ../../msw && pnpm postinstall)"
+  "compileTrigger": "save"
 }

--- a/examples/zimic-with-vitest-jsdom/.stackblitzrc
+++ b/examples/zimic-with-vitest-jsdom/.stackblitzrc
@@ -1,4 +1,5 @@
 {
+  "startCommand": "pnpm install && (cd node_modules/@zimic/interceptor && pnpm postinstall && cd ../../msw && pnpm postinstall)",
   "installDependencies": false,
-  "startCommand": "pnpm install && (cd node_modules/@zimic/interceptor && pnpm postinstall && cd ../../msw && pnpm postinstall)"
+  "compileTrigger": "save"
 }

--- a/examples/zimic-with-vitest-node/.stackblitzrc
+++ b/examples/zimic-with-vitest-node/.stackblitzrc
@@ -1,4 +1,5 @@
 {
+  "startCommand": "pnpm install && (cd node_modules/@zimic/interceptor && pnpm postinstall && cd ../../msw && pnpm postinstall)",
   "installDependencies": false,
-  "startCommand": "pnpm install && (cd node_modules/@zimic/interceptor && pnpm postinstall && cd ../../msw && pnpm postinstall)"
+  "compileTrigger": "save"
 }


### PR DESCRIPTION
`compileTrigger: 'save'` brings StackBlitz closer to running our examples locally. It can also improve performance by only rerunning tests when the user saves, for example.