### PR TITLE
feat(ws): `WebSocketClient` and `WebSocketServer` event listeners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -149,11 +149,18 @@ jobs:
 
       - name: Run tests
         run: |
+          extraTurboFilters=''
+
+          if [[ "$NODE_VERSION" -lt 22 ]]; then
+            # @zimic/ws requires Node.js >=22.
+            extraTurboFilters='--filter !@zimic/ws'
+          fi
+
           pnpm turbo \
             test:turbo \
             --continue \
             --concurrency 1 \
-            ${{ env.TURBO_FILTERS }}
+            ${{ env.TURBO_FILTERS }} $extraTurboFilters
         env:
           PLAYWRIGHT_WORKERS: 2
 

--- a/apps/zimic-test-client/tests/exports/exports.node.test.ts
+++ b/apps/zimic-test-client/tests/exports/exports.node.test.ts
@@ -20,7 +20,7 @@ describe('Exports (Node.js)', () => {
   });
 
   it('exports all expected resources from @zimic/ws', () => {
-    expectTypeOf<WebSocketServer>().not.toBeAny();
+    expectTypeOf<WebSocketServer<never>>().not.toBeAny();
     expect(typeof WebSocketServer).toBe('function');
 
     expectTypeOf<WebSocketServerOptions>().not.toBeAny();

--- a/apps/zimic-test-client/tests/exports/exports.test.ts
+++ b/apps/zimic-test-client/tests/exports/exports.test.ts
@@ -120,7 +120,6 @@ import {
   WebSocketTimeoutError,
   WebSocketOpenTimeoutError,
   WebSocketCloseTimeoutError,
-  WebSocketMessageAbortError,
 } from '@zimic/ws';
 import { describe, expect, expectTypeOf, it } from 'vitest';
 
@@ -270,9 +269,6 @@ describe('Exports', () => {
 
     expectTypeOf<WebSocketCloseTimeoutError>().not.toBeAny();
     expect(typeof WebSocketCloseTimeoutError).toBe('function');
-
-    expectTypeOf<WebSocketMessageAbortError>().not.toBeAny();
-    expect(typeof WebSocketMessageAbortError).toBe('function');
   });
 
   it('exports all expected resources from @zimic/interceptor', () => {

--- a/apps/zimic-web/docs/zimic-interceptor/api/5-interceptor-server.md
+++ b/apps/zimic-web/docs/zimic-interceptor/api/5-interceptor-server.md
@@ -25,7 +25,9 @@ The hostname of the server. It can be reassigned to a new value if the server is
 
 ## `server.port`
 
-The port of the server. It can be reassigned to a new value if the server is not running.
+The port of the server. It can be reassigned to a new value if the server is not running. If not provided, it will be
+`undefined` until the server is started, at which point the server will use a random available port and this property
+will be updated accordingly.
 
 **Type**: `number | undefined`
 

--- a/packages/zimic-fetch/vitest.config.mts
+++ b/packages/zimic-fetch/vitest.config.mts
@@ -9,7 +9,6 @@ export default defineConfig({
     globals: false,
     testTimeout: 5000,
     hookTimeout: 5000,
-    retry: process.env.CI === 'true' ? 1 : 0,
     maxWorkers: process.env.CI === 'true' ? '50%' : '25%',
     clearMocks: true,
     projects: [

--- a/packages/zimic-utils/src/server/index.ts
+++ b/packages/zimic-utils/src/server/index.ts
@@ -1,6 +1,7 @@
 export {
   startHttpServer,
   stopHttpServer,
+  getHttpServerHostname,
   getHttpServerPort,
   DEFAULT_HTTP_SERVER_LIFECYCLE_TIMEOUT,
   HttpServerTimeoutError,

--- a/packages/zimic-utils/src/server/lifecycle.ts
+++ b/packages/zimic-utils/src/server/lifecycle.ts
@@ -84,6 +84,16 @@ export async function stopHttpServer(server: HttpServer, options: { timeout?: nu
   });
 }
 
+export function getHttpServerHostname(server: HttpServer) {
+  const address = server.address();
+
+  if (typeof address === 'string') {
+    return undefined;
+  } else {
+    return address?.address;
+  }
+}
+
 export function getHttpServerPort(server: HttpServer) {
   const address = server.address();
 

--- a/packages/zimic-ws/package.json
+++ b/packages/zimic-ws/package.json
@@ -35,7 +35,7 @@
     "provenance": true
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.4.0"
   },
   "license": "MIT",
   "files": [

--- a/packages/zimic-ws/src/client/ClientSocket.ts
+++ b/packages/zimic-ws/src/client/ClientSocket.ts
@@ -1,7 +1,0 @@
-import NodeWebSocket from 'ws';
-
-// WebSocket is available natively in browsers and Node.js >=22.
-const isNativeWebSocketAvailable = typeof WebSocket !== 'undefined';
-
-export const ClientSocket = (isNativeWebSocketAvailable ? WebSocket : NodeWebSocket) as typeof WebSocket;
-export type ClientSocket = InstanceType<typeof ClientSocket>;

--- a/packages/zimic-ws/src/client/WebSocketClient.ts
+++ b/packages/zimic-ws/src/client/WebSocketClient.ts
@@ -103,25 +103,33 @@ export class WebSocketClient<Schema extends WebSocketSchema> implements Omit<
     this.#protocols = protocols;
   }
 
-  static CONNECTING = WebSocket.CONNECTING;
+  static get CONNECTING() {
+    return WebSocket.CONNECTING;
+  }
 
   get CONNECTING() {
     return WebSocketClient.CONNECTING;
   }
 
-  static OPEN = WebSocket.OPEN;
+  static get OPEN() {
+    return WebSocket.OPEN;
+  }
 
   get OPEN() {
     return WebSocketClient.OPEN;
   }
 
-  static CLOSING = WebSocket.CLOSING;
+  static get CLOSING() {
+    return WebSocket.CLOSING;
+  }
 
   get CLOSING() {
     return WebSocketClient.CLOSING;
   }
 
-  static CLOSED = WebSocket.CLOSED;
+  static get CLOSED() {
+    return WebSocket.CLOSED;
+  }
 
   get CLOSED() {
     return WebSocketClient.CLOSED;

--- a/packages/zimic-ws/src/client/WebSocketClient.ts
+++ b/packages/zimic-ws/src/client/WebSocketClient.ts
@@ -78,7 +78,7 @@ export class WebSocketClient<Schema extends WebSocketSchema> implements Omit<
     error: null,
   };
 
-  private nonUnitaryListeners: {
+  private listenerToRawListener: {
     [Type in WebSocketClient.EventType]: Map<
       WebSocketClient.EventListener<Schema, Type>,
       WebSocketClientRawEventListener
@@ -191,14 +191,18 @@ export class WebSocketClient<Schema extends WebSocketSchema> implements Omit<
   private applyListeners(socket: WebSocket) {
     for (const type of ['open', 'message', 'close', 'error'] as const) {
       const unitaryListener = this[`on${type}`] as WebSocketClient.EventListener<Schema, typeof type> | null;
-      const rawUnitaryListener = unitaryListener ? this.nonUnitaryListeners[type].get(unitaryListener) : undefined;
+      const rawUnitaryListener = unitaryListener ? this.listenerToRawListener[type].get(unitaryListener) : undefined;
 
       if (rawUnitaryListener) {
         socket[`on${type}`] = rawUnitaryListener;
       }
 
-      for (const rawListener of this.nonUnitaryListeners[type].values()) {
-        socket.addEventListener(type, rawListener);
+      for (const rawListener of this.listenerToRawListener[type].values()) {
+        const isRawUnitaryListener = rawListener === rawUnitaryListener;
+
+        if (!isRawUnitaryListener) {
+          socket.addEventListener(type, rawListener);
+        }
       }
     }
   }
@@ -227,7 +231,7 @@ export class WebSocketClient<Schema extends WebSocketSchema> implements Omit<
     const rawListener = listener.bind(this) as WebSocketClientRawEventListener;
 
     this.socket?.addEventListener(type, rawListener, options);
-    this.nonUnitaryListeners[type].set(listener, rawListener);
+    this.listenerToRawListener[type].set(listener, rawListener);
   }
 
   removeEventListener<Type extends WebSocketClient.EventType>(
@@ -235,11 +239,11 @@ export class WebSocketClient<Schema extends WebSocketSchema> implements Omit<
     listener: WebSocketClient.EventListener<Schema, Type>,
     options?: boolean | EventListenerOptions,
   ) {
-    const rawListener = this.nonUnitaryListeners[type].get(listener);
+    const rawListener = this.listenerToRawListener[type].get(listener);
 
     if (rawListener) {
       this.socket?.removeEventListener(type, rawListener, options);
-      this.nonUnitaryListeners[type].delete(listener);
+      this.listenerToRawListener[type].delete(listener);
     }
   }
 
@@ -282,18 +286,18 @@ export class WebSocketClient<Schema extends WebSocketSchema> implements Omit<
     const currentListener = this.unitaryListeners[type];
 
     if (currentListener) {
-      const rawListener = this.nonUnitaryListeners[type].get(currentListener);
+      const rawListener = this.listenerToRawListener[type].get(currentListener);
 
       if (this.socket && rawListener) {
         this.socket[`on${type}`] = null;
       }
 
-      this.nonUnitaryListeners[type].delete(currentListener);
+      this.listenerToRawListener[type].delete(currentListener);
     }
 
     if (listener) {
       const rawListener = listener.bind(this) as WebSocketClientRawEventListener;
-      this.nonUnitaryListeners[type].set(listener, rawListener);
+      this.listenerToRawListener[type].set(listener, rawListener);
 
       if (this.socket) {
         this.socket[`on${type}`] = rawListener;

--- a/packages/zimic-ws/src/client/WebSocketClient.ts
+++ b/packages/zimic-ws/src/client/WebSocketClient.ts
@@ -1,30 +1,77 @@
-import { WebSocketEvent, WebSocketEventType, WebSocketMessageData, WebSocketSchema } from '@/types/schema';
+import { PossiblePromise } from '@zimic/utils/types';
 
-import { ClientSocket } from './ClientSocket';
+import { WebSocketMessageData, WebSocketSchema } from '@/types/schema';
+
 import { closeClientSocket, openClientSocket } from './utils/lifecycle';
 
-export type WebSocketClientEventListener<Schema extends WebSocketSchema, Type extends WebSocketEventType<Schema>> = (
-  this: WebSocketClient<Schema>,
-  event: WebSocketEvent<Schema, Type>,
-) => unknown;
+export namespace WebSocketClient {
+  export type ReadyState =
+    | typeof WebSocketClient.CONNECTING
+    | typeof WebSocketClient.OPEN
+    | typeof WebSocketClient.CLOSING
+    | typeof WebSocketClient.CLOSED;
 
-type WebSocketClientRawEventListener = (this: ClientSocket, event: Event) => unknown;
+  // The schema is not used in the event types, but it's included for consistency and future extensibility.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  export type OpenEvent<_Schema extends WebSocketSchema> = globalThis.Event;
 
-class WebSocketClient<Schema extends WebSocketSchema> implements Omit<
+  export type MessageEvent<Schema extends WebSocketSchema> = globalThis.MessageEvent<WebSocketMessageData<Schema>>;
+
+  // The schema is not used in the event types, but it's included for consistency and future extensibility.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  export type CloseEvent<_Schema extends WebSocketSchema> = globalThis.CloseEvent;
+
+  // The schema is not used in the event types, but it's included for consistency and future extensibility.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  export type ErrorEvent<_Schema extends WebSocketSchema> = globalThis.Event;
+
+  interface Events<Schema extends WebSocketSchema = WebSocketSchema> {
+    open: OpenEvent<Schema>;
+    message: MessageEvent<Schema>;
+    close: CloseEvent<Schema>;
+    error: ErrorEvent<Schema>;
+  }
+
+  export type EventType = keyof Events<WebSocketSchema>;
+
+  export type Event<
+    Schema extends WebSocketSchema = WebSocketSchema,
+    Type extends EventType = EventType,
+  > = Events<Schema>[Type];
+
+  interface EventListenerParameters<Schema extends WebSocketSchema> {
+    open: [event: Event<Schema, 'open'>];
+    message: [event: Event<Schema, 'message'>];
+    close: [event: Event<Schema, 'close'>];
+    error: [event: Event<Schema, 'error'>];
+  }
+
+  export type EventListener<Schema extends WebSocketSchema, Type extends EventType> = (
+    this: WebSocketClient<Schema>,
+    ...parameters: EventListenerParameters<Schema>[Type]
+  ) => PossiblePromise<void>;
+}
+
+type WebSocketClientRawEventListener = (this: WebSocket, event: Event) => PossiblePromise<void>;
+
+export class WebSocketClient<Schema extends WebSocketSchema> implements Omit<
   WebSocket,
   `${string}EventListener` | `on${string}`
 > {
-  private socket?: ClientSocket;
-  private _binaryType: BinaryType = 'blob';
+  private socket?: WebSocket;
 
-  private _onopen: WebSocketClientEventListener<Schema, 'open'> | null = null;
-  private _onmessage: WebSocketClientEventListener<Schema, 'message'> | null = null;
-  private _onclose: WebSocketClientEventListener<Schema, 'close'> | null = null;
-  private _onerror: WebSocketClientEventListener<Schema, 'error'> | null = null;
+  #url: string;
+  #protocols?: string | string[];
+  #binaryType: BinaryType = 'blob';
+
+  #onopen: WebSocketClient.EventListener<Schema, 'open'> | null = null;
+  #onmessage: WebSocketClient.EventListener<Schema, 'message'> | null = null;
+  #onclose: WebSocketClient.EventListener<Schema, 'close'> | null = null;
+  #onerror: WebSocketClient.EventListener<Schema, 'error'> | null = null;
 
   private listeners: {
-    [Type in WebSocketEventType<Schema>]: Map<
-      WebSocketClientEventListener<Schema, Type>,
+    [Type in WebSocketClient.EventType]: Map<
+      WebSocketClient.EventListener<Schema, Type>,
       WebSocketClientRawEventListener
     >;
   } = {
@@ -34,41 +81,49 @@ class WebSocketClient<Schema extends WebSocketSchema> implements Omit<
     error: new Map(),
   };
 
-  constructor(
-    private _url: string,
-    private protocols?: string | string[],
-  ) {}
+  constructor(socket: WebSocket);
+  constructor(_url: string, protocols?: string | string[]);
+  constructor(urlOrSocket: WebSocket | string, protocols?: string | string[]) {
+    if (typeof urlOrSocket === 'string') {
+      this.#url = urlOrSocket;
+    } else {
+      this.#url = urlOrSocket.url;
+      this.socket = urlOrSocket;
+    }
 
-  static CONNECTING = ClientSocket.CONNECTING;
+    this.#protocols = protocols;
+  }
+
+  static CONNECTING = WebSocket.CONNECTING;
 
   get CONNECTING() {
     return WebSocketClient.CONNECTING;
   }
 
-  static OPEN = ClientSocket.OPEN;
+  static OPEN = WebSocket.OPEN;
 
   get OPEN() {
     return WebSocketClient.OPEN;
   }
 
-  static CLOSING = ClientSocket.CLOSING;
+  static CLOSING = WebSocket.CLOSING;
 
   get CLOSING() {
     return WebSocketClient.CLOSING;
   }
 
-  static CLOSED = ClientSocket.CLOSED;
+  static CLOSED = WebSocket.CLOSED;
 
   get CLOSED() {
     return WebSocketClient.CLOSED;
   }
 
   get binaryType() {
-    return this.socket?.binaryType ?? this._binaryType;
+    return this.socket?.binaryType ?? this.#binaryType;
   }
 
   set binaryType(value: 'blob' | 'arraybuffer') {
-    this._binaryType = value;
+    this.#binaryType = value;
 
     if (this.socket) {
       this.socket.binaryType = value;
@@ -76,7 +131,7 @@ class WebSocketClient<Schema extends WebSocketSchema> implements Omit<
   }
 
   get url() {
-    return this.socket?.url ?? this._url;
+    return this.socket?.url ?? this.#url;
   }
 
   get protocol() {
@@ -87,8 +142,9 @@ class WebSocketClient<Schema extends WebSocketSchema> implements Omit<
     return this.socket?.extensions ?? '';
   }
 
-  get readyState() {
-    return this.socket?.readyState ?? ClientSocket.CLOSED;
+  get readyState(): WebSocketClient.ReadyState {
+    const readyState = this.socket?.readyState ?? WebSocket.CLOSED;
+    return readyState as WebSocketClient.ReadyState;
   }
 
   get bufferedAmount() {
@@ -96,13 +152,32 @@ class WebSocketClient<Schema extends WebSocketSchema> implements Omit<
   }
 
   async open(options: { timeout?: number } = {}) {
-    this.socket = new ClientSocket(this._url, this.protocols);
+    const socket = new WebSocket(this.#url, this.#protocols);
 
-    if (this.socket.binaryType !== this._binaryType) {
-      this.socket.binaryType = this._binaryType;
+    if (socket.binaryType !== this.binaryType) {
+      socket.binaryType = this.binaryType;
     }
 
-    await openClientSocket(this.socket, options);
+    this.applyListeners(socket);
+
+    await openClientSocket(socket, options);
+
+    this.socket = socket;
+  }
+
+  private applyListeners(socket: WebSocket) {
+    for (const type of ['open', 'message', 'close', 'error'] as const) {
+      const unitaryListener = this[`on${type}`] as WebSocketClient.EventListener<Schema, typeof type> | null;
+      const rawUnitaryListener = unitaryListener ? this.listeners[type].get(unitaryListener) : undefined;
+
+      if (rawUnitaryListener) {
+        socket[`on${type}`] = rawUnitaryListener;
+      }
+
+      for (const rawListener of this.listeners[type].values()) {
+        socket.addEventListener(type, rawListener);
+      }
+    }
   }
 
   async close(code?: number, reason?: string, options: { timeout?: number } = {}) {
@@ -113,19 +188,6 @@ class WebSocketClient<Schema extends WebSocketSchema> implements Omit<
     try {
       await closeClientSocket(this.socket, { ...options, code, reason });
     } finally {
-      this.onopen = null;
-      this.onmessage = null;
-      this.onclose = null;
-      this.onerror = null;
-
-      for (const [type, listenerToRawListener] of Object.entries(this.listeners)) {
-        for (const rawListener of listenerToRawListener.values()) {
-          this.socket.removeEventListener(type, rawListener);
-        }
-
-        listenerToRawListener.clear();
-      }
-
       this.socket = undefined;
     }
   }
@@ -134,9 +196,9 @@ class WebSocketClient<Schema extends WebSocketSchema> implements Omit<
     this.socket?.send(data);
   }
 
-  addEventListener<Type extends WebSocketEventType<Schema>>(
+  addEventListener<Type extends WebSocketClient.EventType>(
     type: Type,
-    listener: (this: WebSocketClient<Schema>, event: WebSocketEvent<Schema, Type>) => unknown,
+    listener: WebSocketClient.EventListener<Schema, Type>,
     options?: boolean | AddEventListenerOptions,
   ) {
     const rawListener = listener.bind(this) as WebSocketClientRawEventListener;
@@ -145,9 +207,9 @@ class WebSocketClient<Schema extends WebSocketSchema> implements Omit<
     this.listeners[type].set(listener, rawListener);
   }
 
-  removeEventListener<Type extends WebSocketEventType<Schema>>(
+  removeEventListener<Type extends WebSocketClient.EventType>(
     type: Type,
-    listener: (this: WebSocketClient<Schema>, event: WebSocketEvent<Schema, Type>) => unknown,
+    listener: WebSocketClient.EventListener<Schema, Type>,
     options?: boolean | EventListenerOptions,
   ) {
     const rawListener = this.listeners[type].get(listener);
@@ -159,42 +221,42 @@ class WebSocketClient<Schema extends WebSocketSchema> implements Omit<
   }
 
   get onopen() {
-    return this._onopen;
+    return this.#onopen;
   }
 
-  set onopen(listener: WebSocketClientEventListener<Schema, 'open'> | null) {
-    this.setUnitaryEventListener('open', listener);
+  set onopen(listener: WebSocketClient.EventListener<Schema, 'open'> | null) {
+    this.setEventListener('open', listener);
   }
 
   get onmessage() {
-    return this._onmessage;
+    return this.#onmessage;
   }
 
-  set onmessage(listener: WebSocketClientEventListener<Schema, 'message'> | null) {
-    this.setUnitaryEventListener('message', listener);
+  set onmessage(listener: WebSocketClient.EventListener<Schema, 'message'> | null) {
+    this.setEventListener('message', listener);
   }
 
   get onclose() {
-    return this._onclose;
+    return this.#onclose;
   }
 
-  set onclose(listener: WebSocketClientEventListener<Schema, 'close'> | null) {
-    this.setUnitaryEventListener('close', listener);
+  set onclose(listener: WebSocketClient.EventListener<Schema, 'close'> | null) {
+    this.setEventListener('close', listener);
   }
 
   get onerror() {
-    return this._onerror;
+    return this.#onerror;
   }
 
-  set onerror(listener: WebSocketClientEventListener<Schema, 'error'> | null) {
-    this.setUnitaryEventListener('error', listener);
+  set onerror(listener: WebSocketClient.EventListener<Schema, 'error'> | null) {
+    this.setEventListener('error', listener);
   }
 
-  private setUnitaryEventListener<Type extends WebSocketEventType<Schema>>(
-    type: Type,
-    listener: WebSocketClientEventListener<Schema, Type> | null,
-  ) {
-    type PrivateUnitaryListener = typeof listener;
+  private setEventListener<
+    Type extends WebSocketClient.EventType,
+    Listener extends WebSocketClient.EventListener<Schema, Type> | null,
+  >(type: Type, listener: Listener) {
+    const listenerProperty = `_on${type}` as keyof WebSocketClient<Schema>;
 
     if (listener) {
       const rawListener = listener.bind(this) as WebSocketClientRawEventListener;
@@ -204,9 +266,9 @@ class WebSocketClient<Schema extends WebSocketSchema> implements Omit<
         this.socket[`on${type}`] = rawListener;
       }
 
-      (this[`_on${type}`] as PrivateUnitaryListener) = listener;
+      (this[listenerProperty] as Listener) = listener;
     } else {
-      const currentListener = this[`_on${type}`] as PrivateUnitaryListener;
+      const currentListener = this[listenerProperty] as Listener;
 
       if (currentListener) {
         this.listeners[type].delete(currentListener);
@@ -216,13 +278,11 @@ class WebSocketClient<Schema extends WebSocketSchema> implements Omit<
         this.socket[`on${type}`] = null;
       }
 
-      (this[`_on${type}`] as PrivateUnitaryListener) = null;
+      (this[listenerProperty] as Listener | null) = null;
     }
   }
 
-  dispatchEvent<Type extends WebSocketEventType<Schema>>(event: WebSocketEvent<Schema, Type>) {
+  dispatchEvent<Type extends WebSocketClient.EventType>(event: WebSocketClient.Event<Schema, Type>) {
     return this.socket?.dispatchEvent(event) ?? false;
   }
 }
-
-export default WebSocketClient;

--- a/packages/zimic-ws/src/client/WebSocketClient.ts
+++ b/packages/zimic-ws/src/client/WebSocketClient.ts
@@ -69,12 +69,16 @@ export class WebSocketClient<Schema extends WebSocketSchema> implements Omit<
   #protocols?: string | string[];
   #binaryType: BinaryType = 'blob';
 
-  #onopen: WebSocketClient.EventListener<Schema, 'open'> | null = null;
-  #onmessage: WebSocketClient.EventListener<Schema, 'message'> | null = null;
-  #onclose: WebSocketClient.EventListener<Schema, 'close'> | null = null;
-  #onerror: WebSocketClient.EventListener<Schema, 'error'> | null = null;
+  private unitaryListeners: {
+    [Type in WebSocketClient.EventType]: WebSocketClient.EventListener<Schema, Type> | null;
+  } = {
+    open: null,
+    message: null,
+    close: null,
+    error: null,
+  };
 
-  private listeners: {
+  private nonUnitaryListeners: {
     [Type in WebSocketClient.EventType]: Map<
       WebSocketClient.EventListener<Schema, Type>,
       WebSocketClientRawEventListener
@@ -156,7 +160,13 @@ export class WebSocketClient<Schema extends WebSocketSchema> implements Omit<
     return this.socket?.bufferedAmount ?? 0;
   }
 
-  async open(options: WebSocketClientOpenOptions = {}) {
+  async open(options?: WebSocketClientOpenOptions) {
+    if (this.readyState === WebSocketClient.OPEN) {
+      return;
+    }
+
+    await this.close();
+
     const socket = new WebSocket(this.#url, this.#protocols);
 
     if (socket.binaryType !== this.binaryType) {
@@ -173,19 +183,19 @@ export class WebSocketClient<Schema extends WebSocketSchema> implements Omit<
   private applyListeners(socket: WebSocket) {
     for (const type of ['open', 'message', 'close', 'error'] as const) {
       const unitaryListener = this[`on${type}`] as WebSocketClient.EventListener<Schema, typeof type> | null;
-      const rawUnitaryListener = unitaryListener ? this.listeners[type].get(unitaryListener) : undefined;
+      const rawUnitaryListener = unitaryListener ? this.nonUnitaryListeners[type].get(unitaryListener) : undefined;
 
       if (rawUnitaryListener) {
         socket[`on${type}`] = rawUnitaryListener;
       }
 
-      for (const rawListener of this.listeners[type].values()) {
+      for (const rawListener of this.nonUnitaryListeners[type].values()) {
         socket.addEventListener(type, rawListener);
       }
     }
   }
 
-  async close(code?: number, reason?: string, options: WebSocketClientCloseOptions = {}) {
+  async close(code?: number, reason?: string, options?: WebSocketClientCloseOptions) {
     if (!this.socket) {
       return;
     }
@@ -209,7 +219,7 @@ export class WebSocketClient<Schema extends WebSocketSchema> implements Omit<
     const rawListener = listener.bind(this) as WebSocketClientRawEventListener;
 
     this.socket?.addEventListener(type, rawListener, options);
-    this.listeners[type].set(listener, rawListener);
+    this.nonUnitaryListeners[type].set(listener, rawListener);
   }
 
   removeEventListener<Type extends WebSocketClient.EventType>(
@@ -217,16 +227,16 @@ export class WebSocketClient<Schema extends WebSocketSchema> implements Omit<
     listener: WebSocketClient.EventListener<Schema, Type>,
     options?: boolean | EventListenerOptions,
   ) {
-    const rawListener = this.listeners[type].get(listener);
+    const rawListener = this.nonUnitaryListeners[type].get(listener);
 
     if (rawListener) {
       this.socket?.removeEventListener(type, rawListener, options);
-      this.listeners[type].delete(listener);
+      this.nonUnitaryListeners[type].delete(listener);
     }
   }
 
   get onopen() {
-    return this.#onopen;
+    return this.unitaryListeners.open;
   }
 
   set onopen(listener: WebSocketClient.EventListener<Schema, 'open'> | null) {
@@ -234,7 +244,7 @@ export class WebSocketClient<Schema extends WebSocketSchema> implements Omit<
   }
 
   get onmessage() {
-    return this.#onmessage;
+    return this.unitaryListeners.message;
   }
 
   set onmessage(listener: WebSocketClient.EventListener<Schema, 'message'> | null) {
@@ -242,7 +252,7 @@ export class WebSocketClient<Schema extends WebSocketSchema> implements Omit<
   }
 
   get onclose() {
-    return this.#onclose;
+    return this.unitaryListeners.close;
   }
 
   set onclose(listener: WebSocketClient.EventListener<Schema, 'close'> | null) {
@@ -250,7 +260,7 @@ export class WebSocketClient<Schema extends WebSocketSchema> implements Omit<
   }
 
   get onerror() {
-    return this.#onerror;
+    return this.unitaryListeners.error;
   }
 
   set onerror(listener: WebSocketClient.EventListener<Schema, 'error'> | null) {
@@ -261,29 +271,33 @@ export class WebSocketClient<Schema extends WebSocketSchema> implements Omit<
     Type extends WebSocketClient.EventType,
     Listener extends WebSocketClient.EventListener<Schema, Type> | null,
   >(type: Type, listener: Listener) {
-    const listenerProperty = `_on${type}` as keyof WebSocketClient<Schema>;
+    const currentListener = this.unitaryListeners[type];
+
+    if (currentListener) {
+      const rawListener = this.nonUnitaryListeners[type].get(currentListener);
+
+      if (this.socket && rawListener) {
+        this.socket[`on${type}`] = null;
+      }
+
+      this.nonUnitaryListeners[type].delete(currentListener);
+    }
 
     if (listener) {
       const rawListener = listener.bind(this) as WebSocketClientRawEventListener;
-      this.listeners[type].set(listener, rawListener);
+      this.nonUnitaryListeners[type].set(listener, rawListener);
 
       if (this.socket) {
         this.socket[`on${type}`] = rawListener;
       }
 
-      (this[listenerProperty] as Listener) = listener;
+      (this.unitaryListeners[type] as Listener) = listener;
     } else {
-      const currentListener = this[listenerProperty] as Listener;
-
-      if (currentListener) {
-        this.listeners[type].delete(currentListener);
-      }
-
       if (this.socket) {
         this.socket[`on${type}`] = null;
       }
 
-      (this[listenerProperty] as Listener | null) = null;
+      (this.unitaryListeners[type] as Listener | null) = null;
     }
   }
 

--- a/packages/zimic-ws/src/client/WebSocketClient.ts
+++ b/packages/zimic-ws/src/client/WebSocketClient.ts
@@ -177,13 +177,18 @@ export class WebSocketClient<Schema extends WebSocketSchema> implements Omit<
 
     const socket = new WebSocket(this.#url, this.#protocols);
 
-    if (socket.binaryType !== this.binaryType) {
-      socket.binaryType = this.binaryType;
+    try {
+      if (socket.binaryType !== this.binaryType) {
+        socket.binaryType = this.binaryType;
+      }
+
+      this.applyListeners(socket);
+
+      await openWebSocketClient(socket, options);
+    } catch (error) {
+      socket.close();
+      throw error;
     }
-
-    this.applyListeners(socket);
-
-    await openWebSocketClient(socket, options);
 
     this.socket = socket;
   }

--- a/packages/zimic-ws/src/client/WebSocketClient.ts
+++ b/packages/zimic-ws/src/client/WebSocketClient.ts
@@ -2,7 +2,12 @@ import { PossiblePromise } from '@zimic/utils/types';
 
 import { WebSocketMessageData, WebSocketSchema } from '@/types/schema';
 
-import { closeClientSocket, openClientSocket } from './utils/lifecycle';
+import {
+  closeWebSocketClient,
+  openWebSocketClient,
+  WebSocketClientCloseOptions,
+  WebSocketClientOpenOptions,
+} from './utils/lifecycle';
 
 export namespace WebSocketClient {
   export type ReadyState =
@@ -151,7 +156,7 @@ export class WebSocketClient<Schema extends WebSocketSchema> implements Omit<
     return this.socket?.bufferedAmount ?? 0;
   }
 
-  async open(options: { timeout?: number } = {}) {
+  async open(options: WebSocketClientOpenOptions = {}) {
     const socket = new WebSocket(this.#url, this.#protocols);
 
     if (socket.binaryType !== this.binaryType) {
@@ -160,7 +165,7 @@ export class WebSocketClient<Schema extends WebSocketSchema> implements Omit<
 
     this.applyListeners(socket);
 
-    await openClientSocket(socket, options);
+    await openWebSocketClient(socket, options);
 
     this.socket = socket;
   }
@@ -180,13 +185,13 @@ export class WebSocketClient<Schema extends WebSocketSchema> implements Omit<
     }
   }
 
-  async close(code?: number, reason?: string, options: { timeout?: number } = {}) {
+  async close(code?: number, reason?: string, options: WebSocketClientCloseOptions = {}) {
     if (!this.socket) {
       return;
     }
 
     try {
-      await closeClientSocket(this.socket, { ...options, code, reason });
+      await closeWebSocketClient(this.socket, { ...options, code, reason });
     } finally {
       this.socket = undefined;
     }

--- a/packages/zimic-ws/src/client/__tests__/WebSocketClient.test.ts
+++ b/packages/zimic-ws/src/client/__tests__/WebSocketClient.test.ts
@@ -27,7 +27,7 @@ describe('WebSocketClient', () => {
     httpServer = createHttpServer();
     webSocketServer = new WebSocketServer({ httpServer });
 
-    await startHttpServer(httpServer, { hostname: 'localhost' });
+    await startHttpServer(httpServer, { hostname: '127.0.0.1' });
     await webSocketServer.open();
 
     expect(webSocketServer.isOpen).toBe(true);

--- a/packages/zimic-ws/src/client/__tests__/WebSocketClient.test.ts
+++ b/packages/zimic-ws/src/client/__tests__/WebSocketClient.test.ts
@@ -3,11 +3,14 @@ import { waitFor, waitForNot } from '@zimic/utils/time';
 import { createServer as createHttpServer, Server as HttpServer } from 'http';
 import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
 
+import { WebSocketCloseTimeoutError } from '@/errors/WebSocketCloseTimeoutError';
+import { WebSocketOpenTimeoutError } from '@/errors/WebSocketOpenTimeoutError';
 import { WebSocketServer } from '@/server';
 import { WebSocketSchema } from '@/types/schema';
 
 import { openWebSocketClient } from '../utils/lifecycle';
 import { WebSocketClient } from '../WebSocketClient';
+import { delayWebSocketClose, delayWebSocketListenerTrigger } from './utils';
 
 describe('WebSocketClient', () => {
   let httpServer: HttpServer;
@@ -96,7 +99,7 @@ describe('WebSocketClient', () => {
       );
     });
 
-    it('should support construction from an already-created native socket', async () => {
+    it('should support construction from a native socket', async () => {
       const protocols = ['protocol1'];
 
       const nativeWebSocketClient = new WebSocket(webSocketServer.baseURL, protocols);
@@ -120,6 +123,36 @@ describe('WebSocketClient', () => {
 
       webSocketClient.binaryType = 'arraybuffer';
       expect(nativeWebSocketClient.binaryType).toBe('arraybuffer');
+
+      await webSocketClient.close();
+
+      expect(nativeWebSocketClient.readyState).toBe(WebSocket.CLOSED);
+      expect(webSocketClient.readyState).toBe(WebSocket.CLOSED);
+    });
+
+    it('should be open if the native socket is already open when constructed', async () => {
+      const protocols = ['protocol1'];
+
+      const nativeWebSocketClient = new WebSocket(webSocketServer.baseURL, protocols);
+      await openWebSocketClient(nativeWebSocketClient);
+
+      expect(nativeWebSocketClient.readyState).toBe(WebSocket.OPEN);
+
+      webSocketClient = new WebSocketClient<Schema>(nativeWebSocketClient);
+
+      expect(webSocketClient.readyState).toBe(WebSocket.OPEN);
+      expect(webSocketClient.url).toBe(nativeWebSocketClient.url);
+      expect(webSocketClient.protocol).toBe(protocols[0]);
+
+      await webSocketClient.open();
+
+      expect(nativeWebSocketClient.readyState).toBe(WebSocket.OPEN);
+      expect(webSocketClient.readyState).toBe(WebSocket.OPEN);
+
+      await openWebSocketClient(nativeWebSocketClient);
+
+      expect(nativeWebSocketClient.readyState).toBe(WebSocket.OPEN);
+      expect(webSocketClient.readyState).toBe(WebSocket.OPEN);
 
       await webSocketClient.close();
 
@@ -535,6 +568,48 @@ describe('WebSocketClient', () => {
       expect(dispatched).toBe(true);
 
       expect(errorListener).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Timeouts', () => {
+    it('should throw an open timeout error if opening times out', async () => {
+      const delayedListenerTrigger = delayWebSocketListenerTrigger(100);
+
+      try {
+        webSocketClient = new WebSocketClient<Schema>(webSocketServer.baseURL);
+
+        const timeoutDuration = 5;
+
+        const openPromise = webSocketClient.open({ timeout: timeoutDuration });
+        await expect(openPromise).rejects.toThrow(new WebSocketOpenTimeoutError(timeoutDuration));
+
+        await delayedListenerTrigger.asPromise();
+
+        expect(webSocketClient.readyState).toBe(webSocketClient.CLOSED);
+      } finally {
+        delayedListenerTrigger.restore();
+      }
+    });
+
+    it('should throw a close timeout error if closing times out', async () => {
+      webSocketClient = new WebSocketClient<Schema>(webSocketServer.baseURL);
+
+      await webSocketClient.open();
+
+      const delayedWebSocketClose = delayWebSocketClose(100);
+
+      try {
+        const timeoutDuration = 5;
+
+        const closePromise = webSocketClient.close(undefined, undefined, { timeout: timeoutDuration });
+        await expect(closePromise).rejects.toThrow(new WebSocketCloseTimeoutError(timeoutDuration));
+
+        await delayedWebSocketClose.toPromise();
+
+        expect(webSocketClient.readyState).toBe(webSocketClient.CLOSED);
+      } finally {
+        delayedWebSocketClose.restore();
+      }
     });
   });
 });

--- a/packages/zimic-ws/src/client/__tests__/WebSocketClient.test.ts
+++ b/packages/zimic-ws/src/client/__tests__/WebSocketClient.test.ts
@@ -1,97 +1,540 @@
-import { describe, expect, it } from 'vitest';
+import { startHttpServer, stopHttpServer } from '@zimic/utils/server';
+import { waitFor, waitForNot } from '@zimic/utils/time';
+import { createServer as createHttpServer, Server as HttpServer } from 'http';
+import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
 
+import { WebSocketServer } from '@/server';
+import { WebSocketSchema } from '@/types/schema';
+
+import { openWebSocketClient } from '../utils/lifecycle';
 import { WebSocketClient } from '../WebSocketClient';
 
 describe('WebSocketClient', () => {
-  it('should inherit all ready states from the native WebSocket class', () => {
-    expect(WebSocketClient.CONNECTING).toBe(WebSocket.CONNECTING);
-    expect(WebSocketClient.OPEN).toBe(WebSocket.OPEN);
-    expect(WebSocketClient.CLOSING).toBe(WebSocket.CLOSING);
-    expect(WebSocketClient.CLOSED).toBe(WebSocket.CLOSED);
+  let httpServer: HttpServer;
 
-    const client = new WebSocketClient('ws://localhost:3000');
+  type Schema = WebSocketSchema<{
+    type: 'message';
+    data: string;
+  }>;
 
-    expect(client.CONNECTING).toBe(WebSocket.CONNECTING);
-    expect(client.OPEN).toBe(WebSocket.OPEN);
-    expect(client.CLOSING).toBe(WebSocket.CLOSING);
-    expect(client.CLOSED).toBe(WebSocket.CLOSED);
+  let webSocketServer: WebSocketServer<Schema>;
+  let webSocketClient: WebSocketClient<Schema> | undefined;
+
+  beforeEach(async () => {
+    httpServer = createHttpServer();
+    webSocketServer = new WebSocketServer({ httpServer });
+
+    await startHttpServer(httpServer, { hostname: 'localhost' });
+    await webSocketServer.open();
+
+    expect(webSocketServer.isOpen).toBe(true);
   });
 
-  it('should have the correct URL after instantiated', () => {
-    const url = 'ws://localhost:3000/socket';
+  afterEach(async () => {
+    await webSocketClient?.close();
+    webSocketClient = undefined;
 
-    const client = new WebSocketClient(url);
-    expect(client.url).toBe(url);
+    await webSocketServer.close();
+    await stopHttpServer(httpServer);
   });
 
-  it('should support setting and getting the binary type', () => {
-    const client = new WebSocketClient('ws://localhost:3000');
-    expect(client.binaryType).toBe('blob');
+  describe('Lifecycle', () => {
+    it('should open and close correctly', async () => {
+      webSocketClient = new WebSocketClient<Schema>(webSocketServer.baseURL);
+      expect(webSocketClient.readyState).toBe(webSocketClient.CLOSED);
 
-    client.binaryType = 'arraybuffer';
-    expect(client.binaryType).toBe('arraybuffer');
+      await webSocketClient.open();
+      expect(webSocketClient.readyState).toBe(webSocketClient.OPEN);
+
+      await webSocketClient.close();
+      expect(webSocketClient.readyState).toBe(webSocketClient.CLOSED);
+    });
+
+    it('should not throw an error if opened multiple times', async () => {
+      webSocketClient = new WebSocketClient<Schema>(webSocketServer.baseURL);
+      expect(webSocketClient.readyState).toBe(webSocketClient.CLOSED);
+
+      await webSocketClient.open();
+      await webSocketClient.open();
+      await webSocketClient.open();
+
+      expect(webSocketClient.readyState).toBe(webSocketClient.OPEN);
+    });
+
+    it('should not throw an error if closed multiple times', async () => {
+      webSocketClient = new WebSocketClient<Schema>(webSocketServer.baseURL);
+      expect(webSocketClient.readyState).toBe(webSocketClient.CLOSED);
+
+      await webSocketClient.open();
+      expect(webSocketClient.readyState).toBe(webSocketClient.OPEN);
+
+      await webSocketClient.close();
+      await webSocketClient.close();
+      await webSocketClient.close();
+
+      expect(webSocketClient.readyState).toBe(webSocketClient.CLOSED);
+    });
+
+    it('should close with code and reason', async () => {
+      webSocketClient = new WebSocketClient<Schema>(webSocketServer.baseURL);
+
+      const closeListener = vi.fn<WebSocketClient.EventListener<WebSocketSchema, 'close'>>();
+      webSocketClient.addEventListener('close', closeListener);
+
+      await webSocketClient.open();
+
+      const closeCode = 4000;
+      const closeReason = 'test-close-reason';
+      await webSocketClient.close(closeCode, closeReason);
+
+      expect(closeListener).toHaveBeenCalledTimes(1);
+      expect(closeListener).toHaveBeenCalledWith(
+        expect.objectContaining({
+          code: closeCode,
+          reason: closeReason,
+        }),
+      );
+    });
+
+    it('should support construction from an already-created native socket', async () => {
+      const protocols = ['protocol1'];
+
+      const nativeWebSocketClient = new WebSocket(webSocketServer.baseURL, protocols);
+      webSocketClient = new WebSocketClient<Schema>(nativeWebSocketClient);
+
+      expect(nativeWebSocketClient.readyState).toBe(WebSocket.CONNECTING);
+      expect(webSocketClient.readyState).toBe(WebSocket.CONNECTING);
+
+      await openWebSocketClient(nativeWebSocketClient);
+
+      expect(nativeWebSocketClient.readyState).toBe(WebSocket.OPEN);
+      expect(webSocketClient.readyState).toBe(WebSocket.OPEN);
+
+      await webSocketClient.open();
+
+      expect(nativeWebSocketClient.readyState).toBe(WebSocket.OPEN);
+
+      expect(webSocketClient.readyState).toBe(WebSocket.OPEN);
+      expect(webSocketClient.url).toBe(nativeWebSocketClient.url);
+      expect(webSocketClient.protocol).toBe(protocols[0]);
+
+      webSocketClient.binaryType = 'arraybuffer';
+      expect(nativeWebSocketClient.binaryType).toBe('arraybuffer');
+
+      await webSocketClient.close();
+
+      expect(nativeWebSocketClient.readyState).toBe(WebSocket.CLOSED);
+      expect(webSocketClient.readyState).toBe(WebSocket.CLOSED);
+    });
   });
 
-  // TODO: Opening the client requires mocking a WebSocket server using @zimic/interceptor
-  it.todo('should support getting protocols', async () => {
-    const protocols = ['protocol1', 'protocol2'];
+  describe('Properties', () => {
+    it('should inherit all ready states from the native WebSocket class', () => {
+      expect(WebSocketClient.CONNECTING).toBe(WebSocket.CONNECTING);
+      expect(WebSocketClient.OPEN).toBe(WebSocket.OPEN);
+      expect(WebSocketClient.CLOSING).toBe(WebSocket.CLOSING);
+      expect(WebSocketClient.CLOSED).toBe(WebSocket.CLOSED);
 
-    const client = new WebSocketClient('ws://localhost:3000', protocols);
-    expect(client.protocol).toBe(undefined);
+      webSocketClient = new WebSocketClient<Schema>(webSocketServer.baseURL);
 
-    await client.open();
+      expect(webSocketClient.CONNECTING).toBe(WebSocket.CONNECTING);
+      expect(webSocketClient.OPEN).toBe(WebSocket.OPEN);
+      expect(webSocketClient.CLOSING).toBe(WebSocket.CLOSING);
+      expect(webSocketClient.CLOSED).toBe(WebSocket.CLOSED);
+    });
 
-    expect(client.protocol).toBe(protocols[0]);
+    it('should expose URL, protocol, extensions, state, and buffer correctly', async () => {
+      const protocols = ['protocol1', 'protocol2'];
+      webSocketClient = new WebSocketClient<Schema>(webSocketServer.baseURL, protocols);
+
+      expect(webSocketClient.url).toBe(webSocketServer.baseURL);
+      expect(webSocketClient.protocol).toBe('');
+      expect(webSocketClient.extensions).toBe('');
+      expect(webSocketClient.readyState).toBe(webSocketClient.CLOSED);
+      expect(webSocketClient.bufferedAmount).toBe(0);
+
+      await webSocketClient.open();
+
+      expect(webSocketClient.protocol).toBe(protocols[0]);
+      expect(webSocketClient.extensions).toBe('');
+      expect(webSocketClient.readyState).toBe(webSocketClient.OPEN);
+      expect(webSocketClient.bufferedAmount).toBe(0);
+    });
+
+    it('should support setting binary type before and after opening', async () => {
+      webSocketClient = new WebSocketClient<Schema>(webSocketServer.baseURL);
+
+      expect(webSocketClient.binaryType).toBe('blob');
+
+      webSocketClient.binaryType = 'arraybuffer';
+      expect(webSocketClient.binaryType).toBe('arraybuffer');
+
+      await webSocketClient.open();
+      expect(webSocketClient.binaryType).toBe('arraybuffer');
+
+      webSocketClient.binaryType = 'blob';
+      expect(webSocketClient.binaryType).toBe('blob');
+    });
   });
 
-  // TODO: Opening the client requires mocking a WebSocket server using @zimic/interceptor
-  it.todo('should support getting extensions', async () => {
-    const client = new WebSocketClient('ws://localhost:3000');
-    expect(client.extensions).toBe('');
+  describe('Messaging', () => {
+    it('should not throw if sending while closed', () => {
+      webSocketClient = new WebSocketClient<Schema>(webSocketServer.baseURL);
 
-    await client.open();
+      expect(() => {
+        webSocketClient!.send(
+          JSON.stringify({
+            type: 'message',
+            data: 'test',
+          }),
+        );
+      }).not.toThrow();
+    });
 
-    expect(client.extensions).toBe('');
+    it('should send and receive messages', async () => {
+      webSocketClient = new WebSocketClient<Schema>(webSocketServer.baseURL);
+
+      webSocketServer.addEventListener('connection', (serverWebSocketClient) => {
+        serverWebSocketClient.addEventListener('message', (event) => {
+          const message = JSON.parse(event.data);
+          expectTypeOf(message).toEqualTypeOf<Schema>();
+
+          serverWebSocketClient.send(
+            JSON.stringify({
+              type: 'message',
+              data: `response: ${message.data}`,
+            }),
+          );
+        });
+      });
+
+      const messageListener = vi.fn<WebSocketClient.EventListener<WebSocketSchema, 'message'>>();
+      webSocketClient.addEventListener('message', messageListener);
+
+      await webSocketClient.open();
+      webSocketClient.send(
+        JSON.stringify({
+          type: 'message',
+          data: 'hello',
+        }),
+      );
+
+      await waitFor(() => {
+        expect(messageListener).toHaveBeenCalledTimes(1);
+        expect(messageListener).toHaveBeenCalledWith(
+          expect.objectContaining({
+            data: JSON.stringify({
+              type: 'message',
+              data: 'response: hello',
+            }),
+          }),
+        );
+      });
+    });
   });
 
-  it('should be closed after instantiated', () => {
-    const client = new WebSocketClient('ws://localhost:3000');
-    expect(client.readyState).toBe(client.CLOSED);
+  describe('Listeners', () => {
+    it('should support adding and removing non-unitary listeners', async () => {
+      webSocketClient = new WebSocketClient<Schema>(webSocketServer.baseURL);
+
+      const onOpen = vi.fn<WebSocketClient.EventListener<WebSocketSchema, 'open'>>();
+      const onMessage = vi.fn<WebSocketClient.EventListener<WebSocketSchema, 'message'>>();
+      const onClose = vi.fn<WebSocketClient.EventListener<WebSocketSchema, 'close'>>();
+      const onError = vi.fn<WebSocketClient.EventListener<WebSocketSchema, 'error'>>();
+
+      webSocketServer.addEventListener('connection', (serverClient) => {
+        serverClient.send(
+          JSON.stringify({
+            type: 'message',
+            data: 'hello',
+          }),
+        );
+      });
+
+      webSocketClient.addEventListener('open', onOpen);
+      webSocketClient.addEventListener('message', onMessage);
+      webSocketClient.addEventListener('close', onClose);
+      webSocketClient.addEventListener('error', onError);
+
+      expect(webSocketClient.onopen).toBe(null);
+      expect(webSocketClient.onmessage).toBe(null);
+      expect(webSocketClient.onclose).toBe(null);
+      expect(webSocketClient.onerror).toBe(null);
+
+      await webSocketClient.open();
+
+      await waitFor(() => {
+        expect(onOpen).toHaveBeenCalledTimes(1);
+        expect(onMessage).toHaveBeenCalledTimes(1);
+      });
+      expect(onError).toHaveBeenCalledTimes(0);
+      expect(onClose).toHaveBeenCalledTimes(0);
+
+      webSocketClient.dispatchEvent(new Event('error'));
+
+      await waitFor(() => {
+        expect(onOpen).toHaveBeenCalledTimes(1);
+        expect(onMessage).toHaveBeenCalledTimes(1);
+        expect(onError).toHaveBeenCalledTimes(1);
+      });
+      expect(onClose).toHaveBeenCalledTimes(0);
+
+      await webSocketClient.close();
+
+      await waitFor(() => {
+        expect(onOpen).toHaveBeenCalledTimes(1);
+        expect(onMessage).toHaveBeenCalledTimes(1);
+        expect(onError).toHaveBeenCalledTimes(1);
+        expect(onClose).toHaveBeenCalledTimes(1);
+      });
+
+      webSocketClient.removeEventListener('open', onOpen);
+      webSocketClient.removeEventListener('message', onMessage);
+      webSocketClient.removeEventListener('close', onClose);
+      webSocketClient.removeEventListener('error', onError);
+
+      expect(webSocketClient.onopen).toBe(null);
+      expect(webSocketClient.onmessage).toBe(null);
+      expect(webSocketClient.onclose).toBe(null);
+      expect(webSocketClient.onerror).toBe(null);
+
+      await webSocketClient.open();
+      webSocketClient.dispatchEvent(new Event('error'));
+      await webSocketClient.close();
+
+      await waitForNot(() => {
+        expect(onOpen.mock.calls.length).toBeGreaterThan(1);
+      });
+      await waitForNot(() => {
+        expect(onMessage.mock.calls.length).toBeGreaterThan(1);
+      });
+      await waitForNot(() => {
+        expect(onError.mock.calls.length).toBeGreaterThan(1);
+      });
+      await waitForNot(() => {
+        expect(onClose.mock.calls.length).toBeGreaterThan(1);
+      });
+    });
+
+    it('should support setting and removing unitary listeners', async () => {
+      webSocketClient = new WebSocketClient<Schema>(webSocketServer.baseURL);
+
+      const onOpen = vi.fn<WebSocketClient.EventListener<WebSocketSchema, 'open'>>();
+      const onMessage = vi.fn<WebSocketClient.EventListener<WebSocketSchema, 'message'>>();
+      const onClose = vi.fn<WebSocketClient.EventListener<WebSocketSchema, 'close'>>();
+      const onError = vi.fn<WebSocketClient.EventListener<WebSocketSchema, 'error'>>();
+
+      webSocketServer.addEventListener('connection', (serverClient) => {
+        serverClient.send(
+          JSON.stringify({
+            type: 'message',
+            data: 'hello',
+          }),
+        );
+      });
+
+      webSocketClient.onopen = onOpen;
+      webSocketClient.onmessage = onMessage;
+      webSocketClient.onclose = onClose;
+      webSocketClient.onerror = onError;
+
+      expect(webSocketClient.onopen).toBe(onOpen);
+      expect(webSocketClient.onmessage).toBe(onMessage);
+      expect(webSocketClient.onclose).toBe(onClose);
+      expect(webSocketClient.onerror).toBe(onError);
+
+      await webSocketClient.open();
+
+      await waitFor(() => {
+        expect(onOpen).toHaveBeenCalledTimes(1);
+        expect(onMessage).toHaveBeenCalledTimes(1);
+      });
+      expect(onError).toHaveBeenCalledTimes(0);
+      expect(onClose).toHaveBeenCalledTimes(0);
+
+      webSocketClient.dispatchEvent(new Event('error'));
+
+      await waitFor(() => {
+        expect(onOpen).toHaveBeenCalledTimes(1);
+        expect(onMessage).toHaveBeenCalledTimes(1);
+        expect(onError).toHaveBeenCalledTimes(1);
+      });
+      expect(onClose).toHaveBeenCalledTimes(0);
+
+      await webSocketClient.close();
+
+      await waitFor(() => {
+        expect(onOpen).toHaveBeenCalledTimes(1);
+        expect(onMessage).toHaveBeenCalledTimes(1);
+        expect(onError).toHaveBeenCalledTimes(1);
+        expect(onClose).toHaveBeenCalledTimes(1);
+      });
+
+      await webSocketClient.open();
+
+      expect(onOpen).toHaveBeenCalledTimes(2);
+      expect(onMessage).toHaveBeenCalledTimes(1);
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(onClose).toHaveBeenCalledTimes(1);
+
+      webSocketClient.onopen = null;
+      webSocketClient.onmessage = null;
+      webSocketClient.onclose = null;
+      webSocketClient.onerror = null;
+
+      expect(webSocketClient.onopen).toBe(null);
+      expect(webSocketClient.onmessage).toBe(null);
+      expect(webSocketClient.onclose).toBe(null);
+      expect(webSocketClient.onerror).toBe(null);
+
+      webSocketClient.dispatchEvent(new Event('error'));
+      await webSocketClient.close();
+
+      expect(onOpen).toHaveBeenCalledTimes(2);
+      expect(onMessage).toHaveBeenCalledTimes(1);
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('should replace previous unitary listeners if reassigned', async () => {
+      webSocketClient = new WebSocketClient<Schema>(webSocketServer.baseURL);
+
+      const openListener = vi.fn<WebSocketClient.EventListener<WebSocketSchema, 'open'>>();
+      const otherOpenListener = vi.fn<WebSocketClient.EventListener<WebSocketSchema, 'open'>>();
+
+      webSocketClient.onopen = openListener;
+      webSocketClient.onopen = otherOpenListener;
+
+      await webSocketClient.open();
+
+      expect(openListener).not.toHaveBeenCalled();
+      expect(otherOpenListener).toHaveBeenCalledTimes(1);
+
+      const closeListener = vi.fn<WebSocketClient.EventListener<WebSocketSchema, 'close'>>();
+      const otherCloseListener = vi.fn<WebSocketClient.EventListener<WebSocketSchema, 'close'>>();
+
+      webSocketClient.onclose = closeListener;
+      webSocketClient.onclose = otherCloseListener;
+
+      await webSocketClient.close();
+
+      expect(closeListener).not.toHaveBeenCalled();
+      expect(otherCloseListener).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not replace non-unitary listeners when assigning unitary listeners', async () => {
+      webSocketClient = new WebSocketClient<Schema>(webSocketServer.baseURL);
+
+      const onOpen = vi.fn<WebSocketClient.EventListener<WebSocketSchema, 'open'>>();
+      const openListener = vi.fn<WebSocketClient.EventListener<WebSocketSchema, 'open'>>();
+
+      webSocketClient.onopen = onOpen;
+      webSocketClient.addEventListener('open', openListener);
+
+      await webSocketClient.open();
+
+      expect(onOpen).toHaveBeenCalledTimes(1);
+      expect(openListener).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not replace non-unitary listeners when multiple are added', async () => {
+      webSocketClient = new WebSocketClient<Schema>(webSocketServer.baseURL);
+
+      const openListener = vi.fn<WebSocketClient.EventListener<WebSocketSchema, 'open'>>();
+      const otherOpenListener = vi.fn<WebSocketClient.EventListener<WebSocketSchema, 'open'>>();
+
+      webSocketClient.addEventListener('open', openListener);
+      webSocketClient.addEventListener('open', otherOpenListener);
+
+      await webSocketClient.open();
+
+      expect(openListener).toHaveBeenCalledTimes(1);
+      expect(otherOpenListener).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not throw when removing non-unitary listeners multiple times', async () => {
+      webSocketClient = new WebSocketClient<Schema>(webSocketServer.baseURL);
+
+      const openListener = vi.fn<WebSocketClient.EventListener<WebSocketSchema, 'open'>>();
+
+      webSocketClient.addEventListener('open', openListener);
+
+      webSocketClient.removeEventListener('open', openListener);
+      webSocketClient.removeEventListener('open', openListener);
+      webSocketClient.removeEventListener('open', openListener);
+
+      await webSocketClient.open();
+
+      expect(openListener).not.toHaveBeenCalled();
+    });
+
+    it('should not throw when clearing unitary listeners multiple times', async () => {
+      webSocketClient = new WebSocketClient<Schema>(webSocketServer.baseURL);
+
+      const onOpen = vi.fn<WebSocketClient.EventListener<WebSocketSchema, 'open'>>();
+
+      webSocketClient.onopen = onOpen;
+      webSocketClient.onopen = null;
+      webSocketClient.onopen = null;
+      webSocketClient.onopen = null;
+
+      await webSocketClient.open();
+
+      expect(onOpen).not.toHaveBeenCalled();
+    });
+
+    it('should allow non-unitary listeners added after opened', async () => {
+      webSocketClient = new WebSocketClient<Schema>(webSocketServer.baseURL);
+
+      await webSocketClient.open();
+
+      const closeListener = vi.fn<WebSocketClient.EventListener<WebSocketSchema, 'close'>>();
+      webSocketClient.addEventListener('close', closeListener);
+
+      await webSocketClient.close();
+
+      expect(closeListener).toHaveBeenCalledTimes(1);
+    });
+
+    it('should allow unitary listeners added after opened', async () => {
+      webSocketClient = new WebSocketClient<Schema>(webSocketServer.baseURL);
+
+      await webSocketClient.open();
+
+      const onClose = vi.fn<WebSocketClient.EventListener<WebSocketSchema, 'close'>>();
+      webSocketClient.onclose = onClose;
+
+      await webSocketClient.close();
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
   });
 
-  // TODO: Opening the client requires mocking a WebSocket server using @zimic/interceptor
-  it.todo('should support getting buffered amount', async () => {
-    const client = new WebSocketClient('ws://localhost:3000');
-    expect(client.bufferedAmount).toBe(0);
+  describe('Dispatch Event', () => {
+    it('should return false when dispatching with no socket', () => {
+      webSocketClient = new WebSocketClient<Schema>(webSocketServer.baseURL);
 
-    await client.open();
+      const errorListener = vi.fn<WebSocketClient.EventListener<WebSocketSchema, 'error'>>();
+      webSocketClient.addEventListener('error', errorListener);
 
-    expect(client.bufferedAmount).toBe(0);
-  });
+      const dispatched = webSocketClient.dispatchEvent(new Event('error'));
+      expect(dispatched).toBe(false);
 
-  it.todo('should not throw an error if opened multiple times', async () => {
-    const client = new WebSocketClient('ws://localhost:3000');
-    expect(client.readyState).toBe(client.CLOSED);
+      expect(errorListener).toHaveBeenCalledTimes(0);
+    });
 
-    await client.open();
-    await client.open();
-    await client.open();
+    it('should dispatch events through the underlying socket when open', async () => {
+      webSocketClient = new WebSocketClient<Schema>(webSocketServer.baseURL);
 
-    expect(client.readyState).toBe(client.OPEN);
-  });
+      const errorListener = vi.fn<WebSocketClient.EventListener<WebSocketSchema, 'error'>>();
+      webSocketClient.addEventListener('error', errorListener);
 
-  it.todo('should not throw an error if closed multiple times', async () => {
-    const client = new WebSocketClient('ws://localhost:3000');
-    expect(client.readyState).toBe(client.CLOSED);
+      await webSocketClient.open();
 
-    await client.open();
+      const dispatched = webSocketClient.dispatchEvent(new Event('error'));
+      expect(dispatched).toBe(true);
 
-    expect(client.readyState).toBe(client.OPEN);
-
-    await client.close();
-    await client.close();
-    await client.close();
-
-    expect(client.readyState).toBe(client.CLOSED);
+      expect(errorListener).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/packages/zimic-ws/src/client/__tests__/WebSocketClient.test.ts
+++ b/packages/zimic-ws/src/client/__tests__/WebSocketClient.test.ts
@@ -1,21 +1,20 @@
 import { describe, expect, it } from 'vitest';
 
-import { ClientSocket } from '../ClientSocket';
-import WebSocketClient from '../WebSocketClient';
+import { WebSocketClient } from '../WebSocketClient';
 
 describe('WebSocketClient', () => {
   it('should inherit all ready states from the native WebSocket class', () => {
-    expect(WebSocketClient.CONNECTING).toBe(ClientSocket.CONNECTING);
-    expect(WebSocketClient.OPEN).toBe(ClientSocket.OPEN);
-    expect(WebSocketClient.CLOSING).toBe(ClientSocket.CLOSING);
-    expect(WebSocketClient.CLOSED).toBe(ClientSocket.CLOSED);
+    expect(WebSocketClient.CONNECTING).toBe(WebSocket.CONNECTING);
+    expect(WebSocketClient.OPEN).toBe(WebSocket.OPEN);
+    expect(WebSocketClient.CLOSING).toBe(WebSocket.CLOSING);
+    expect(WebSocketClient.CLOSED).toBe(WebSocket.CLOSED);
 
     const client = new WebSocketClient('ws://localhost:3000');
 
-    expect(client.CONNECTING).toBe(ClientSocket.CONNECTING);
-    expect(client.OPEN).toBe(ClientSocket.OPEN);
-    expect(client.CLOSING).toBe(ClientSocket.CLOSING);
-    expect(client.CLOSED).toBe(ClientSocket.CLOSED);
+    expect(client.CONNECTING).toBe(WebSocket.CONNECTING);
+    expect(client.OPEN).toBe(WebSocket.OPEN);
+    expect(client.CLOSING).toBe(WebSocket.CLOSING);
+    expect(client.CLOSED).toBe(WebSocket.CLOSED);
   });
 
   it('should have the correct URL after instantiated', () => {

--- a/packages/zimic-ws/src/client/__tests__/utils.ts
+++ b/packages/zimic-ws/src/client/__tests__/utils.ts
@@ -6,10 +6,9 @@ export function delayWebSocketListenerTrigger(delayDuration: number) {
 
   const promises = new Set<Promise<void>>();
 
-  const delayedWebSocketAddEventListener = vi.spyOn(WebSocket.prototype, 'addEventListener').mockImplementationOnce(
-    /* istanbul ignore if -- @preserve
-     * This function may not be executed if tests do not way for the open event to be emitted. */
-    function (this: WebSocket, type, listener) {
+  const delayedWebSocketAddEventListener = vi
+    .spyOn(WebSocket.prototype, 'addEventListener')
+    .mockImplementationOnce(function (this: WebSocket, type, listener) {
       const promise = waitForDelay(delayDuration).then(() => {
         originalWebSocketAddEventListener.call(this, type, listener as () => void);
         promises.delete(promise);
@@ -17,8 +16,7 @@ export function delayWebSocketListenerTrigger(delayDuration: number) {
       promises.add(promise);
 
       return this;
-    },
-  );
+    });
 
   return {
     restore() {

--- a/packages/zimic-ws/src/client/__tests__/utils.ts
+++ b/packages/zimic-ws/src/client/__tests__/utils.ts
@@ -1,0 +1,59 @@
+import { waitForDelay } from '@zimic/utils/time';
+import { vi } from 'vitest';
+
+export function delayWebSocketListenerTrigger(delayDuration: number) {
+  const originalWebSocketAddEventListener = WebSocket.prototype.addEventListener;
+
+  const promises = new Set<Promise<void>>();
+
+  const delayedWebSocketAddEventListener = vi.spyOn(WebSocket.prototype, 'addEventListener').mockImplementationOnce(
+    /* istanbul ignore if -- @preserve
+     * This function may not be executed if tests do not way for the open event to be emitted. */
+    function (this: WebSocket, type, listener) {
+      const promise = waitForDelay(delayDuration).then(() => {
+        originalWebSocketAddEventListener.call(this, type, listener as () => void);
+        promises.delete(promise);
+      });
+      promises.add(promise);
+
+      return this;
+    },
+  );
+
+  return {
+    restore() {
+      delayedWebSocketAddEventListener.mockRestore();
+    },
+    asPromise() {
+      return Promise.all(promises);
+    },
+  };
+}
+
+export function delayWebSocketClose(delayDuration: number) {
+  const originalWebSocketClose = WebSocket.prototype.close;
+
+  const promises = new Set<Promise<void>>();
+
+  const delayedWebSocketClose = vi.spyOn(WebSocket.prototype, 'close').mockImplementationOnce(function (
+    this: WebSocket,
+    ...parameters
+  ) {
+    const promise = waitForDelay(delayDuration).then(() => {
+      originalWebSocketClose.apply(this, parameters);
+      promises.delete(promise);
+    });
+    promises.add(promise);
+
+    return this;
+  });
+
+  return {
+    restore() {
+      delayedWebSocketClose.mockRestore();
+    },
+    toPromise() {
+      return Promise.all(promises);
+    },
+  };
+}

--- a/packages/zimic-ws/src/client/utils/lifecycle.ts
+++ b/packages/zimic-ws/src/client/utils/lifecycle.ts
@@ -1,9 +1,7 @@
 import { WebSocketCloseTimeoutError } from '@/errors/WebSocketCloseTimeoutError';
 import { WebSocketOpenTimeoutError } from '@/errors/WebSocketOpenTimeoutError';
 
-import { ClientSocket } from '../ClientSocket';
-
-export async function openClientSocket(socket: ClientSocket, options: { timeout?: number } = {}) {
+export async function openClientSocket(socket: WebSocket, options: { timeout?: number } = {}) {
   const { timeout: timeoutDuration } = options;
 
   const isAlreadyOpen = socket.readyState === socket.OPEN;
@@ -45,7 +43,7 @@ export async function openClientSocket(socket: ClientSocket, options: { timeout?
 }
 
 export async function closeClientSocket(
-  socket: ClientSocket,
+  socket: WebSocket,
   options: { code?: number; reason?: string; timeout?: number } = {},
 ) {
   const { timeout: timeoutDuration } = options;

--- a/packages/zimic-ws/src/client/utils/lifecycle.ts
+++ b/packages/zimic-ws/src/client/utils/lifecycle.ts
@@ -17,25 +17,25 @@ export async function openWebSocketClient(socket: WebSocket, options: WebSocketC
   }
 
   await new Promise<void>((resolve, reject) => {
-    function removeListeners() {
+    const openTimeout = setTimeout(() => {
+      const timeoutError = new WebSocketOpenTimeoutError(timeoutDuration);
+      handleError(timeoutError); // eslint-disable-line @typescript-eslint/no-use-before-define
+    }, timeoutDuration);
+
+    function clearTimeoutAndListeners() {
+      clearTimeout(openTimeout);
       socket.removeEventListener('open', handleOpenSuccess); // eslint-disable-line @typescript-eslint/no-use-before-define
       socket.removeEventListener('error', handleError); // eslint-disable-line @typescript-eslint/no-use-before-define
       socket.removeEventListener('close', handleError); // eslint-disable-line @typescript-eslint/no-use-before-define
     }
 
     function handleError(error: unknown) {
-      removeListeners();
+      clearTimeoutAndListeners();
       reject(error);
     }
 
-    const openTimeout = setTimeout(() => {
-      const timeoutError = new WebSocketOpenTimeoutError(timeoutDuration);
-      handleError(timeoutError);
-    }, timeoutDuration);
-
     function handleOpenSuccess() {
-      removeListeners();
-      clearTimeout(openTimeout);
+      clearTimeoutAndListeners();
       resolve();
     }
 
@@ -60,7 +60,13 @@ export async function closeWebSocketClient(
   }
 
   await new Promise<void>((resolve, reject) => {
+    const closeTimeout = setTimeout(() => {
+      const timeoutError = new WebSocketCloseTimeoutError(timeoutDuration);
+      handleError(timeoutError); // eslint-disable-line @typescript-eslint/no-use-before-define
+    }, timeoutDuration);
+
     function removeListeners() {
+      clearTimeout(closeTimeout);
       socket.removeEventListener('error', handleError); // eslint-disable-line @typescript-eslint/no-use-before-define
       socket.removeEventListener('close', handleClose); // eslint-disable-line @typescript-eslint/no-use-before-define
     }
@@ -70,14 +76,8 @@ export async function closeWebSocketClient(
       reject(error);
     }
 
-    const closeTimeout = setTimeout(() => {
-      const timeoutError = new WebSocketCloseTimeoutError(timeoutDuration);
-      handleError(timeoutError);
-    }, timeoutDuration);
-
     function handleClose() {
       removeListeners();
-      clearTimeout(closeTimeout);
       resolve();
     }
 

--- a/packages/zimic-ws/src/client/utils/lifecycle.ts
+++ b/packages/zimic-ws/src/client/utils/lifecycle.ts
@@ -1,7 +1,11 @@
 import { WebSocketCloseTimeoutError } from '@/errors/WebSocketCloseTimeoutError';
 import { WebSocketOpenTimeoutError } from '@/errors/WebSocketOpenTimeoutError';
 
-export async function openClientSocket(socket: WebSocket, options: { timeout?: number } = {}) {
+export interface WebSocketClientOpenOptions {
+  timeout?: number;
+}
+
+export async function openWebSocketClient(socket: WebSocket, options: WebSocketClientOpenOptions = {}) {
   const { timeout: timeoutDuration } = options;
 
   const isAlreadyOpen = socket.readyState === socket.OPEN;
@@ -42,9 +46,11 @@ export async function openClientSocket(socket: WebSocket, options: { timeout?: n
   });
 }
 
-export async function closeClientSocket(
+export type WebSocketClientCloseOptions = WebSocketClientOpenOptions;
+
+export async function closeWebSocketClient(
   socket: WebSocket,
-  options: { code?: number; reason?: string; timeout?: number } = {},
+  options: WebSocketClientCloseOptions & { code?: number; reason?: string } = {},
 ) {
   const { timeout: timeoutDuration } = options;
 

--- a/packages/zimic-ws/src/client/utils/lifecycle.ts
+++ b/packages/zimic-ws/src/client/utils/lifecycle.ts
@@ -22,20 +22,21 @@ export async function openWebSocketClient(socket: WebSocket, options: WebSocketC
       handleError(timeoutError); // eslint-disable-line @typescript-eslint/no-use-before-define
     }, timeoutDuration);
 
-    function clearTimeoutAndListeners() {
+    function removeListenersAndTimeout() {
       clearTimeout(openTimeout);
+
       socket.removeEventListener('open', handleOpenSuccess); // eslint-disable-line @typescript-eslint/no-use-before-define
       socket.removeEventListener('error', handleError); // eslint-disable-line @typescript-eslint/no-use-before-define
       socket.removeEventListener('close', handleError); // eslint-disable-line @typescript-eslint/no-use-before-define
     }
 
     function handleError(error: unknown) {
-      clearTimeoutAndListeners();
+      removeListenersAndTimeout();
       reject(error);
     }
 
     function handleOpenSuccess() {
-      clearTimeoutAndListeners();
+      removeListenersAndTimeout();
       resolve();
     }
 
@@ -65,19 +66,20 @@ export async function closeWebSocketClient(
       handleError(timeoutError); // eslint-disable-line @typescript-eslint/no-use-before-define
     }, timeoutDuration);
 
-    function removeListeners() {
+    function removeListenersAndTimeout() {
       clearTimeout(closeTimeout);
+
       socket.removeEventListener('error', handleError); // eslint-disable-line @typescript-eslint/no-use-before-define
       socket.removeEventListener('close', handleClose); // eslint-disable-line @typescript-eslint/no-use-before-define
     }
 
     function handleError(error: unknown) {
-      removeListeners();
+      removeListenersAndTimeout();
       reject(error);
     }
 
     function handleClose() {
-      removeListeners();
+      removeListenersAndTimeout();
       resolve();
     }
 

--- a/packages/zimic-ws/src/client/utils/lifecycle.ts
+++ b/packages/zimic-ws/src/client/utils/lifecycle.ts
@@ -50,7 +50,7 @@ export type WebSocketClientCloseOptions = WebSocketClientOpenOptions;
 
 export async function closeWebSocketClient(
   socket: WebSocket,
-  options: WebSocketClientCloseOptions & { code?: number; reason?: string } = {},
+  options: WebSocketClientCloseOptions & { code?: number; reason?: string },
 ) {
   const { timeout: timeoutDuration } = options;
 

--- a/packages/zimic-ws/src/client/utils/lifecycle.ts
+++ b/packages/zimic-ws/src/client/utils/lifecycle.ts
@@ -17,14 +17,14 @@ export async function openWebSocketClient(socket: WebSocket, options: WebSocketC
   }
 
   await new Promise<void>((resolve, reject) => {
-    function removeAllSocketListeners() {
+    function removeListeners() {
       socket.removeEventListener('open', handleOpenSuccess); // eslint-disable-line @typescript-eslint/no-use-before-define
       socket.removeEventListener('error', handleError); // eslint-disable-line @typescript-eslint/no-use-before-define
       socket.removeEventListener('close', handleError); // eslint-disable-line @typescript-eslint/no-use-before-define
     }
 
     function handleError(error: unknown) {
-      removeAllSocketListeners();
+      removeListeners();
       reject(error);
     }
 
@@ -34,7 +34,7 @@ export async function openWebSocketClient(socket: WebSocket, options: WebSocketC
     }, timeoutDuration);
 
     function handleOpenSuccess() {
-      removeAllSocketListeners();
+      removeListeners();
       clearTimeout(openTimeout);
       resolve();
     }
@@ -60,13 +60,13 @@ export async function closeWebSocketClient(
   }
 
   await new Promise<void>((resolve, reject) => {
-    function removeAllSocketListeners() {
+    function removeListeners() {
       socket.removeEventListener('error', handleError); // eslint-disable-line @typescript-eslint/no-use-before-define
       socket.removeEventListener('close', handleClose); // eslint-disable-line @typescript-eslint/no-use-before-define
     }
 
     function handleError(error: unknown) {
-      removeAllSocketListeners();
+      removeListeners();
       reject(error);
     }
 
@@ -76,7 +76,7 @@ export async function closeWebSocketClient(
     }, timeoutDuration);
 
     function handleClose() {
-      removeAllSocketListeners();
+      removeListeners();
       clearTimeout(closeTimeout);
       resolve();
     }

--- a/packages/zimic-ws/src/client/utils/lifecycle.ts
+++ b/packages/zimic-ws/src/client/utils/lifecycle.ts
@@ -1,12 +1,14 @@
 import { WebSocketCloseTimeoutError } from '@/errors/WebSocketCloseTimeoutError';
 import { WebSocketOpenTimeoutError } from '@/errors/WebSocketOpenTimeoutError';
 
+export const DEFAULT_WEB_SOCKET_LIFECYCLE_TIMEOUT = 60 * 1000;
+
 export interface WebSocketClientOpenOptions {
   timeout?: number;
 }
 
 export async function openWebSocketClient(socket: WebSocket, options: WebSocketClientOpenOptions = {}) {
-  const { timeout: timeoutDuration } = options;
+  const { timeout: timeoutDuration = DEFAULT_WEB_SOCKET_LIFECYCLE_TIMEOUT } = options;
 
   const isAlreadyOpen = socket.readyState === socket.OPEN;
 
@@ -26,13 +28,10 @@ export async function openWebSocketClient(socket: WebSocket, options: WebSocketC
       reject(error);
     }
 
-    const openTimeout =
-      timeoutDuration === undefined
-        ? undefined
-        : setTimeout(() => {
-            const timeoutError = new WebSocketOpenTimeoutError(timeoutDuration);
-            handleError(timeoutError);
-          }, timeoutDuration);
+    const openTimeout = setTimeout(() => {
+      const timeoutError = new WebSocketOpenTimeoutError(timeoutDuration);
+      handleError(timeoutError);
+    }, timeoutDuration);
 
     function handleOpenSuccess() {
       removeAllSocketListeners();
@@ -52,7 +51,7 @@ export async function closeWebSocketClient(
   socket: WebSocket,
   options: WebSocketClientCloseOptions & { code?: number; reason?: string },
 ) {
-  const { timeout: timeoutDuration } = options;
+  const { timeout: timeoutDuration = DEFAULT_WEB_SOCKET_LIFECYCLE_TIMEOUT } = options;
 
   const isAlreadyClosed = socket.readyState === socket.CLOSED;
 
@@ -71,13 +70,10 @@ export async function closeWebSocketClient(
       reject(error);
     }
 
-    const closeTimeout =
-      timeoutDuration === undefined
-        ? undefined
-        : setTimeout(() => {
-            const timeoutError = new WebSocketCloseTimeoutError(timeoutDuration);
-            handleError(timeoutError);
-          }, timeoutDuration);
+    const closeTimeout = setTimeout(() => {
+      const timeoutError = new WebSocketCloseTimeoutError(timeoutDuration);
+      handleError(timeoutError);
+    }, timeoutDuration);
 
     function handleClose() {
       removeAllSocketListeners();

--- a/packages/zimic-ws/src/errors/WebSocketMessageAbortError.ts
+++ b/packages/zimic-ws/src/errors/WebSocketMessageAbortError.ts
@@ -1,8 +1,0 @@
-import { WebSocketTimeoutError } from './WebSocketTimeoutError';
-
-export class WebSocketMessageAbortError extends WebSocketTimeoutError {
-  constructor() {
-    super('Web socket message was aborted.');
-    this.name = 'WebSocketMessageAbortError';
-  }
-}

--- a/packages/zimic-ws/src/index.ts
+++ b/packages/zimic-ws/src/index.ts
@@ -6,3 +6,4 @@ export { WebSocketOpenTimeoutError } from './errors/WebSocketOpenTimeoutError';
 export { WebSocketTimeoutError } from './errors/WebSocketTimeoutError';
 
 export { WebSocketClient } from './client/WebSocketClient';
+export type { WebSocketClientOpenOptions, WebSocketClientCloseOptions } from './client/utils/lifecycle';

--- a/packages/zimic-ws/src/index.ts
+++ b/packages/zimic-ws/src/index.ts
@@ -1,6 +1,8 @@
+export type { WebSocketSchema, WebSocketMessageData } from './types/schema';
+
 export { WebSocketCloseTimeoutError } from './errors/WebSocketCloseTimeoutError';
 export { WebSocketMessageAbortError } from './errors/WebSocketMessageAbortError';
 export { WebSocketOpenTimeoutError } from './errors/WebSocketOpenTimeoutError';
 export { WebSocketTimeoutError } from './errors/WebSocketTimeoutError';
 
-export { default as WebSocketClient } from './client/WebSocketClient';
+export { WebSocketClient } from './client/WebSocketClient';

--- a/packages/zimic-ws/src/index.ts
+++ b/packages/zimic-ws/src/index.ts
@@ -1,7 +1,6 @@
 export type { WebSocketSchema, WebSocketMessageData } from './types/schema';
 
 export { WebSocketCloseTimeoutError } from './errors/WebSocketCloseTimeoutError';
-export { WebSocketMessageAbortError } from './errors/WebSocketMessageAbortError';
 export { WebSocketOpenTimeoutError } from './errors/WebSocketOpenTimeoutError';
 export { WebSocketTimeoutError } from './errors/WebSocketTimeoutError';
 

--- a/packages/zimic-ws/src/server/ServerSocket.ts
+++ b/packages/zimic-ws/src/server/ServerSocket.ts
@@ -1,1 +1,0 @@
-export { WebSocketServer as ServerSocket } from 'ws';

--- a/packages/zimic-ws/src/server/WebSocketServer.ts
+++ b/packages/zimic-ws/src/server/WebSocketServer.ts
@@ -7,6 +7,7 @@ import { WebSocketServer as NodeWebSocketServer } from 'ws';
 import { WebSocketClient } from '@/client/WebSocketClient';
 import { WebSocketSchema } from '@/types/schema';
 
+import ClosedWebSocketServerError from './errors/ClosedWebSocketServerError';
 import {
   closeWebSocketServer,
   openWebSocketServer,
@@ -17,7 +18,7 @@ import {
 export namespace WebSocketServer {
   export type EventType = 'listening' | 'connection' | 'error' | 'close';
 
-  interface EventListenerParameters<Schema extends WebSocketSchema> {
+  export interface EventListenerParameters<Schema extends WebSocketSchema> {
     connection: [client: WebSocketClient<Schema>, request: IncomingMessage];
     error: [error: Error];
     close: [];
@@ -66,23 +67,28 @@ export class WebSocketServer<Schema extends WebSocketSchema> {
   }
 
   get baseURL() {
+    if (!this.isOpen) {
+      throw new ClosedWebSocketServerError();
+    }
     return `${this.protocol}://${this.hostname}:${this.port}`;
   }
 
   get protocol() {
-    return this.#httpServer instanceof HttpsServer ? 'https' : 'http';
+    return this.#httpServer instanceof HttpsServer ? 'wss' : 'ws';
   }
 
   get hostname() {
+    if (!this.isOpen) {
+      throw new ClosedWebSocketServerError();
+    }
     return getHttpServerHostname(this.#httpServer);
   }
 
   get port() {
+    if (!this.isOpen) {
+      throw new ClosedWebSocketServerError();
+    }
     return getHttpServerPort(this.#httpServer);
-  }
-
-  get httpServer() {
-    return this.#httpServer;
   }
 
   get isOpen() {
@@ -94,15 +100,17 @@ export class WebSocketServer<Schema extends WebSocketSchema> {
       await this.close();
     }
 
-    this.#webSocketServer = new NodeWebSocketServer({ server: this.#httpServer });
+    const webSocketServer = new NodeWebSocketServer({ server: this.#httpServer });
 
     for (const [type, listeners] of Object.entries(this.listeners)) {
       for (const [_listener, rawListener] of listeners) {
-        this.#webSocketServer.addListener(type, rawListener);
+        webSocketServer.addListener(type, rawListener);
       }
     }
 
-    await openWebSocketServer(this.#httpServer, this.#webSocketServer, options);
+    await openWebSocketServer(this.#httpServer, webSocketServer, options);
+
+    this.#webSocketServer = webSocketServer;
   }
 
   async close(options: WebSocketServerCloseOptions = {}) {
@@ -111,6 +119,7 @@ export class WebSocketServer<Schema extends WebSocketSchema> {
     }
 
     await closeWebSocketServer(this.#httpServer, this.#webSocketServer, options);
+
     this.#webSocketServer = undefined;
   }
 
@@ -125,7 +134,7 @@ export class WebSocketServer<Schema extends WebSocketSchema> {
     listener: WebSocketServer.EventListener<Schema, Type>,
   ) {
     const rawListener = this.createRawListener(type, listener);
-    this.#webSocketServer?.addListener(type, rawListener);
+    this.#webSocketServer?.on(type, rawListener);
     this.listeners[type].set(listener, rawListener);
   }
 
@@ -138,7 +147,10 @@ export class WebSocketServer<Schema extends WebSocketSchema> {
         const typedListener = listener as WebSocketServer.EventListener<Schema, 'connection'>;
 
         return ((...[rawClient, ...parameters]: WebSocketServerRawEventListenerParameters['connection']) => {
-          typedListener.call(this, new WebSocketClient<Schema>(rawClient), ...parameters);
+          const wrappedClient =
+            rawClient instanceof WebSocketClient ? rawClient : new WebSocketClient<Schema>(rawClient);
+
+          typedListener.call(this, wrappedClient, ...parameters);
         }) as WebSocketServerRawEventListener<Type>;
       }
 
@@ -163,8 +175,21 @@ export class WebSocketServer<Schema extends WebSocketSchema> {
     const rawListener = this.listeners[type].get(listener);
 
     if (rawListener) {
-      this.#webSocketServer?.removeListener(type, rawListener);
+      this.#webSocketServer?.off(type, rawListener);
       this.listeners[type].delete(listener);
+    }
+  }
+
+  emit<Type extends WebSocketServer.EventType>(
+    type: Type,
+    ...parameters: WebSocketServer.EventListenerParameters<Schema>[Type]
+  ) {
+    if (this.#webSocketServer) {
+      this.#webSocketServer.emit(type, ...parameters);
+    } else {
+      for (const [listener] of this.listeners[type]) {
+        listener.call(this, ...parameters);
+      }
     }
   }
 }

--- a/packages/zimic-ws/src/server/WebSocketServer.ts
+++ b/packages/zimic-ws/src/server/WebSocketServer.ts
@@ -102,13 +102,18 @@ export class WebSocketServer<Schema extends WebSocketSchema> {
 
     const webSocketServer = new NodeWebSocketServer({ server: this.#httpServer });
 
-    for (const [type, listeners] of Object.entries(this.listeners)) {
-      for (const [_listener, rawListener] of listeners) {
-        webSocketServer.addListener(type, rawListener);
+    try {
+      for (const [type, listeners] of Object.entries(this.listeners)) {
+        for (const [_listener, rawListener] of listeners) {
+          webSocketServer.addListener(type, rawListener);
+        }
       }
-    }
 
-    await openWebSocketServer(this.#httpServer, webSocketServer, options);
+      await openWebSocketServer(this.#httpServer, webSocketServer, options);
+    } catch (error) {
+      await closeWebSocketServer(this.#httpServer, webSocketServer);
+      throw error;
+    }
 
     this.#webSocketServer = webSocketServer;
   }

--- a/packages/zimic-ws/src/server/WebSocketServer.ts
+++ b/packages/zimic-ws/src/server/WebSocketServer.ts
@@ -95,9 +95,9 @@ export class WebSocketServer<Schema extends WebSocketSchema> {
     return this.#httpServer.listening && this.#webSocketServer !== undefined;
   }
 
-  async open(options: WebSocketServerOpenOptions = {}) {
-    if (this.#webSocketServer) {
-      await this.close();
+  async open(options?: WebSocketServerOpenOptions) {
+    if (this.isOpen) {
+      return;
     }
 
     const webSocketServer = new NodeWebSocketServer({ server: this.#httpServer });
@@ -113,7 +113,7 @@ export class WebSocketServer<Schema extends WebSocketSchema> {
     this.#webSocketServer = webSocketServer;
   }
 
-  async close(options: WebSocketServerCloseOptions = {}) {
+  async close(options?: WebSocketServerCloseOptions) {
     if (!this.#webSocketServer) {
       return;
     }

--- a/packages/zimic-ws/src/server/WebSocketServer.ts
+++ b/packages/zimic-ws/src/server/WebSocketServer.ts
@@ -111,7 +111,7 @@ export class WebSocketServer<Schema extends WebSocketSchema> {
 
       await openWebSocketServer(this.#httpServer, webSocketServer, options);
     } catch (error) {
-      await closeWebSocketServer(this.#httpServer, webSocketServer);
+      await closeWebSocketServer(webSocketServer);
       throw error;
     }
 
@@ -123,7 +123,7 @@ export class WebSocketServer<Schema extends WebSocketSchema> {
       return;
     }
 
-    await closeWebSocketServer(this.#httpServer, this.#webSocketServer, options);
+    await closeWebSocketServer(this.#webSocketServer, options);
 
     this.#webSocketServer = undefined;
   }

--- a/packages/zimic-ws/src/server/WebSocketServer.ts
+++ b/packages/zimic-ws/src/server/WebSocketServer.ts
@@ -1,45 +1,141 @@
-import { Server as HttpServer } from 'http';
+import { PossiblePromise } from '@zimic/utils/types';
+import { Server as HttpServer, IncomingMessage } from 'http';
 import { Server as HttpsServer } from 'https';
+import { WebSocketServer as NodeWebSocketServer } from 'ws';
 
-import { ServerSocket } from './ServerSocket';
+import { WebSocketClient } from '@/client/WebSocketClient';
+import { WebSocketSchema } from '@/types/schema';
+
 import { closeServerSocket, openServerSocket } from './utils/lifecycle';
+
+export namespace WebSocketServer {
+  export type EventType = 'listening' | 'connection' | 'error' | 'close';
+
+  interface EventListenerParameters<Schema extends WebSocketSchema> {
+    connection: [client: WebSocketClient<Schema>, request: IncomingMessage];
+    error: [error: Error];
+    close: [];
+    listening: [];
+  }
+
+  export type EventListener<Schema extends WebSocketSchema, Type extends EventType> = (
+    this: WebSocketServer<Schema>,
+    ...parameters: EventListenerParameters<Schema>[Type]
+  ) => PossiblePromise<void>;
+}
 
 export interface WebSocketServerOptions {
   server: HttpServer | HttpsServer;
 }
 
-class WebSocketServer {
-  private server: HttpServer | HttpsServer;
-  private socket: ServerSocket;
-  private isSocketOpen: boolean;
-
-  constructor(options: WebSocketServerOptions) {
-    this.server = options.server;
-    this.socket = new ServerSocket({ server: options.server });
-    this.isSocketOpen = options.server.listening;
-  }
-
-  get isRunning() {
-    return this.server.listening && this.isSocketOpen;
-  }
-
-  async start(options: { timeout?: number } = {}) {
-    if (this.isSocketOpen) {
-      return;
-    }
-
-    await openServerSocket(this.server, this.socket, options);
-    this.isSocketOpen = true;
-  }
-
-  async stop(options: { timeout?: number } = {}) {
-    if (!this.isSocketOpen) {
-      return;
-    }
-
-    await closeServerSocket(this.server, this.socket, options);
-    this.isSocketOpen = false;
-  }
+export interface WebSocketServerRawEventListenerParameters {
+  connection: [client: WebSocket, request: IncomingMessage];
+  error: [error: Error];
+  close: [];
+  listening: [];
 }
 
-export default WebSocketServer;
+type WebSocketServerRawEventListener<Type extends WebSocketServer.EventType> = (
+  ...parameters: WebSocketServerRawEventListenerParameters[Type]
+) => void;
+
+export class WebSocketServer<Schema extends WebSocketSchema> {
+  private httpServer: HttpServer | HttpsServer;
+  private webSocketServer: NodeWebSocketServer;
+
+  #isOpen = false;
+
+  private listeners: {
+    [Type in WebSocketServer.EventType]: Map<
+      WebSocketServer.EventListener<Schema, Type>,
+      WebSocketServerRawEventListener<Type>
+    >;
+  } = {
+    connection: new Map(),
+    listening: new Map(),
+    close: new Map(),
+    error: new Map(),
+  };
+
+  constructor(options: WebSocketServerOptions) {
+    this.httpServer = options.server;
+    this.webSocketServer = new NodeWebSocketServer({ server: this.httpServer });
+    this.#isOpen = this.httpServer.listening;
+  }
+
+  get isOpen() {
+    return this.httpServer.listening && this.#isOpen;
+  }
+
+  async open(options: { timeout?: number } = {}) {
+    if (this.#isOpen) {
+      return;
+    }
+
+    await openServerSocket(this.httpServer, this.webSocketServer, options);
+    this.#isOpen = true;
+  }
+
+  async close(options: { timeout?: number } = {}) {
+    if (!this.#isOpen) {
+      return;
+    }
+
+    await closeServerSocket(this.httpServer, this.webSocketServer, options);
+    this.#isOpen = false;
+  }
+
+  addEventListener(type: 'connection', listener: WebSocketServer.EventListener<Schema, 'connection'>): void;
+  addEventListener(type: 'error', listener: WebSocketServer.EventListener<Schema, 'error'>): void;
+  addEventListener(
+    type: 'listening' | 'close',
+    listener: WebSocketServer.EventListener<Schema, 'listening' | 'close'>,
+  ): void;
+  addEventListener<Type extends WebSocketServer.EventType>(
+    type: Type,
+    listener: WebSocketServer.EventListener<Schema, Type>,
+  ) {
+    const rawListener = this.createRawListener(type, listener);
+    this.webSocketServer.addListener(type, rawListener);
+    this.listeners[type].set(listener, rawListener);
+  }
+
+  private createRawListener<Type extends WebSocketServer.EventType>(
+    type: Type,
+    listener: WebSocketServer.EventListener<Schema, Type>,
+  ) {
+    switch (type) {
+      case 'connection': {
+        const typedListener = listener as WebSocketServer.EventListener<Schema, 'connection'>;
+
+        return ((...[rawClient, ...parameters]: WebSocketServerRawEventListenerParameters['connection']) => {
+          typedListener.call(this, new WebSocketClient<Schema>(rawClient), ...parameters);
+        }) as WebSocketServerRawEventListener<Type>;
+      }
+
+      case 'listening':
+      case 'error':
+      case 'close':
+      default:
+        return listener.bind(this) as WebSocketServerRawEventListener<Type>;
+    }
+  }
+
+  removeEventListener(type: 'connection', listener: WebSocketServer.EventListener<Schema, 'connection'>): void;
+  removeEventListener(type: 'error', listener: WebSocketServer.EventListener<Schema, 'error'>): void;
+  removeEventListener(
+    type: 'listening' | 'close',
+    listener: WebSocketServer.EventListener<Schema, 'listening' | 'close'>,
+  ): void;
+  removeEventListener<Type extends WebSocketServer.EventType>(
+    type: Type,
+    listener: WebSocketServer.EventListener<Schema, Type>,
+  ) {
+    const rawListener = this.listeners[type].get(listener);
+
+    if (rawListener) {
+      this.webSocketServer.removeListener(type, rawListener);
+      this.listeners[type].delete(listener);
+    }
+  }
+}

--- a/packages/zimic-ws/src/server/WebSocketServer.ts
+++ b/packages/zimic-ws/src/server/WebSocketServer.ts
@@ -1,3 +1,4 @@
+import { getHttpServerHostname, getHttpServerPort } from '@zimic/utils/server';
 import { PossiblePromise } from '@zimic/utils/types';
 import { Server as HttpServer, IncomingMessage } from 'http';
 import { Server as HttpsServer } from 'https';
@@ -6,7 +7,12 @@ import { WebSocketServer as NodeWebSocketServer } from 'ws';
 import { WebSocketClient } from '@/client/WebSocketClient';
 import { WebSocketSchema } from '@/types/schema';
 
-import { closeServerSocket, openServerSocket } from './utils/lifecycle';
+import {
+  closeWebSocketServer,
+  openWebSocketServer,
+  WebSocketServerCloseOptions,
+  WebSocketServerOpenOptions,
+} from './utils/lifecycle';
 
 export namespace WebSocketServer {
   export type EventType = 'listening' | 'connection' | 'error' | 'close';
@@ -25,7 +31,7 @@ export namespace WebSocketServer {
 }
 
 export interface WebSocketServerOptions {
-  server: HttpServer | HttpsServer;
+  httpServer: HttpServer | HttpsServer;
 }
 
 export interface WebSocketServerRawEventListenerParameters {
@@ -40,10 +46,8 @@ type WebSocketServerRawEventListener<Type extends WebSocketServer.EventType> = (
 ) => void;
 
 export class WebSocketServer<Schema extends WebSocketSchema> {
-  private httpServer: HttpServer | HttpsServer;
-  private webSocketServer: NodeWebSocketServer;
-
-  #isOpen = false;
+  #httpServer: HttpServer | HttpsServer;
+  #webSocketServer?: NodeWebSocketServer;
 
   private listeners: {
     [Type in WebSocketServer.EventType]: Map<
@@ -58,31 +62,56 @@ export class WebSocketServer<Schema extends WebSocketSchema> {
   };
 
   constructor(options: WebSocketServerOptions) {
-    this.httpServer = options.server;
-    this.webSocketServer = new NodeWebSocketServer({ server: this.httpServer });
-    this.#isOpen = this.httpServer.listening;
+    this.#httpServer = options.httpServer;
+  }
+
+  get baseURL() {
+    return `${this.protocol}://${this.hostname}:${this.port}`;
+  }
+
+  get protocol() {
+    return this.#httpServer instanceof HttpsServer ? 'https' : 'http';
+  }
+
+  get hostname() {
+    return getHttpServerHostname(this.#httpServer);
+  }
+
+  get port() {
+    return getHttpServerPort(this.#httpServer);
+  }
+
+  get httpServer() {
+    return this.#httpServer;
   }
 
   get isOpen() {
-    return this.httpServer.listening && this.#isOpen;
+    return this.#httpServer.listening && this.#webSocketServer !== undefined;
   }
 
-  async open(options: { timeout?: number } = {}) {
-    if (this.#isOpen) {
+  async open(options: WebSocketServerOpenOptions = {}) {
+    if (this.#webSocketServer) {
+      await this.close();
+    }
+
+    this.#webSocketServer = new NodeWebSocketServer({ server: this.#httpServer });
+
+    for (const [type, listeners] of Object.entries(this.listeners)) {
+      for (const [_listener, rawListener] of listeners) {
+        this.#webSocketServer.addListener(type, rawListener);
+      }
+    }
+
+    await openWebSocketServer(this.#httpServer, this.#webSocketServer, options);
+  }
+
+  async close(options: WebSocketServerCloseOptions = {}) {
+    if (!this.#webSocketServer) {
       return;
     }
 
-    await openServerSocket(this.httpServer, this.webSocketServer, options);
-    this.#isOpen = true;
-  }
-
-  async close(options: { timeout?: number } = {}) {
-    if (!this.#isOpen) {
-      return;
-    }
-
-    await closeServerSocket(this.httpServer, this.webSocketServer, options);
-    this.#isOpen = false;
+    await closeWebSocketServer(this.#httpServer, this.#webSocketServer, options);
+    this.#webSocketServer = undefined;
   }
 
   addEventListener(type: 'connection', listener: WebSocketServer.EventListener<Schema, 'connection'>): void;
@@ -96,7 +125,7 @@ export class WebSocketServer<Schema extends WebSocketSchema> {
     listener: WebSocketServer.EventListener<Schema, Type>,
   ) {
     const rawListener = this.createRawListener(type, listener);
-    this.webSocketServer.addListener(type, rawListener);
+    this.#webSocketServer?.addListener(type, rawListener);
     this.listeners[type].set(listener, rawListener);
   }
 
@@ -134,7 +163,7 @@ export class WebSocketServer<Schema extends WebSocketSchema> {
     const rawListener = this.listeners[type].get(listener);
 
     if (rawListener) {
-      this.webSocketServer.removeListener(type, rawListener);
+      this.#webSocketServer?.removeListener(type, rawListener);
       this.listeners[type].delete(listener);
     }
   }

--- a/packages/zimic-ws/src/server/__tests__/WebSocketServer.node.test.ts
+++ b/packages/zimic-ws/src/server/__tests__/WebSocketServer.node.test.ts
@@ -19,7 +19,7 @@ describe('WebSocketServer', () => {
 
   beforeEach(async () => {
     httpServer = createHttpServer();
-    await startHttpServer(httpServer, { hostname: 'localhost' });
+    await startHttpServer(httpServer, { hostname: '127.0.0.1' });
   });
 
   afterEach(async () => {
@@ -137,7 +137,7 @@ describe('WebSocketServer', () => {
       const httpsServer = createHttpsServer();
 
       try {
-        await startHttpServer(httpsServer, { hostname: 'localhost' });
+        await startHttpServer(httpsServer, { hostname: '127.0.0.1' });
 
         webSocketServer = new WebSocketServer({ httpServer: httpsServer });
         await webSocketServer.open();
@@ -291,7 +291,7 @@ describe('WebSocketServer', () => {
       expect(listeningListener).toHaveBeenCalledTimes(0);
 
       const openPromise = webSocketServer.open();
-      await startHttpServer(httpServer, { hostname: 'localhost' });
+      await startHttpServer(httpServer, { hostname: '127.0.0.1' });
 
       await openPromise;
 

--- a/packages/zimic-ws/src/server/__tests__/WebSocketServer.node.test.ts
+++ b/packages/zimic-ws/src/server/__tests__/WebSocketServer.node.test.ts
@@ -1,96 +1,459 @@
-import { startHttpServer, stopHttpServer } from '@zimic/utils/server';
-import { createServer as createHttpServer } from 'http';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { getHttpServerPort, startHttpServer, stopHttpServer } from '@zimic/utils/server';
+import { createServer as createHttpServer, Server as HttpServer, IncomingMessage } from 'http';
+import { createServer as createHttpsServer } from 'https';
+import { Socket } from 'net';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { WebSocketClient } from '@/client/WebSocketClient';
+
+import ClosedWebSocketServerError from '../errors/ClosedWebSocketServerError';
 import { WebSocketServer } from '../WebSocketServer';
 
 describe('WebSocketServer', () => {
-  const httpServer = createHttpServer();
+  let httpServer: HttpServer;
+  let webSocketServer: WebSocketServer<{}> | undefined;
+  let webSocketClient: WebSocketClient<{}> | undefined;
 
   beforeEach(async () => {
-    await startHttpServer(httpServer);
+    httpServer = createHttpServer();
+    await startHttpServer(httpServer, { hostname: 'localhost' });
   });
 
   afterEach(async () => {
+    await webSocketServer?.close();
+    webSocketServer = undefined;
+
+    await webSocketClient?.close();
+    webSocketClient = undefined;
+
     await stopHttpServer(httpServer);
   });
 
-  it('should be running if the underlying server is listening', async () => {
-    expect(httpServer.listening).toBe(true);
+  describe('Lifecycle', () => {
+    it('should start and stop the server socket correctly', async () => {
+      webSocketServer = new WebSocketServer({ httpServer });
 
-    const server = new WebSocketServer({ server: httpServer });
-    expect(server.isOpen).toBe(true);
+      expect(httpServer.listening).toBe(true);
+      expect(webSocketServer.isOpen).toBe(false);
 
-    await stopHttpServer(httpServer);
+      await webSocketServer.open();
 
-    expect(httpServer.listening).toBe(false);
-    expect(server.isOpen).toBe(false);
+      expect(httpServer.listening).toBe(true);
+      expect(webSocketServer.isOpen).toBe(true);
+
+      await webSocketServer.close();
+
+      expect(httpServer.listening).toBe(true);
+      expect(webSocketServer.isOpen).toBe(false);
+
+      await stopHttpServer(httpServer);
+
+      expect(httpServer.listening).toBe(false);
+      expect(webSocketServer.isOpen).toBe(false);
+    });
+
+    it('should not be open even if the underlying server is listening if not explicitly opened', async () => {
+      expect(httpServer.listening).toBe(true);
+
+      webSocketServer = new WebSocketServer({ httpServer });
+      expect(webSocketServer.isOpen).toBe(false);
+
+      await stopHttpServer(httpServer);
+
+      expect(httpServer.listening).toBe(false);
+      expect(webSocketServer.isOpen).toBe(false);
+    });
+
+    it('should not throw an error if opened multiple times', async () => {
+      webSocketServer = new WebSocketServer({ httpServer });
+
+      expect(httpServer.listening).toBe(true);
+      expect(webSocketServer.isOpen).toBe(false);
+
+      await webSocketServer.open();
+      await webSocketServer.open();
+      await webSocketServer.open();
+
+      expect(httpServer.listening).toBe(true);
+      expect(webSocketServer.isOpen).toBe(true);
+    });
+
+    it('should not throw an error if closed multiple times', async () => {
+      webSocketServer = new WebSocketServer({ httpServer });
+
+      expect(httpServer.listening).toBe(true);
+      expect(webSocketServer.isOpen).toBe(false);
+
+      await webSocketServer.open();
+
+      expect(httpServer.listening).toBe(true);
+      expect(webSocketServer.isOpen).toBe(true);
+
+      await webSocketServer.close();
+      await webSocketServer.close();
+      await webSocketServer.close();
+
+      expect(httpServer.listening).toBe(true);
+      expect(webSocketServer.isOpen).toBe(false);
+
+      await stopHttpServer(httpServer);
+
+      expect(httpServer.listening).toBe(false);
+      expect(webSocketServer.isOpen).toBe(false);
+    });
+
+    it('should close automatically when the underlying server is closed', async () => {
+      webSocketServer = new WebSocketServer({ httpServer });
+
+      expect(httpServer.listening).toBe(true);
+      expect(webSocketServer.isOpen).toBe(false);
+
+      await webSocketServer.open();
+
+      expect(httpServer.listening).toBe(true);
+      expect(webSocketServer.isOpen).toBe(true);
+
+      await stopHttpServer(httpServer);
+
+      expect(httpServer.listening).toBe(false);
+      expect(webSocketServer.isOpen).toBe(false);
+    });
   });
 
-  it('should start and stop the server socket correctly', async () => {
-    const server = new WebSocketServer({ server: httpServer });
+  describe('Base URL', () => {
+    it('should have the correct base URL if open with an underlying HTTP server', async () => {
+      webSocketServer = new WebSocketServer({ httpServer });
 
-    expect(httpServer.listening).toBe(true);
-    expect(server.isOpen).toBe(true);
+      await webSocketServer.open();
 
-    await server.open();
+      expect(webSocketServer.isOpen).toBe(true);
+      expect(webSocketServer.baseURL).toBe(`ws://127.0.0.1:${webSocketServer.port}`);
+    });
 
-    expect(httpServer.listening).toBe(true);
-    expect(server.isOpen).toBe(true);
+    it('should have the correct base URL if open with an underlying HTTPS server', async () => {
+      const httpsServer = createHttpsServer();
 
-    await server.close();
+      try {
+        await startHttpServer(httpsServer, { hostname: 'localhost' });
 
-    expect(httpServer.listening).toBe(true);
-    expect(server.isOpen).toBe(false);
+        webSocketServer = new WebSocketServer({ httpServer: httpsServer });
+        await webSocketServer.open();
 
-    await stopHttpServer(httpServer);
+        expect(webSocketServer.isOpen).toBe(true);
+        expect(webSocketServer.baseURL).toBe(`wss://127.0.0.1:${webSocketServer.port}`);
+      } finally {
+        await stopHttpServer(httpsServer);
+      }
+    });
 
-    expect(httpServer.listening).toBe(false);
-    expect(server.isOpen).toBe(false);
+    it('should not have a base URL if underlying server is not listening', async () => {
+      await stopHttpServer(httpServer);
+      expect(httpServer.listening).toBe(false);
+
+      webSocketServer = new WebSocketServer({ httpServer });
+
+      expect(webSocketServer.isOpen).toBe(false);
+      expect(() => webSocketServer!.baseURL).toThrow(ClosedWebSocketServerError);
+    });
+
+    it('should not have a base URL if not open, even if underlying server is listening', () => {
+      expect(httpServer.listening).toBe(true);
+
+      webSocketServer = new WebSocketServer({ httpServer });
+
+      expect(webSocketServer.isOpen).toBe(false);
+      expect(() => webSocketServer!.baseURL).toThrow(ClosedWebSocketServerError);
+    });
   });
 
-  it('should not throw an error if started multiple times', async () => {
-    const server = new WebSocketServer({ server: httpServer });
+  describe('Hostname', () => {
+    it('should have the correct hostname if open', async () => {
+      webSocketServer = new WebSocketServer({ httpServer });
 
-    expect(httpServer.listening).toBe(true);
-    expect(server.isOpen).toBe(true);
+      await webSocketServer.open();
 
-    await server.open();
-    await server.open();
-    await server.open();
+      expect(webSocketServer.isOpen).toBe(true);
+      expect(webSocketServer.hostname).toBe('127.0.0.1');
+    });
 
-    expect(httpServer.listening).toBe(true);
-    expect(server.isOpen).toBe(true);
+    it('should not have a hostname if underlying server is not listening', async () => {
+      await stopHttpServer(httpServer);
+      expect(httpServer.listening).toBe(false);
+
+      webSocketServer = new WebSocketServer({ httpServer });
+
+      expect(webSocketServer.isOpen).toBe(false);
+      expect(() => webSocketServer!.hostname).toThrow(ClosedWebSocketServerError);
+    });
+
+    it('should not have a hostname if not open, even if underlying server is listening', () => {
+      expect(httpServer.listening).toBe(true);
+
+      webSocketServer = new WebSocketServer({ httpServer });
+
+      expect(webSocketServer.isOpen).toBe(false);
+      expect(() => webSocketServer!.hostname).toThrow(ClosedWebSocketServerError);
+    });
   });
 
-  it('should not throw an error if stopped multiple times', async () => {
-    const server = new WebSocketServer({ server: httpServer });
+  describe('Port', () => {
+    it('should have the correct port if open', async () => {
+      webSocketServer = new WebSocketServer({ httpServer });
 
-    expect(httpServer.listening).toBe(true);
-    expect(server.isOpen).toBe(true);
+      await webSocketServer.open();
 
-    await server.close();
-    await server.close();
-    await server.close();
+      expect(webSocketServer.isOpen).toBe(true);
+      expect(webSocketServer.port).toBe(getHttpServerPort(httpServer));
+    });
 
-    expect(httpServer.listening).toBe(true);
-    expect(server.isOpen).toBe(false);
+    it('should not have a port if underlying server is not listening', async () => {
+      await stopHttpServer(httpServer);
+      expect(httpServer.listening).toBe(false);
 
-    await stopHttpServer(httpServer);
+      webSocketServer = new WebSocketServer({ httpServer });
 
-    expect(httpServer.listening).toBe(false);
-    expect(server.isOpen).toBe(false);
+      expect(webSocketServer.isOpen).toBe(false);
+      expect(() => webSocketServer!.port).toThrow(ClosedWebSocketServerError);
+    });
+
+    it('should not have a port if not open, even if underlying server is listening', () => {
+      expect(httpServer.listening).toBe(true);
+
+      webSocketServer = new WebSocketServer({ httpServer });
+
+      expect(webSocketServer.isOpen).toBe(false);
+      expect(() => webSocketServer!.port).toThrow(ClosedWebSocketServerError);
+    });
   });
 
-  it('should stop automatically when the underlying server is stopped', async () => {
-    const server = new WebSocketServer({ server: httpServer });
+  describe('Listeners', () => {
+    it('should trigger connection listeners', async () => {
+      webSocketServer = new WebSocketServer({ httpServer });
 
-    expect(httpServer.listening).toBe(true);
-    expect(server.isOpen).toBe(true);
+      const connectionListener = vi.fn();
+      webSocketServer.addEventListener('connection', connectionListener);
 
-    await stopHttpServer(httpServer);
+      await webSocketServer.open();
 
-    expect(httpServer.listening).toBe(false);
-    expect(server.isOpen).toBe(false);
+      webSocketClient = new WebSocketClient(webSocketServer.baseURL);
+
+      expect(connectionListener).toHaveBeenCalledTimes(0);
+
+      await webSocketClient.open();
+
+      expect(connectionListener).toHaveBeenCalledTimes(1);
+      expect(connectionListener).toHaveBeenCalledWith(
+        expect.any(WebSocketClient),
+        expect.objectContaining({ url: '/' }),
+      );
+
+      const otherWebSocketClient = new WebSocketClient(webSocketServer.baseURL);
+
+      try {
+        await otherWebSocketClient.open();
+
+        expect(connectionListener).toHaveBeenCalledTimes(2);
+        expect(connectionListener).toHaveBeenNthCalledWith(
+          2,
+          expect.any(WebSocketClient),
+          expect.objectContaining({ url: '/' }),
+        );
+      } finally {
+        await otherWebSocketClient.close();
+      }
+    });
+
+    it('should trigger error listeners', async () => {
+      webSocketServer = new WebSocketServer({ httpServer });
+      await webSocketServer.open();
+
+      const errorListener = vi.fn();
+      webSocketServer.addEventListener('error', errorListener);
+
+      const error = new Error();
+      webSocketServer.emit('error', error);
+
+      expect(errorListener).toHaveBeenCalledTimes(1);
+      expect(errorListener).toHaveBeenCalledWith(error);
+    });
+
+    it('should trigger listening listeners', async () => {
+      await stopHttpServer(httpServer);
+
+      webSocketServer = new WebSocketServer({ httpServer });
+
+      const listeningListener = vi.fn();
+      webSocketServer.addEventListener('listening', listeningListener);
+
+      expect(listeningListener).toHaveBeenCalledTimes(0);
+
+      const openPromise = webSocketServer.open();
+      await startHttpServer(httpServer, { hostname: 'localhost' });
+
+      await openPromise;
+
+      expect(listeningListener).toHaveBeenCalledTimes(1);
+    });
+
+    it('should trigger close listeners', async () => {
+      webSocketServer = new WebSocketServer({ httpServer });
+
+      const closeListener = vi.fn();
+      webSocketServer.addEventListener('close', closeListener);
+
+      await webSocketServer.open();
+
+      expect(closeListener).toHaveBeenCalledTimes(0);
+
+      await webSocketServer.close();
+
+      expect(closeListener).toHaveBeenCalledTimes(1);
+    });
+
+    it('should support triggering listeners directly with emit without opening the server', () => {
+      webSocketServer = new WebSocketServer({ httpServer });
+
+      const connectionListener = vi.fn();
+      webSocketServer.addEventListener('connection', connectionListener);
+
+      const webSocketClient = new WebSocketClient('');
+      const request = new IncomingMessage(new Socket());
+      webSocketServer.emit('connection', webSocketClient, request);
+      expect(connectionListener).toHaveBeenCalledTimes(1);
+      expect(connectionListener).toHaveBeenCalledWith(webSocketClient, request);
+
+      const errorListener = vi.fn();
+      webSocketServer.addEventListener('error', errorListener);
+
+      const error = new Error();
+      webSocketServer.emit('error', error);
+      expect(errorListener).toHaveBeenCalledTimes(1);
+      expect(errorListener).toHaveBeenCalledWith(error);
+
+      const listeningListener = vi.fn();
+      webSocketServer.addEventListener('listening', listeningListener);
+
+      webSocketServer.emit('listening');
+      expect(listeningListener).toHaveBeenCalledTimes(1);
+
+      const closeListener = vi.fn();
+      webSocketServer.addEventListener('close', closeListener);
+
+      webSocketServer.emit('close');
+      expect(closeListener).toHaveBeenCalledTimes(1);
+    });
+
+    it('should support triggering listeners directly with emit after opening the server', async () => {
+      webSocketServer = new WebSocketServer({ httpServer });
+      await webSocketServer.open();
+
+      const connectionListener = vi.fn();
+      webSocketServer.addEventListener('connection', connectionListener);
+
+      const webSocketClient = new WebSocketClient('');
+      const request = new IncomingMessage(new Socket());
+      webSocketServer.emit('connection', webSocketClient, request);
+
+      expect(connectionListener).toHaveBeenCalledTimes(1);
+      expect(connectionListener).toHaveBeenCalledWith(webSocketClient, request);
+
+      const errorListener = vi.fn();
+      webSocketServer.addEventListener('error', errorListener);
+
+      const error = new Error();
+      webSocketServer.emit('error', error);
+      expect(errorListener).toHaveBeenCalledTimes(1);
+      expect(errorListener).toHaveBeenCalledWith(error);
+
+      const listeningListener = vi.fn();
+      webSocketServer.addEventListener('listening', listeningListener);
+
+      webSocketServer.emit('listening');
+      expect(listeningListener).toHaveBeenCalledTimes(1);
+
+      const closeListener = vi.fn();
+      webSocketServer.addEventListener('close', closeListener);
+
+      webSocketServer.emit('close');
+      expect(closeListener).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not trigger removed listeners', async () => {
+      webSocketServer = new WebSocketServer({ httpServer });
+
+      const closeListener = vi.fn();
+      webSocketServer.addEventListener('close', closeListener);
+      webSocketServer.removeEventListener('close', closeListener);
+
+      await webSocketServer.open();
+      await webSocketServer.close();
+
+      expect(closeListener).not.toHaveBeenCalled();
+    });
+
+    it('should not throw error if a listener is removed multiple times', async () => {
+      webSocketServer = new WebSocketServer({ httpServer });
+
+      const closeListener = vi.fn();
+      webSocketServer.addEventListener('close', closeListener);
+
+      webSocketServer.removeEventListener('close', closeListener);
+      webSocketServer.removeEventListener('close', closeListener);
+      webSocketServer.removeEventListener('close', closeListener);
+
+      await webSocketServer.open();
+      await webSocketServer.close();
+
+      expect(closeListener).not.toHaveBeenCalled();
+    });
+
+    it('should not duplicate listeners after opening repeatedly', async () => {
+      webSocketServer = new WebSocketServer({ httpServer });
+
+      const connectionListener = vi.fn();
+      webSocketServer.addEventListener('connection', connectionListener);
+
+      await webSocketServer.open();
+      await webSocketServer.open();
+      await webSocketServer.open();
+
+      webSocketClient = new WebSocketClient(webSocketServer.baseURL);
+      await webSocketClient.open();
+
+      expect(connectionListener).toHaveBeenCalledTimes(1);
+    });
+
+    it('should preserve listeners after closing and reopening', async () => {
+      webSocketServer = new WebSocketServer({ httpServer });
+
+      const connectionListener = vi.fn();
+      webSocketServer.addEventListener('connection', connectionListener);
+
+      const closeListener = vi.fn();
+      webSocketServer.addEventListener('close', closeListener);
+
+      await webSocketServer.open();
+
+      webSocketClient = new WebSocketClient(webSocketServer.baseURL);
+      await webSocketClient.open();
+
+      expect(connectionListener).toHaveBeenCalledTimes(1);
+      expect(closeListener).toHaveBeenCalledTimes(0);
+
+      await webSocketServer.close();
+
+      expect(connectionListener).toHaveBeenCalledTimes(1);
+      expect(closeListener).toHaveBeenCalledTimes(1);
+
+      await webSocketServer.open();
+
+      expect(connectionListener).toHaveBeenCalledTimes(1);
+      expect(closeListener).toHaveBeenCalledTimes(1);
+
+      await webSocketClient.open();
+
+      expect(connectionListener).toHaveBeenCalledTimes(2);
+      expect(closeListener).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/packages/zimic-ws/src/server/__tests__/WebSocketServer.node.test.ts
+++ b/packages/zimic-ws/src/server/__tests__/WebSocketServer.node.test.ts
@@ -2,7 +2,7 @@ import { startHttpServer, stopHttpServer } from '@zimic/utils/server';
 import { createServer as createHttpServer } from 'http';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import WebSocketServer from '../WebSocketServer';
+import { WebSocketServer } from '../WebSocketServer';
 
 describe('WebSocketServer', () => {
   const httpServer = createHttpServer();
@@ -15,82 +15,82 @@ describe('WebSocketServer', () => {
     await stopHttpServer(httpServer);
   });
 
-  it('should be listening if the underlying server is listening', async () => {
+  it('should be running if the underlying server is listening', async () => {
     expect(httpServer.listening).toBe(true);
 
     const server = new WebSocketServer({ server: httpServer });
-    expect(server.isRunning).toBe(true);
+    expect(server.isOpen).toBe(true);
 
     await stopHttpServer(httpServer);
 
     expect(httpServer.listening).toBe(false);
-    expect(server.isRunning).toBe(false);
+    expect(server.isOpen).toBe(false);
   });
 
   it('should start and stop the server socket correctly', async () => {
     const server = new WebSocketServer({ server: httpServer });
 
     expect(httpServer.listening).toBe(true);
-    expect(server.isRunning).toBe(true);
+    expect(server.isOpen).toBe(true);
 
-    await server.start();
-
-    expect(httpServer.listening).toBe(true);
-    expect(server.isRunning).toBe(true);
-
-    await server.stop();
+    await server.open();
 
     expect(httpServer.listening).toBe(true);
-    expect(server.isRunning).toBe(false);
+    expect(server.isOpen).toBe(true);
+
+    await server.close();
+
+    expect(httpServer.listening).toBe(true);
+    expect(server.isOpen).toBe(false);
 
     await stopHttpServer(httpServer);
 
     expect(httpServer.listening).toBe(false);
-    expect(server.isRunning).toBe(false);
+    expect(server.isOpen).toBe(false);
   });
 
   it('should not throw an error if started multiple times', async () => {
     const server = new WebSocketServer({ server: httpServer });
 
     expect(httpServer.listening).toBe(true);
-    expect(server.isRunning).toBe(true);
+    expect(server.isOpen).toBe(true);
 
-    await server.start();
-    await server.start();
-    await server.start();
+    await server.open();
+    await server.open();
+    await server.open();
 
     expect(httpServer.listening).toBe(true);
-    expect(server.isRunning).toBe(true);
+    expect(server.isOpen).toBe(true);
   });
 
   it('should not throw an error if stopped multiple times', async () => {
     const server = new WebSocketServer({ server: httpServer });
 
     expect(httpServer.listening).toBe(true);
-    expect(server.isRunning).toBe(true);
+    expect(server.isOpen).toBe(true);
 
-    await server.stop();
-    await server.stop();
-    await server.stop();
+    await server.close();
+    await server.close();
+    await server.close();
 
     expect(httpServer.listening).toBe(true);
-    expect(server.isRunning).toBe(false);
+    expect(server.isOpen).toBe(false);
 
     await stopHttpServer(httpServer);
 
     expect(httpServer.listening).toBe(false);
-    expect(server.isRunning).toBe(false);
+    expect(server.isOpen).toBe(false);
   });
 
   it('should stop automatically when the underlying server is stopped', async () => {
     const server = new WebSocketServer({ server: httpServer });
 
     expect(httpServer.listening).toBe(true);
-    expect(server.isRunning).toBe(true);
+    expect(server.isOpen).toBe(true);
 
     await stopHttpServer(httpServer);
 
     expect(httpServer.listening).toBe(false);
-    expect(server.isRunning).toBe(false);
+    expect(server.isOpen).toBe(false);
   });
 });

--- a/packages/zimic-ws/src/server/__tests__/WebSocketServer.node.test.ts
+++ b/packages/zimic-ws/src/server/__tests__/WebSocketServer.node.test.ts
@@ -5,9 +5,12 @@ import { Socket } from 'net';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { WebSocketClient } from '@/client/WebSocketClient';
+import { WebSocketCloseTimeoutError } from '@/errors/WebSocketCloseTimeoutError';
+import { WebSocketOpenTimeoutError } from '@/errors/WebSocketOpenTimeoutError';
 
 import ClosedWebSocketServerError from '../errors/ClosedWebSocketServerError';
 import { WebSocketServer } from '../WebSocketServer';
+import { delayWebSocketServerClose } from './utils';
 
 describe('WebSocketServer', () => {
   let httpServer: HttpServer;
@@ -454,6 +457,48 @@ describe('WebSocketServer', () => {
 
       expect(connectionListener).toHaveBeenCalledTimes(2);
       expect(closeListener).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Timeouts', () => {
+    it('should throw an open timeout error if opening times out', async () => {
+      await stopHttpServer(httpServer);
+
+      webSocketServer = new WebSocketServer({ httpServer });
+
+      const timeoutDuration = 50;
+
+      await expect(
+        webSocketServer.open({
+          timeout: timeoutDuration,
+        }),
+      ).rejects.toThrow(new WebSocketOpenTimeoutError(timeoutDuration));
+
+      expect(webSocketServer.isOpen).toBe(false);
+    });
+
+    it('should throw a close timeout error if closing times out', async () => {
+      webSocketServer = new WebSocketServer({ httpServer });
+      await webSocketServer.open();
+
+      const delayedWebSocketServerClose = delayWebSocketServerClose(300);
+
+      try {
+        const timeoutDuration = 50;
+
+        await expect(
+          webSocketServer.close({
+            timeout: timeoutDuration,
+          }),
+        ).rejects.toThrow(new WebSocketCloseTimeoutError(timeoutDuration));
+
+        await delayedWebSocketServerClose.toPromise();
+
+        expect(webSocketServer.isOpen).toBe(true);
+      } finally {
+        delayedWebSocketServerClose.restore();
+        await webSocketServer.close();
+      }
     });
   });
 });

--- a/packages/zimic-ws/src/server/__tests__/utils.ts
+++ b/packages/zimic-ws/src/server/__tests__/utils.ts
@@ -8,7 +8,7 @@ export function delayWebSocketServerClose(delayDuration: number) {
   const promises = new Set<Promise<void>>();
 
   const delayedWebSocketServerClose = vi.spyOn(WebSocketServer.prototype, 'close').mockImplementationOnce(function (
-    this: WebSocket,
+    this: WebSocketServer,
     ...parameters
   ) {
     const promise = waitForDelay(delayDuration).then(() => {

--- a/packages/zimic-ws/src/server/__tests__/utils.ts
+++ b/packages/zimic-ws/src/server/__tests__/utils.ts
@@ -1,0 +1,31 @@
+import { waitForDelay } from '@zimic/utils/time';
+import { vi } from 'vitest';
+import { WebSocketServer } from 'ws';
+
+export function delayWebSocketServerClose(delayDuration: number) {
+  const originalWebSocketServerClose = WebSocketServer.prototype.close;
+
+  const promises = new Set<Promise<void>>();
+
+  const delayedWebSocketServerClose = vi.spyOn(WebSocketServer.prototype, 'close').mockImplementationOnce(function (
+    this: WebSocket,
+    ...parameters
+  ) {
+    const promise = waitForDelay(delayDuration).then(() => {
+      originalWebSocketServerClose.apply(this, parameters);
+      promises.delete(promise);
+    });
+    promises.add(promise);
+
+    return this;
+  });
+
+  return {
+    restore() {
+      delayedWebSocketServerClose.mockRestore();
+    },
+    toPromise() {
+      return Promise.all(promises);
+    },
+  };
+}

--- a/packages/zimic-ws/src/server/errors/ClosedWebSocketServerError.ts
+++ b/packages/zimic-ws/src/server/errors/ClosedWebSocketServerError.ts
@@ -1,0 +1,8 @@
+class ClosedWebSocketServerError extends Error {
+  constructor() {
+    super('The WebSocket server is closed. Did you forget to open it?');
+    this.name = 'ClosedWebSocketServerError';
+  }
+}
+
+export default ClosedWebSocketServerError;

--- a/packages/zimic-ws/src/server/index.ts
+++ b/packages/zimic-ws/src/server/index.ts
@@ -1,2 +1,3 @@
 export { WebSocketServer } from './WebSocketServer';
 export type { WebSocketServerOptions } from './WebSocketServer';
+export type { WebSocketServerOpenOptions, WebSocketServerCloseOptions } from './utils/lifecycle';

--- a/packages/zimic-ws/src/server/index.ts
+++ b/packages/zimic-ws/src/server/index.ts
@@ -1,2 +1,2 @@
-export { default as WebSocketServer } from './WebSocketServer';
+export { WebSocketServer } from './WebSocketServer';
 export type { WebSocketServerOptions } from './WebSocketServer';

--- a/packages/zimic-ws/src/server/utils/lifecycle.ts
+++ b/packages/zimic-ws/src/server/utils/lifecycle.ts
@@ -2,6 +2,7 @@ import { Server as HttpServer } from 'http';
 import { Server as HttpsServer } from 'https';
 import { WebSocketServer as NodeWebSocketServer } from 'ws';
 
+import { DEFAULT_WEB_SOCKET_LIFECYCLE_TIMEOUT } from '@/client/utils/lifecycle';
 import { WebSocketCloseTimeoutError } from '@/errors/WebSocketCloseTimeoutError';
 import { WebSocketOpenTimeoutError } from '@/errors/WebSocketOpenTimeoutError';
 
@@ -14,7 +15,7 @@ export async function openWebSocketServer(
   webSocketServer: NodeWebSocketServer,
   options: WebSocketServerOpenOptions = {},
 ) {
-  const { timeout: timeoutDuration } = options;
+  const { timeout: timeoutDuration = DEFAULT_WEB_SOCKET_LIFECYCLE_TIMEOUT } = options;
 
   const isAlreadyOpen = httpServer.listening;
 
@@ -23,23 +24,25 @@ export async function openWebSocketServer(
   }
 
   await new Promise<void>((resolve, reject) => {
-    const openTimeout =
-      timeoutDuration === undefined
-        ? undefined
-        : setTimeout(() => {
-            const timeoutError = new WebSocketOpenTimeoutError(timeoutDuration);
-            reject(timeoutError);
-          }, timeoutDuration);
+    const openTimeout = setTimeout(() => {
+      const timeoutError = new WebSocketOpenTimeoutError(timeoutDuration);
+      reject(timeoutError);
+    }, timeoutDuration);
 
     webSocketServer.once('listening', () => {
       clearTimeout(openTimeout);
       resolve();
     });
 
-    webSocketServer.once('error', (error) => {
-      clearTimeout(openTimeout);
-      reject(error);
-    });
+    webSocketServer.once(
+      'error',
+      /* istanbul ignore next -- @preserve
+       * This is not expected since the server is not started unless it is not running. */
+      (error) => {
+        clearTimeout(openTimeout);
+        reject(error);
+      },
+    );
   });
 }
 
@@ -50,7 +53,7 @@ export async function closeWebSocketServer(
   webSocketServer: NodeWebSocketServer,
   options: WebSocketServerCloseOptions = {},
 ) {
-  const { timeout: timeoutDuration } = options;
+  const { timeout: timeoutDuration = DEFAULT_WEB_SOCKET_LIFECYCLE_TIMEOUT } = options;
 
   const isAlreadyClosed = !httpServer.listening;
 
@@ -59,13 +62,10 @@ export async function closeWebSocketServer(
   }
 
   await new Promise<void>((resolve, reject) => {
-    const closeTimeout =
-      timeoutDuration === undefined
-        ? undefined
-        : setTimeout(() => {
-            const timeoutError = new WebSocketCloseTimeoutError(timeoutDuration);
-            reject(timeoutError);
-          }, timeoutDuration);
+    const closeTimeout = setTimeout(() => {
+      const timeoutError = new WebSocketCloseTimeoutError(timeoutDuration);
+      reject(timeoutError);
+    }, timeoutDuration);
 
     for (const client of webSocketServer.clients) {
       client.close();

--- a/packages/zimic-ws/src/server/utils/lifecycle.ts
+++ b/packages/zimic-ws/src/server/utils/lifecycle.ts
@@ -1,14 +1,13 @@
 import { Server as HttpServer } from 'http';
 import { Server as HttpsServer } from 'https';
+import { WebSocketServer as NodeWebSocketServer } from 'ws';
 
 import { WebSocketCloseTimeoutError } from '@/errors/WebSocketCloseTimeoutError';
 import { WebSocketOpenTimeoutError } from '@/errors/WebSocketOpenTimeoutError';
 
-import { ServerSocket } from '../ServerSocket';
-
 export async function openServerSocket(
   server: HttpServer | HttpsServer,
-  socket: ServerSocket,
+  socket: NodeWebSocketServer,
   options: { timeout?: number } = {},
 ) {
   const { timeout: timeoutDuration } = options;
@@ -42,7 +41,7 @@ export async function openServerSocket(
 
 export async function closeServerSocket(
   server: HttpServer | HttpsServer,
-  socket: ServerSocket,
+  socket: NodeWebSocketServer,
   options: { timeout?: number } = {},
 ) {
   const { timeout: timeoutDuration } = options;

--- a/packages/zimic-ws/src/server/utils/lifecycle.ts
+++ b/packages/zimic-ws/src/server/utils/lifecycle.ts
@@ -49,17 +49,10 @@ export async function openWebSocketServer(
 export type WebSocketServerCloseOptions = WebSocketServerOpenOptions;
 
 export async function closeWebSocketServer(
-  httpServer: HttpServer | HttpsServer,
   webSocketServer: NodeWebSocketServer,
   options: WebSocketServerCloseOptions = {},
 ) {
   const { timeout: timeoutDuration = DEFAULT_WEB_SOCKET_LIFECYCLE_TIMEOUT } = options;
-
-  const isAlreadyClosed = !httpServer.listening;
-
-  if (isAlreadyClosed) {
-    return;
-  }
 
   await new Promise<void>((resolve, reject) => {
     const closeTimeout = setTimeout(() => {

--- a/packages/zimic-ws/src/server/utils/lifecycle.ts
+++ b/packages/zimic-ws/src/server/utils/lifecycle.ts
@@ -29,20 +29,27 @@ export async function openWebSocketServer(
       reject(timeoutError);
     }, timeoutDuration);
 
-    webSocketServer.once('listening', () => {
+    function removeListenersAndTimeout() {
       clearTimeout(openTimeout);
-      resolve();
-    });
 
-    webSocketServer.once(
-      'error',
-      /* istanbul ignore next -- @preserve
-       * This is not expected since the server is not started unless it is not running. */
-      (error) => {
-        clearTimeout(openTimeout);
-        reject(error);
-      },
-    );
+      webSocketServer.off('listening', handleListening); // eslint-disable-line @typescript-eslint/no-use-before-define
+      webSocketServer.off('error', handleError); // eslint-disable-line @typescript-eslint/no-use-before-define
+    }
+
+    /* istanbul ignore next -- @preserve
+     * This is not expected since the server is not started unless it is not running. */
+    function handleError(error: unknown) {
+      removeListenersAndTimeout();
+      reject(error);
+    }
+
+    function handleListening() {
+      removeListenersAndTimeout();
+      resolve();
+    }
+
+    webSocketServer.on('listening', handleListening);
+    webSocketServer.on('error', handleError);
   });
 }
 

--- a/packages/zimic-ws/src/server/utils/lifecycle.ts
+++ b/packages/zimic-ws/src/server/utils/lifecycle.ts
@@ -5,14 +5,18 @@ import { WebSocketServer as NodeWebSocketServer } from 'ws';
 import { WebSocketCloseTimeoutError } from '@/errors/WebSocketCloseTimeoutError';
 import { WebSocketOpenTimeoutError } from '@/errors/WebSocketOpenTimeoutError';
 
-export async function openServerSocket(
-  server: HttpServer | HttpsServer,
-  socket: NodeWebSocketServer,
-  options: { timeout?: number } = {},
+export interface WebSocketServerOpenOptions {
+  timeout?: number;
+}
+
+export async function openWebSocketServer(
+  httpServer: HttpServer | HttpsServer,
+  webSocketServer: NodeWebSocketServer,
+  options: WebSocketServerOpenOptions = {},
 ) {
   const { timeout: timeoutDuration } = options;
 
-  const isAlreadyOpen = server.listening;
+  const isAlreadyOpen = httpServer.listening;
 
   if (isAlreadyOpen) {
     return;
@@ -27,26 +31,28 @@ export async function openServerSocket(
             reject(timeoutError);
           }, timeoutDuration);
 
-    socket.once('listening', () => {
+    webSocketServer.once('listening', () => {
       clearTimeout(openTimeout);
       resolve();
     });
 
-    socket.once('error', (error) => {
+    webSocketServer.once('error', (error) => {
       clearTimeout(openTimeout);
       reject(error);
     });
   });
 }
 
-export async function closeServerSocket(
-  server: HttpServer | HttpsServer,
-  socket: NodeWebSocketServer,
-  options: { timeout?: number } = {},
+export type WebSocketServerCloseOptions = WebSocketServerOpenOptions;
+
+export async function closeWebSocketServer(
+  httpServer: HttpServer | HttpsServer,
+  webSocketServer: NodeWebSocketServer,
+  options: WebSocketServerCloseOptions = {},
 ) {
   const { timeout: timeoutDuration } = options;
 
-  const isAlreadyClosed = !server.listening;
+  const isAlreadyClosed = !httpServer.listening;
 
   if (isAlreadyClosed) {
     return;
@@ -61,11 +67,11 @@ export async function closeServerSocket(
             reject(timeoutError);
           }, timeoutDuration);
 
-    for (const client of socket.clients) {
+    for (const client of webSocketServer.clients) {
       client.close();
     }
 
-    socket.close((error) => {
+    webSocketServer.close((error) => {
       clearTimeout(closeTimeout);
 
       /* istanbul ignore if -- @preserve

--- a/packages/zimic-ws/src/types/schema.ts
+++ b/packages/zimic-ws/src/types/schema.ts
@@ -16,17 +16,3 @@ export type WebSocketMessageData<Schema extends WebSocketSchema> = Schema extend
     : Schema extends string
       ? Schema
       : JSONStringified<Schema>;
-
-export interface WebSocketEventMap<Schema extends WebSocketSchema> {
-  open: Event;
-  message: MessageEvent<WebSocketMessageData<Schema>>;
-  close: CloseEvent;
-  error: Event;
-}
-
-export type WebSocketEventType<Schema extends WebSocketSchema = WebSocketSchema> = keyof WebSocketEventMap<Schema>;
-
-export type WebSocketEvent<
-  Schema extends WebSocketSchema = WebSocketSchema,
-  Type extends WebSocketEventType = WebSocketEventType,
-> = WebSocketEventMap<Schema>[Type];

--- a/packages/zimic-ws/turbo.json
+++ b/packages/zimic-ws/turbo.json
@@ -3,6 +3,7 @@
   "extends": ["//"],
   "tasks": {
     "build": {
+      "dependsOn": ["@zimic/utils#build"],
       "inputs": [
         "src/**/*.{ts,json}",
         "{package,tsconfig}.json",

--- a/packages/zimic-ws/vitest.config.mts
+++ b/packages/zimic-ws/vitest.config.mts
@@ -46,11 +46,10 @@ export default defineConfig({
       reporter: ['text', 'html'],
       reportsDirectory: './tests/coverage',
       thresholds: {
-        // Coverage is temporarily disabled while we integrate this package with @zimic/interceptor for mocking.
-        // functions: 100,
-        // lines: 100,
-        // statements: 100,
-        // branches: 100,
+        functions: 100,
+        lines: 100,
+        statements: 100,
+        branches: 100,
       },
       exclude: [
         '**/node_modules/**',

--- a/packages/zimic-ws/vitest.config.mts
+++ b/packages/zimic-ws/vitest.config.mts
@@ -9,7 +9,6 @@ export default defineConfig({
     globals: false,
     testTimeout: 5000,
     hookTimeout: 5000,
-    retry: process.env.CI === 'true' ? 1 : 0,
     maxWorkers: process.env.CI === 'true' ? '50%' : '25%',
     clearMocks: true,
     projects: [
@@ -22,22 +21,25 @@ export default defineConfig({
           exclude: ['**/*.browser.test.ts'],
         },
       },
-      {
-        extends: true,
-        test: {
-          name: 'browser',
-          environment: undefined,
-          include: ['./{src,tests}/**/*.test.ts', './{src,tests}/**/*.browser.test.ts'],
-          exclude: ['**/*.node.test.ts'],
-          browser: {
-            instances: [{ browser: 'chromium' }],
-            provider: playwright(),
-            enabled: true,
-            headless: true,
-            screenshotFailures: false,
-          },
-        },
-      },
+      // TODO: Testing in a browser environment is temporarily disabled while we implement WebSocket interceptors in
+      // @zimic/interceptor. For now, we only run tests in a Node environment, which can spin up and manipulate
+      // WebSocket servers for testing.
+      // {
+      //   extends: true,
+      //   test: {
+      //     name: 'browser',
+      //     environment: undefined,
+      //     include: ['./{src,tests}/**/*.test.ts', './{src,tests}/**/*.browser.test.ts'],
+      //     exclude: ['**/*.node.test.ts'],
+      //     browser: {
+      //       instances: [{ browser: 'chromium' }],
+      //       provider: playwright(),
+      //       enabled: true,
+      //       headless: true,
+      //       screenshotFailures: false,
+      //     },
+      //   },
+      // },
     ],
     coverage: {
       provider: 'istanbul',


### PR DESCRIPTION
- refactor(ws): use global `WebSocket` instead of falling back to `ws` import
- refactor(ws): improve websocket server api and implementation
- refactor(ws): improve websocket client api and implementation
- fix(ws): change minimum node version to 22
- fix(ws): avoid recursive dependencies in turbo build
- test(test-client): fix failing tests
- test(root): remove unnecessary retries
- feat(utils): add `getHttpServerHostname`
- refactor(ws): improve server open and close options
- refactor(ws): improve client open and close options
- test(ws): extend server test coverage
- test(ws): extend client test coverage
- test(ws): extend overall test coverage to 100%
- test(test-client): remove unexpected export check
- docs(web): improve interceptor server port description
