### PR TITLE
refactor(examples): remove `--turbo` from `dev` scripts

### DIFF
--- a/examples/zimic-with-next-js-app/package.json
+++ b/examples/zimic-with-next-js-app/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": false,
   "scripts": {
-    "dev": "dotenv -c development -- next dev --turbo",
+    "dev": "dotenv -c development -- next dev",
     "mock": "pnpm mock:start -- pnpm mock:load",
     "mock:start": "zimic-interceptor server start --hostname 127.0.0.1 --port 4001 --ephemeral",
     "mock:load": "tsx ./tests/interceptors/scripts/load.ts",

--- a/examples/zimic-with-next-js-pages/package.json
+++ b/examples/zimic-with-next-js-pages/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": false,
   "scripts": {
-    "dev": "dotenv -c development -- next dev --turbo",
+    "dev": "dotenv -c development -- next dev",
     "test": "dotenv -c test -- dotenv -c development -- playwright test",
     "test:turbo": "dotenv -v CI=true -- pnpm run test",
     "types:check": "tsc --noEmit",

--- a/examples/zimic-with-playwright/package.json
+++ b/examples/zimic-with-playwright/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": false,
   "scripts": {
-    "dev": "dotenv -c development -- next dev --turbo",
+    "dev": "dotenv -c development -- next dev",
     "mock": "zimic-interceptor server start --hostname 127.0.0.1 --port 4002 --ephemeral",
     "test": "dotenv -c test -- dotenv -c development -- pnpm mock -- playwright test",
     "test:turbo": "dotenv -v CI=true -- pnpm run test",


### PR DESCRIPTION
Since [Turbopack is stable and enabled by default](https://nextjs.org/blog/next-16#turbopack-stable) on Next.js 16, we no longer need to add `--turbo` to the `dev` scripts of our examples.