### PR TITLE
fix(http): rename headers component references in responses

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -145,8 +145,8 @@ jobs:
           turbo-token: ${{ env.TURBO_TOKEN }}
           turbo-team: ${{ env.TURBO_TEAM }}
           install: '"@zimic/*..." "zimic-*..."'
-          build: '"@zimic/*...[HEAD^1]" "zimic-*^...[HEAD^1]"'
-          setup: '"@zimic/*...[HEAD^1]" "zimic-*...[HEAD^1]"'
+          build: '"@zimic/*..." "zimic-*^..."'
+          setup: '"@zimic/*..." "zimic-*..."'
 
       - name: Run tests
         run: |

--- a/apps/zimic-test-client/tests/typegen/typegen.node.test.ts
+++ b/apps/zimic-test-client/tests/typegen/typegen.node.test.ts
@@ -76,10 +76,9 @@ describe('Typegen', () => {
         outputFileName: 'google-maps-3.0.openapi.ts',
       },
       {
-        input:
-          'https://docs-be.here.com/bundle/geocoding-and-search-api-v7-api-reference/page/open-search-v7-external-spec.json',
-        serviceName: 'HereSearch',
-        outputFileName: 'here-geocoding-search-3.0.openapi.ts',
+        input: 'https://router.hereapi.com/v8/openapi',
+        serviceName: 'HereRouting',
+        outputFileName: 'here-routing-3.0.openapi.ts',
       },
     ])(
       'should correctly generate types from $serviceName OpenAPI schema to $outputFileName',

--- a/packages/zimic-http/src/cli/typegen/__tests__/fixtures/openapi/responses.comments.ts
+++ b/packages/zimic-http/src/cli/typegen/__tests__/fixtures/openapi/responses.comments.ts
@@ -60,6 +60,14 @@ export type MyServiceSchema = HttpSchema<{
       };
     };
   };
+  '/users-with-multiple-reference-response-contents-having-component-headers': {
+    POST: {
+      response: {
+        200: MyServiceComponents['responses']['userCreatedMultipleContentsHavingComponentHeaders'];
+        400: MyServiceComponents['responses']['error'];
+      };
+    };
+  };
   '/users-with-multiple-literal-response-contents': {
     POST: {
       response: {
@@ -204,6 +212,40 @@ export interface MyServiceComponents {
             value?: MyServiceComponents['schemas']['User'];
           };
         };
+    /** Success */
+    userCreatedMultipleContentsHavingComponentHeaders:
+      | {
+          headers: {
+            'content-type': 'application/x-yaml';
+            'x-correlation-id': MyServiceComponents['headers']['X-Correlation-Id'];
+            'x-request-id': MyServiceComponents['headers']['X-Request-Id'];
+          };
+          body: {
+            /**
+             * The type of the response
+             *
+             * @enum {string}
+             */
+            type?: 'user-as-application-x-yaml';
+            value?: MyServiceComponents['schemas']['User'];
+          };
+        }
+      | {
+          headers: {
+            'content-type': 'text/x-yaml';
+            'x-correlation-id': MyServiceComponents['headers']['X-Correlation-Id'];
+            'x-request-id': MyServiceComponents['headers']['X-Request-Id'];
+          };
+          body: {
+            /**
+             * The type of the response
+             *
+             * @enum {string}
+             */
+            type?: 'user-as-text-x-yaml';
+            value?: MyServiceComponents['schemas']['User'];
+          };
+        };
     /** Not Found */
     notFoundError: {
       headers: {
@@ -262,5 +304,9 @@ export interface MyServiceComponents {
         message: string;
       };
     };
+  };
+  headers: {
+    'X-Correlation-Id': string;
+    'X-Request-Id': string;
   };
 }

--- a/packages/zimic-http/src/cli/typegen/__tests__/fixtures/openapi/responses.ts
+++ b/packages/zimic-http/src/cli/typegen/__tests__/fixtures/openapi/responses.ts
@@ -56,6 +56,14 @@ export type MyServiceSchema = HttpSchema<{
       };
     };
   };
+  '/users-with-multiple-reference-response-contents-having-component-headers': {
+    POST: {
+      response: {
+        200: MyServiceComponents['responses']['userCreatedMultipleContentsHavingComponentHeaders'];
+        400: MyServiceComponents['responses']['error'];
+      };
+    };
+  };
   '/users-with-multiple-literal-response-contents': {
     POST: {
       response: {
@@ -158,6 +166,29 @@ export interface MyServiceComponents {
             value?: MyServiceComponents['schemas']['User'];
           };
         };
+    userCreatedMultipleContentsHavingComponentHeaders:
+      | {
+          headers: {
+            'content-type': 'application/x-yaml';
+            'x-correlation-id': MyServiceComponents['headers']['X-Correlation-Id'];
+            'x-request-id': MyServiceComponents['headers']['X-Request-Id'];
+          };
+          body: {
+            type?: 'user-as-application-x-yaml';
+            value?: MyServiceComponents['schemas']['User'];
+          };
+        }
+      | {
+          headers: {
+            'content-type': 'text/x-yaml';
+            'x-correlation-id': MyServiceComponents['headers']['X-Correlation-Id'];
+            'x-request-id': MyServiceComponents['headers']['X-Request-Id'];
+          };
+          body: {
+            type?: 'user-as-text-x-yaml';
+            value?: MyServiceComponents['schemas']['User'];
+          };
+        };
     notFoundError: {
       headers: {
         'content-type': 'application/json';
@@ -202,5 +233,9 @@ export interface MyServiceComponents {
         message: string;
       };
     };
+  };
+  headers: {
+    'X-Correlation-Id': string;
+    'X-Request-Id': string;
   };
 }

--- a/packages/zimic-http/src/cli/typegen/__tests__/fixtures/openapi/responses.yaml
+++ b/packages/zimic-http/src/cli/typegen/__tests__/fixtures/openapi/responses.yaml
@@ -47,6 +47,14 @@ paths:
         '400':
           $ref: '#/components/responses/error'
 
+  /users-with-multiple-reference-response-contents-having-component-headers:
+    post:
+      responses:
+        '200':
+          $ref: '#/components/responses/userCreatedMultipleContentsHavingComponentHeaders'
+        '400':
+          $ref: '#/components/responses/error'
+
   /users-with-multiple-literal-response-contents:
     post:
       responses:
@@ -161,6 +169,17 @@ components:
           type: string
           description: The date and time the user was last updated
 
+  headers:
+    X-Correlation-Id:
+      schema:
+        type: string
+        description: The correlation ID
+
+    X-Request-Id:
+      schema:
+        type: string
+        description: The request ID
+
   responses:
     userCreated:
       description: Success
@@ -191,6 +210,37 @@ components:
               type:
                 type: string
                 enum: [user-as-xml]
+                description: The type of the response
+              value:
+                $ref: '#/components/schemas/User'
+
+    userCreatedMultipleContentsHavingComponentHeaders:
+      description: Success
+      headers:
+        x-correlation-id:
+          $ref: '#/components/headers/X-Correlation-Id'
+        x-request-id:
+          $ref: '#/components/headers/X-Request-Id'
+      content:
+        application/x-yaml:
+          schema:
+            type: object
+            description: The created user as YAML
+            properties:
+              type:
+                type: string
+                enum: [user-as-application-x-yaml]
+                description: The type of the response
+              value:
+                $ref: '#/components/schemas/User'
+        text/x-yaml:
+          schema:
+            type: object
+            description: The created user as plain text YAML
+            properties:
+              type:
+                type: string
+                enum: [user-as-text-x-yaml]
                 description: The type of the response
               value:
                 $ref: '#/components/schemas/User'

--- a/packages/zimic-http/src/typegen/openapi/transform/components.ts
+++ b/packages/zimic-http/src/typegen/openapi/transform/components.ts
@@ -239,6 +239,7 @@ export function renameComponentReferences(node: ts.TypeNode, context: TypeTransf
       const newObjectType = ts.factory.updateTypeReferenceNode(objectType, newIdentifier, objectType.typeArguments);
 
       const newComponentGroupName = normalizeComponentGroupName(componentGroupName);
+
       const newIndexType = ts.factory.updateLiteralTypeNode(
         indexType,
         ts.factory.createStringLiteral(newComponentGroupName),

--- a/packages/zimic-http/src/typegen/openapi/transform/methods.ts
+++ b/packages/zimic-http/src/typegen/openapi/transform/methods.ts
@@ -206,7 +206,7 @@ function normalizeRequestBodyMember(
   };
 }
 
-function normalizeHeaders(headers: ts.TypeLiteralNode) {
+function normalizeHeaders(headers: ts.TypeLiteralNode, context: TypeTransformContext) {
   const newHeaderMembers = headers.members.filter((header) => {
     if (ts.isIndexSignatureDeclaration(header)) {
       return false;
@@ -224,17 +224,23 @@ function normalizeHeaders(headers: ts.TypeLiteralNode) {
     return undefined;
   }
 
-  return ts.factory.updateTypeLiteralNode(headers, ts.factory.createNodeArray(newHeaderMembers));
+  return renameComponentReferences(
+    ts.factory.updateTypeLiteralNode(headers, ts.factory.createNodeArray(newHeaderMembers)),
+    context,
+  );
 }
 
-function normalizeRequestHeaders(requestHeader: ts.TypeElement): NormalizedRequestHeaders | undefined {
+function normalizeRequestHeaders(
+  requestHeader: ts.TypeElement,
+  context: TypeTransformContext,
+): NormalizedRequestHeaders | undefined {
   if (!isRequestHeaders(requestHeader)) {
     return undefined;
   }
 
-  const newType = normalizeHeaders(requestHeader.type);
+  const newType = normalizeHeaders(requestHeader.type, context);
 
-  if (!newType) {
+  if (!newType || !ts.isTypeLiteralNode(newType)) {
     return undefined;
   }
 
@@ -284,7 +290,7 @@ export function normalizeContentType(
     return contentType;
   }
 
-  const newHeader = contentType.members.map(normalizeRequestHeaders).find(isDefined);
+  const newHeader = contentType.members.map((member) => normalizeRequestHeaders(member, context)).find(isDefined);
 
   const newBodyMembers = contentType.members.flatMap((body) => {
     if (isContentPropertySignature(body)) {


### PR DESCRIPTION
During the upgrade in https://github.com/zimicjs/zimic/pull/1275, the Here OpenAPI documentation used in zimic-test-client became unavailable. Commit https://github.com/zimicjs/zimic/pull/1275/changes/f2dd329030ad41b0129d15d4adbb8e16f955e06f changes it to the new documentation path, but this surfaced a bug: header component references in response components were not being renamed. This pull request fixes that and extends the tests to check the renaming.