### PR TITLE
fix(interceptor): check oldest to latest interceptor handlers

### DIFF
--- a/packages/zimic-interceptor/src/http/interceptor/HttpInterceptorClient.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/HttpInterceptorClient.ts
@@ -369,8 +369,7 @@ class HttpInterceptorClient<
       const pathHandlers = this.handlers[method];
 
       for (const handlers of pathHandlers.values()) {
-        for (let handlerIndex = handlers.length - 1; handlerIndex >= 0; handlerIndex--) {
-          const handler = handlers[handlerIndex];
+        for (const handler of handlers) {
           handler.checkTimes();
         }
       }

--- a/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/times.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/times.ts
@@ -361,8 +361,8 @@ export function declareTimesHttpInterceptorTests(options: RuntimeSharedHttpInter
         });
 
         await expectTimesCheckError(() => promiseIfRemote(interceptor.checkTimes(), interceptor), {
-          message: 'Expected exactly 2 requests, but got 0.',
-          expectedNumberOfRequests: 2,
+          message: 'Expected exactly 1 request, but got 0.',
+          expectedNumberOfRequests: 1,
         });
 
         let response = await fetch(joinURL(baseURL, '/users'), { method: 'GET' });
@@ -386,8 +386,8 @@ export function declareTimesHttpInterceptorTests(options: RuntimeSharedHttpInter
         });
 
         await expectTimesCheckError(() => promiseIfRemote(interceptor.checkTimes(), interceptor), {
-          message: 'Expected exactly 2 requests, but got 1.',
-          expectedNumberOfRequests: 2,
+          message: 'Expected exactly 1 request, but got 0.',
+          expectedNumberOfRequests: 1,
         });
 
         response = await fetch(joinURL(baseURL, '/users'), { method: 'GET' });
@@ -408,8 +408,8 @@ export function declareTimesHttpInterceptorTests(options: RuntimeSharedHttpInter
         await promiseIfRemote(handlers[2].checkTimes(), handlers[2]);
 
         await expectTimesCheckError(() => promiseIfRemote(interceptor.checkTimes(), interceptor), {
-          message: 'Expected at least 1 and at most 2 requests, but got 0.',
-          expectedNumberOfRequests: { min: 1, max: 2 },
+          message: 'Expected exactly 1 request, but got 0.',
+          expectedNumberOfRequests: 1,
         });
 
         response = await fetch(joinURL(baseURL, '/users'), { method: 'GET' });
@@ -528,8 +528,8 @@ export function declareTimesHttpInterceptorTests(options: RuntimeSharedHttpInter
         });
 
         await expectTimesCheckError(() => promiseIfRemote(interceptor.checkTimes(), interceptor), {
-          message: 'Expected exactly 2 matching requests, but got 0.',
-          expectedNumberOfRequests: 2,
+          message: 'Expected exactly 1 matching request, but got 0.',
+          expectedNumberOfRequests: 1,
         });
 
         const searchParams = new HttpSearchParams({ value: '2' });
@@ -555,8 +555,8 @@ export function declareTimesHttpInterceptorTests(options: RuntimeSharedHttpInter
         });
 
         await expectTimesCheckError(() => promiseIfRemote(interceptor.checkTimes(), interceptor), {
-          message: 'Expected exactly 2 matching requests, but got 1.',
-          expectedNumberOfRequests: 2,
+          message: 'Expected exactly 1 matching request, but got 0.',
+          expectedNumberOfRequests: 1,
         });
 
         searchParams.set('value', '1');
@@ -579,8 +579,8 @@ export function declareTimesHttpInterceptorTests(options: RuntimeSharedHttpInter
         });
 
         await expectTimesCheckError(() => promiseIfRemote(interceptor.checkTimes(), interceptor), {
-          message: 'Expected exactly 2 matching requests, but got 1.',
-          expectedNumberOfRequests: 2,
+          message: 'Expected at least 1 and at most 2 matching requests, but got 0.',
+          expectedNumberOfRequests: { min: 1, max: 2 },
         });
 
         searchParams.set('value', 'unknown');
@@ -628,7 +628,7 @@ export function declareTimesHttpInterceptorTests(options: RuntimeSharedHttpInter
 
         await expectTimesCheckError(() => promiseIfRemote(interceptor.checkTimes(), interceptor), {
           message: [
-            'Expected exactly 2 matching requests, but got 1.',
+            'Expected at least 1 and at most 2 matching requests, but got 0.',
             '',
             'Requests evaluated by this handler:',
             '',
@@ -640,7 +640,7 @@ export function declareTimesHttpInterceptorTests(options: RuntimeSharedHttpInter
             `       ${color.green('- { "value": "2" }')}`,
             `       ${color.red('+ { "value": "unknown" }')}`,
           ].join('\n'),
-          expectedNumberOfRequests: 2,
+          expectedNumberOfRequests: { min: 1, max: 2 },
         });
 
         searchParams.set('value', '2');


### PR DESCRIPTION
This pull request changes the internal implementation of [`interceptor.checkTimes()`](https://zimic.dev/docs/interceptor/api/http-interceptor#interceptorchecktimes) to check handlers from oldest to latest.

https://github.com/zimicjs/zimic/blob/82e06984b1e65071685c6050038f00331a2880b3/packages/zimic-interceptor/src/http/interceptor/HttpInterceptorClient.ts#L371-L375

Previously, we checked the handlers from latest to oldest, but this is usually counter-intuitive. Users declaring their handlers in the order they are called by the application will receive times check errors from the last handlers, not the first that probably are more related to a test failure.

https://github.com/zimicjs/zimic/blob/ca15945e2c537f32b74f6995045f7fc745a1ab95/packages/zimic-interceptor/src/http/interceptor/HttpInterceptorClient.ts#L371-L376