### PR TITLE
feat(root): node 25 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -126,6 +126,7 @@ jobs:
           - 20
           - 22
           - 24
+          - 25
 
     env:
       NODE_VERSION: ${{ matrix.node-version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -130,11 +130,6 @@ jobs:
 
     env:
       NODE_VERSION: ${{ matrix.node-version }}
-      # Our current MSW version is not compatible with Node.js 25 and needs the --no-experimental-webstorage flag to
-      # work. See https://github.com/mswjs/msw/issues/2624#issuecomment-3546368492.
-      # We still cannot upgrade MSW due to https://github.com/mswjs/msw/issues/2585 and
-      # https://github.com/mswjs/msw/issues/2597.
-      NODE_OPTIONS: ${{ matrix.node-version == 25 && '--no-experimental-webstorage' || '' }}
 
     steps:
       - name: Checkout code
@@ -168,6 +163,11 @@ jobs:
             --concurrency 1 \
             ${{ env.TURBO_FILTERS }} $extraTurboFilters
         env:
+          # Our current MSW version is not compatible with Node.js 25 and needs the --no-experimental-webstorage flag to
+          # work. See https://github.com/mswjs/msw/issues/2624#issuecomment-3546368492.
+          # We still cannot upgrade MSW due to https://github.com/mswjs/msw/issues/2585 and
+          # https://github.com/mswjs/msw/issues/2597.
+          NODE_OPTIONS: ${{ matrix.node-version == 25 && '--no-experimental-webstorage' || '' }}
           PLAYWRIGHT_WORKERS: 2
 
       - name: Upload test results

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -130,6 +130,11 @@ jobs:
 
     env:
       NODE_VERSION: ${{ matrix.node-version }}
+      # Our current MSW version is not compatible with Node.js 25 and needs the --no-experimental-webstorage flag to
+      # work. See https://github.com/mswjs/msw/issues/2624#issuecomment-3546368492.
+      # We still cannot upgrade MSW due to https://github.com/mswjs/msw/issues/2585 and
+      # https://github.com/mswjs/msw/issues/2597.
+      NODE_OPTIONS: ${{ matrix.node-version == 25 && '--no-experimental-webstorage' || '' }}
 
     steps:
       - name: Checkout code

--- a/apps/zimic-web/docs/zimic-interceptor/2-getting-started.mdx
+++ b/apps/zimic-web/docs/zimic-interceptor/2-getting-started.mdx
@@ -30,6 +30,25 @@ different browsers.
 | ----------------------------- | --------- |
 | [Node.js](https://nodejs.org) | >= 20.0.0 |
 
+If you encounter the error `TypeError: localStorage.getItem is not a function` on Node.js >= 25, use the
+[`--no-experimental-webstorage`](https://nodejs.org/api/cli.html#no-experimental-webstorage) flag:
+
+```bash
+node --no-experimental-webstorage your-script.js
+```
+
+You can also apply this flag by setting the
+[`NODE_OPTIONS` environment variable](https://nodejs.org/api/cli.html#node-optionsoptions), in case you don't have
+control over the Node.js execution command:
+
+```bash
+# MacOS/Linux:
+export NODE_OPTIONS='--no-experimental-webstorage'
+
+# Windows:
+set NODE_OPTIONS=--no-experimental-webstorage
+```
+
   </TabItem>
 </Tabs>
 

--- a/apps/zimic-web/docs/zimic-interceptor/2-getting-started.mdx
+++ b/apps/zimic-web/docs/zimic-interceptor/2-getting-started.mdx
@@ -42,7 +42,7 @@ You can also apply this flag by setting the
 control over the Node.js execution command:
 
 ```bash
-# MacOS/Linux:
+# macOS/Linux:
 export NODE_OPTIONS='--no-experimental-webstorage'
 
 # Windows:

--- a/turbo.json
+++ b/turbo.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "ui": "stream",
-  "globalEnv": ["NODE_VERSION"],
+  "globalEnv": ["NODE_VERSION", "NODE_OPTIONS"],
   "tasks": {
     "setup": {
       "cache": false


### PR DESCRIPTION
Tracks Node.js 25 compatibility across the Zimic monorepo by extending CI coverage and documenting the required workaround for current MSW limitations.

- [x] Add Node.js 25 to the CI matrix.
- [x] Apply a Node.js 25–specific `NODE_OPTIONS` workaround (`--no-experimental-webstorage`) for MSW compatibility.
- [x] Document the Node.js 25 workaround for `@zimic/interceptor` users, including `NODE_OPTIONS` usage.

Closes #1242.