### PR TITLE
refactor(interceptor): remove `bufferutil`

### DIFF
--- a/packages/zimic-interceptor/package.json
+++ b/packages/zimic-interceptor/package.json
@@ -106,9 +106,6 @@
     "yargs": "18.0.0",
     "zod": "^4.1.12"
   },
-  "optionalDependencies": {
-    "bufferutil": "4.0.9"
-  },
   "devDependencies": {
     "@types/node": "^24.8.1",
     "@types/ws": "^8.18.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -829,10 +829,6 @@ importers:
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.8.1)(@vitest/browser@3.2.4)(jiti@2.6.1)(jsdom@27.0.1(bufferutil@4.0.9)(postcss@8.5.6))(lightningcss@1.30.1)(msw@2.11.1(@types/node@24.8.1)(typescript@5.9.3))(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
-    optionalDependencies:
-      bufferutil:
-        specifier: 4.0.9
-        version: 4.0.9
 
   packages/zimic-utils:
     devDependencies:


### PR DESCRIPTION
[`ws` installation guide](https://www.npmjs.com/package/ws#opt-in-for-performance) recommends `bufferutil` to improve performance in WebSocket communication. However, it is a binary dependency that requires `python3`, `build-essential`, and `make` to install. Since these packages may not be available by default in many Docker base images, this may introduce additional complexity for projects trying to install `@zimic/interceptor`.

From my tests, removing `bufferutil` did not meaningfully impact our use case and our test execution time was not affected.