### PR TITLE
fix(fetch): remove `response.statusText` from `FetchResponseError` message

### DIFF
--- a/packages/zimic-fetch/src/client/__tests__/FetchClient.errors.toObject.test.ts
+++ b/packages/zimic-fetch/src/client/__tests__/FetchClient.errors.toObject.test.ts
@@ -81,7 +81,7 @@ describe('FetchClient > Errors > toObject', () => {
         expectTypeOf(errorObject).toEqualTypeOf<FetchResponseErrorObject>();
 
         expect(errorObject).toEqual<FetchResponseErrorObject>({
-          message: `POST ${joinURL(baseURL, '/users')} failed with status 409: `,
+          message: `POST ${joinURL(baseURL, '/users')} failed with status 409.`,
           name: 'FetchResponseError',
           request: {
             url: joinURL(baseURL, '/users'),
@@ -161,7 +161,7 @@ describe('FetchClient > Errors > toObject', () => {
         const errorObject = await errorObjectPromise;
 
         expect(errorObject).toEqual<FetchResponseErrorObject>({
-          message: `POST ${joinURL(baseURL, '/users')} failed with status 409: `,
+          message: `POST ${joinURL(baseURL, '/users')} failed with status 409.`,
           name: 'FetchResponseError',
           request: {
             url: joinURL(baseURL, '/users'),
@@ -1189,7 +1189,7 @@ describe('FetchClient > Errors > toObject', () => {
       const errorObject = await errorObjectPromise;
 
       expect(errorObject).toEqual<FetchResponseErrorObject>({
-        message: `POST ${joinURL(baseURL, '/users')} failed with status 409: `,
+        message: `POST ${joinURL(baseURL, '/users')} failed with status 409.`,
         name: 'FetchResponseError',
         request: {
           url: joinURL(baseURL, '/users'),
@@ -1344,7 +1344,7 @@ describe('FetchClient > Errors > toObject', () => {
       expectTypeOf(errorObject).toEqualTypeOf<FetchResponseErrorObject>();
 
       expect(errorObject).toMatchObject<DeepPartial<FetchResponseErrorObject>>({
-        message: `GET ${joinURL(baseURL, '/users?page=1&limit=10')} failed with status 401: `,
+        message: `GET ${joinURL(baseURL, '/users?page=1&limit=10')} failed with status 401.`,
         request: {
           url: joinURL(baseURL, '/users?page=1&limit=10'),
         },

--- a/packages/zimic-fetch/src/client/response/error/FetchResponseError.ts
+++ b/packages/zimic-fetch/src/client/response/error/FetchResponseError.ts
@@ -15,7 +15,7 @@ class FetchResponseError<
     public request: FetchRequest<Schema, Method, Path>,
     public response: FetchResponse<Schema, Method, Path>,
   ) {
-    super(`${request.method} ${request.url} failed with status ${response.status}: ${response.statusText}`);
+    super(`${request.method} ${request.url} failed with status ${response.status}.`);
     this.name = 'FetchResponseError';
   }
 


### PR DESCRIPTION
`@zimic/fetch` used to add `response.statusText` to the end of `FetchResponseError` messages. However, this property is commonly just an empty string, which is the [default value](https://developer.mozilla.org/en-US/docs/Web/API/Response/statusText#value), resulting in error messages with an additional space at the end.

Because of this and since we already include the `response.status` in the message, `response.statusText` is not necessary.