### PR TITLE
fix(interceptor): consider null as empty response body

### DIFF
--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.json.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.bodies.json.test.ts
@@ -250,7 +250,7 @@ describe('FetchClient > Bodies > JSON', () => {
       });
 
       expectResponseStatus(response, 201);
-      expect(await response.json()).toEqual(null);
+      expect(await response.text()).toEqual('');
 
       expect(response).toBeInstanceOf(Response);
       expectTypeOf(response satisfies Response).toEqualTypeOf<FetchResponse<Schema, 'POST', '/users'>>();

--- a/packages/zimic-interceptor/src/http/interceptorWorker/HttpInterceptorWorker.ts
+++ b/packages/zimic-interceptor/src/http/interceptorWorker/HttpInterceptorWorker.ts
@@ -208,6 +208,7 @@ abstract class HttpInterceptorWorker {
 
     if (
       typeof declaration.body === 'string' ||
+      declaration.body === null ||
       declaration.body === undefined ||
       declaration.body instanceof FormData ||
       declaration.body instanceof URLSearchParams ||


### PR DESCRIPTION
There was a missing `declaration.body === null` condition here:

https://github.com/zimicjs/zimic/blob/93bf68204ef30f40576061e02b79b20ae4f07942/packages/zimic-interceptor/src/http/interceptorWorker/HttpInterceptorWorker.ts#L211

It caused response declarations with `body: null` to be interpreted as JSON, thus returning the response body as a string (`'null'`), instead of an empty body as the Fetch API. This is incorrect and our test suite was not converting this scenario.

This PR adds the missing condition and increments our tests to correctly check that `body: null` should lead to an empty response body.