### PR TITLE
fix(interceptor): not error on cleared handler after delay

### DIFF
--- a/packages/zimic-interceptor/src/http/interceptor/HttpInterceptorClient.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/HttpInterceptorClient.ts
@@ -284,6 +284,11 @@ class HttpInterceptorClient<
     }
 
     const responseDeclaration = await matchedHandler.applyResponseDeclaration(parsedRequest);
+
+    if (!responseDeclaration) {
+      return null;
+    }
+
     const response = HttpInterceptorWorker.createResponseFromDeclaration(request, responseDeclaration);
 
     if (this.requestSaving.enabled) {

--- a/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/delay.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/delay.ts
@@ -1,10 +1,13 @@
 import { HttpSchema } from '@zimic/http';
+import expectFetchError from '@zimic/utils/fetch/expectFetchError';
+import waitFor from '@zimic/utils/time/waitFor';
 import waitForDelay from '@zimic/utils/time/waitForDelay';
 import joinURL from '@zimic/utils/url/joinURL';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { promiseIfRemote } from '@/http/interceptorWorker/__tests__/utils/promises';
 import { usingElapsedTime } from '@/utils/time';
+import { usingIgnoredConsole } from '@tests/utils/console';
 import { usingHttpInterceptor } from '@tests/utils/interceptors';
 
 import { HttpInterceptorOptions } from '../../types/options';
@@ -309,6 +312,39 @@ export function declareDelayHttpInterceptorTests(options: RuntimeSharedHttpInter
 
       expect(waitForDelaySpy).toHaveBeenCalledTimes(1);
       expect(waitForDelaySpy).toHaveBeenCalledWith(secondDelay);
+    });
+  });
+
+  it('should not throw an error if the handler is cleared while the delay is being awaited', async () => {
+    await usingHttpInterceptor<Schema>(interceptorOptions, async (interceptor) => {
+      const delay = 200;
+
+      const handler = await promiseIfRemote(
+        interceptor.get('/users').delay(delay).respond({ status: 204 }),
+        interceptor,
+      );
+
+      expect(handler.requests).toHaveLength(0);
+
+      await usingIgnoredConsole(['error'], async (console) => {
+        const { elapsedTime } = await usingElapsedTime(async () => {
+          const fetchPromise = fetch(joinURL(baseURL, '/users'), { method: 'GET' });
+
+          await waitFor(() => {
+            expect(waitForDelaySpy).toHaveBeenCalledTimes(1);
+            expect(waitForDelaySpy).toHaveBeenCalledWith(delay);
+          });
+
+          await promiseIfRemote(handler.clear(), interceptor);
+
+          await expectFetchError(fetchPromise);
+        });
+
+        expect(elapsedTime).toBeGreaterThanOrEqual(delay);
+        expect(handler.requests).toHaveLength(0);
+
+        expect(console.error).toHaveBeenCalledTimes(0);
+      });
     });
   });
 }

--- a/packages/zimic-interceptor/src/http/requestHandler/HttpRequestHandlerClient.ts
+++ b/packages/zimic-interceptor/src/http/requestHandler/HttpRequestHandlerClient.ts
@@ -20,7 +20,6 @@ import { random } from '@/utils/numbers';
 
 import HttpInterceptorClient from '../interceptor/HttpInterceptorClient';
 import DisabledRequestSavingError from './errors/DisabledRequestSavingError';
-import NoResponseDefinitionError from './errors/NoResponseDefinitionError';
 import TimesCheckError from './errors/TimesCheckError';
 import TimesDeclarationPointer from './errors/TimesDeclarationPointer';
 import { InternalHttpRequestHandler } from './types/public';
@@ -433,13 +432,7 @@ class HttpRequestHandlerClient<
     return typeof restriction === 'function';
   }
 
-  async applyResponseDeclaration(
-    request: HttpInterceptorRequest<Path, Default<Schema[Path][Method]>>,
-  ): Promise<HttpRequestHandlerResponseDeclaration<Default<Schema[Path][Method]>, StatusCode>> {
-    if (!this.createResponseDeclaration) {
-      throw new NoResponseDefinitionError();
-    }
-
+  async applyResponseDeclaration(request: HttpInterceptorRequest<Path, Default<Schema[Path][Method]>>) {
     if (this.createResponseDelay) {
       const delay = await this.createResponseDelay(request);
 
@@ -448,7 +441,7 @@ class HttpRequestHandlerClient<
       }
     }
 
-    const appliedDeclaration = await this.createResponseDeclaration(request);
+    const appliedDeclaration = await this.createResponseDeclaration?.(request);
     return appliedDeclaration;
   }
 

--- a/packages/zimic-interceptor/src/http/requestHandler/LocalHttpRequestHandler.ts
+++ b/packages/zimic-interceptor/src/http/requestHandler/LocalHttpRequestHandler.ts
@@ -92,9 +92,7 @@ class LocalHttpRequestHandler<
     return requestMatch;
   }
 
-  async applyResponseDeclaration(
-    request: HttpInterceptorRequest<Path, Default<Schema[Path][Method]>>,
-  ): Promise<HttpRequestHandlerResponseDeclaration<Default<Schema[Path][Method]>, StatusCode>> {
+  async applyResponseDeclaration(request: HttpInterceptorRequest<Path, Default<Schema[Path][Method]>>) {
     return this.client.applyResponseDeclaration(request);
   }
 

--- a/packages/zimic-interceptor/src/http/requestHandler/RemoteHttpRequestHandler.ts
+++ b/packages/zimic-interceptor/src/http/requestHandler/RemoteHttpRequestHandler.ts
@@ -132,9 +132,7 @@ class RemoteHttpRequestHandler<
     return requestMatch;
   }
 
-  async applyResponseDeclaration(
-    request: HttpInterceptorRequest<Path, Default<Schema[Path][Method]>>,
-  ): Promise<HttpRequestHandlerResponseDeclaration<Default<Schema[Path][Method]>, StatusCode>> {
+  async applyResponseDeclaration(request: HttpInterceptorRequest<Path, Default<Schema[Path][Method]>>) {
     return this.client.applyResponseDeclaration(request);
   }
 

--- a/packages/zimic-interceptor/src/http/requestHandler/__tests__/shared/default.ts
+++ b/packages/zimic-interceptor/src/http/requestHandler/__tests__/shared/default.ts
@@ -12,7 +12,6 @@ import HttpInterceptorWorker from '@/http/interceptorWorker/HttpInterceptorWorke
 import LocalHttpInterceptorWorker from '@/http/interceptorWorker/LocalHttpInterceptorWorker';
 import { createInternalHttpInterceptor } from '@tests/utils/interceptors';
 
-import NoResponseDefinitionError from '../../errors/NoResponseDefinitionError';
 import { HttpRequestHandlerRequestMatch } from '../../HttpRequestHandlerClient';
 import type LocalHttpRequestHandler from '../../LocalHttpRequestHandler';
 import RemoteHttpRequestHandler from '../../RemoteHttpRequestHandler';
@@ -154,10 +153,10 @@ export function declareDefaultHttpRequestHandlerTests(
 
     const request = new Request(baseURL);
     const parsedRequest = await HttpInterceptorWorker.parseRawRequest<'/users', MethodSchema>(request);
-    const response = await handler.applyResponseDeclaration(parsedRequest);
+    const responseDeclaration = (await handler.applyResponseDeclaration(parsedRequest))!;
 
-    expect(response.status).toBe(responseStatus);
-    expect(response.body).toEqual(responseBody);
+    expect(responseDeclaration.status).toBe(responseStatus);
+    expect(responseDeclaration.body).toEqual(responseBody);
   });
 
   it('should create response with declared status and body factory', async () => {
@@ -178,26 +177,22 @@ export function declareDefaultHttpRequestHandlerTests(
 
     const request = new Request(baseURL);
     const parsedRequest = await HttpInterceptorWorker.parseRawRequest<'/users', MethodSchema>(request);
-    const response = await handler.applyResponseDeclaration(parsedRequest);
+    const responseDeclaration = (await handler.applyResponseDeclaration(parsedRequest))!;
 
-    expect(response.status).toBe(responseStatus);
-    expect(response.body).toEqual(responseBody);
+    expect(responseDeclaration.status).toBe(responseStatus);
+    expect(responseDeclaration.body).toEqual(responseBody);
 
     expect(responseFactory).toHaveBeenCalledTimes(1);
   });
 
-  it('should throw an error if trying to create a response without a declared response', async () => {
+  it('should not throw an error if trying to create a response without a declared response', async () => {
     const handler = new Handler<Schema, 'POST', '/users'>(interceptorClient, 'POST', '/users');
 
     const request = new Request(baseURL);
     const parsedRequest = await HttpInterceptorWorker.parseRawRequest<'/users', MethodSchema>(request);
 
-    const error = new NoResponseDefinitionError();
-    expect(error).toBeInstanceOf(TypeError);
-
-    await expect(async () => {
-      await handler.applyResponseDeclaration(parsedRequest);
-    }).rejects.toThrowError(error);
+    const responseDeclarationPromise = handler.applyResponseDeclaration(parsedRequest);
+    await expect(responseDeclarationPromise).resolves.toBe(undefined);
   });
 
   it('should keep track of the intercepted requests and responses', async () => {
@@ -209,7 +204,7 @@ export function declareDefaultHttpRequestHandlerTests(
     const firstRequest = new Request(baseURL);
     const parsedFirstRequest = await HttpInterceptorWorker.parseRawRequest<'/users', MethodSchema>(firstRequest);
 
-    const firstResponseDeclaration = await handler.applyResponseDeclaration(parsedFirstRequest);
+    const firstResponseDeclaration = (await handler.applyResponseDeclaration(parsedFirstRequest))!;
     const firstResponse = Response.json(firstResponseDeclaration.body, {
       status: firstResponseDeclaration.status,
     });
@@ -227,7 +222,7 @@ export function declareDefaultHttpRequestHandlerTests(
 
     const secondRequest = new Request(joinURL(baseURL, '/path'));
     const parsedSecondRequest = await HttpInterceptorWorker.parseRawRequest<'/users', MethodSchema>(secondRequest);
-    const secondResponseDeclaration = await handler.applyResponseDeclaration(parsedSecondRequest);
+    const secondResponseDeclaration = (await handler.applyResponseDeclaration(parsedSecondRequest))!;
 
     const secondResponse = Response.json(secondResponseDeclaration.body, {
       status: secondResponseDeclaration.status,
@@ -258,7 +253,7 @@ export function declareDefaultHttpRequestHandlerTests(
     const firstRequest = new Request(baseURL);
     const parsedFirstRequest = await HttpInterceptorWorker.parseRawRequest<'/users', MethodSchema>(firstRequest);
 
-    const firstResponseDeclaration = await handler.applyResponseDeclaration(parsedFirstRequest);
+    const firstResponseDeclaration = (await handler.applyResponseDeclaration(parsedFirstRequest))!;
     const firstResponse = Response.json(firstResponseDeclaration.body, {
       status: firstResponseDeclaration.status,
     });
@@ -292,7 +287,7 @@ export function declareDefaultHttpRequestHandlerTests(
     });
     const parsedRequest = await HttpInterceptorWorker.parseRawRequest<'/users', MethodSchema>(request);
 
-    const responseDeclaration = await handler.applyResponseDeclaration(parsedRequest);
+    const responseDeclaration = (await handler.applyResponseDeclaration(parsedRequest))!;
     const response = Response.json(responseDeclaration.body, { status: responseDeclaration.status });
     const parsedResponse = await LocalHttpInterceptorWorker.parseRawResponse<MethodSchema, 200>(response);
 
@@ -339,7 +334,7 @@ export function declareDefaultHttpRequestHandlerTests(
     const request = new Request(baseURL);
     const parsedRequest = await HttpInterceptorWorker.parseRawRequest<'/users', MethodSchema>(request);
 
-    const responseDeclaration = await handler.applyResponseDeclaration(parsedRequest);
+    const responseDeclaration = (await handler.applyResponseDeclaration(parsedRequest))!;
     const response = Response.json(responseDeclaration.body, { status: responseDeclaration.status });
     const parsedResponse = await LocalHttpInterceptorWorker.parseRawResponse<MethodSchema, 200>(response);
 

--- a/packages/zimic-interceptor/src/http/requestHandler/errors/NoResponseDefinitionError.ts
+++ b/packages/zimic-interceptor/src/http/requestHandler/errors/NoResponseDefinitionError.ts
@@ -1,8 +1,0 @@
-class NoResponseDefinitionError extends TypeError {
-  constructor() {
-    super('Cannot generate a response without a definition. Use .respond() to set a response.');
-    this.name = 'NoResponseDefinitionError';
-  }
-}
-
-export default NoResponseDefinitionError;


### PR DESCRIPTION
### Fixes

- Calling `handler.clear()` or `interceptor.clear()` while awaiting a response delay cause the error `TypeError: this.createResponseDeclaration is not a function`. The method `HttpRequestHandlerClient#applyResponseDeclaration` should return undefined if the response declaration is cleared before the response is sent.