### PR TITLE
chore(ci): replace npm tokens with trusted publishing

### DIFF
--- a/.github/actions/zimic-release-npm/action.yaml
+++ b/.github/actions/zimic-release-npm/action.yaml
@@ -11,9 +11,6 @@ inputs:
   project-directory:
     description: The project directory to release
     required: true
-  npm-token:
-    description: The NPM token to release
-    required: true
 
 outputs:
   version-value:
@@ -50,7 +47,6 @@ runs:
       working-directory: ${{ inputs.project-directory }}
       run: pnpm publish --no-git-checks --tag ${{ steps.zimic-version.outputs.label }}
       env:
-        NODE_AUTH_TOKEN: ${{ inputs.npm-token }}
         NPM_CONFIG_PROVENANCE: true
 
     - name: Save turbo cache

--- a/.github/workflows/release-zimic-fetch-package.yaml
+++ b/.github/workflows/release-zimic-fetch-package.yaml
@@ -45,7 +45,6 @@ jobs:
           ref-name: ${{ github.ref_name }}
           project-name: '@zimic/fetch'
           project-directory: packages/zimic-fetch
-          npm-token: ${{ secrets.ZIMIC_NPM_RELEASE_TOKEN }}
 
   test-npm-release:
     name: Test NPM release

--- a/.github/workflows/release-zimic-http-package.yaml
+++ b/.github/workflows/release-zimic-http-package.yaml
@@ -45,7 +45,6 @@ jobs:
           ref-name: ${{ github.ref_name }}
           project-name: '@zimic/http'
           project-directory: packages/zimic-http
-          npm-token: ${{ secrets.ZIMIC_NPM_RELEASE_TOKEN }}
 
   test-npm-release:
     name: Test NPM release

--- a/.github/workflows/release-zimic-interceptor-package.yaml
+++ b/.github/workflows/release-zimic-interceptor-package.yaml
@@ -45,7 +45,6 @@ jobs:
           ref-name: ${{ github.ref_name }}
           project-name: '@zimic/interceptor'
           project-directory: packages/zimic-interceptor
-          npm-token: ${{ secrets.ZIMIC_NPM_RELEASE_TOKEN }}
 
   test-npm-release:
     name: Test NPM release


### PR DESCRIPTION
We no longer need NPM tokens because we are using [trusted publishing](https://docs.npmjs.com/trusted-publishers) per npm's security recommendations.