### PR TITLE
refactor(http, ws): remove unnecessary casts

### DIFF
--- a/packages/zimic-http/src/cli/typegen/__tests__/openapi.node.test.ts
+++ b/packages/zimic-http/src/cli/typegen/__tests__/openapi.node.test.ts
@@ -282,7 +282,7 @@ describe('Type generation (OpenAPI)', () => {
           ? joinURL(schemaInterceptor.baseURL, 'spec', fixtureName)
           : inputFilePath;
 
-        const inputFileBuffer = (await fs.promises.readFile(inputFilePath)) as Buffer<ArrayBuffer>;
+        const inputFileBuffer = await fs.promises.readFile(inputFilePath);
 
         schemaInterceptor
           .get(`/spec/${fixtureName}`)

--- a/packages/zimic-http/src/formData/HttpFormData.ts
+++ b/packages/zimic-http/src/formData/HttpFormData.ts
@@ -23,9 +23,9 @@ class HttpFormData<LooseSchema extends HttpFormDataSchema.Loose = HttpFormDataSc
     fileName?: string,
   ): void {
     if (fileName === undefined) {
-      super.set(name, blobOrValue as Blob);
+      super.set(name, blobOrValue);
     } else {
-      super.set(name, blobOrValue as Blob, fileName);
+      super.set(name, blobOrValue, fileName);
     }
   }
 
@@ -45,9 +45,9 @@ class HttpFormData<LooseSchema extends HttpFormDataSchema.Loose = HttpFormDataSc
     fileName?: string,
   ): void {
     if (fileName === undefined) {
-      super.append(name, blobOrValue as Blob);
+      super.append(name, blobOrValue);
     } else {
-      super.append(name, blobOrValue as Blob, fileName);
+      super.append(name, blobOrValue, fileName);
     }
   }
 
@@ -194,12 +194,12 @@ class HttpFormData<LooseSchema extends HttpFormDataSchema.Loose = HttpFormDataSc
         const existingFieldValue = object[fieldName] as SchemaValue[];
 
         if (Array.isArray<SchemaValue>(existingFieldValue)) {
-          existingFieldValue.push(fieldValue as SchemaValue);
+          existingFieldValue.push(fieldValue);
         } else {
           object[fieldName] = [existingFieldValue, fieldValue] as SchemaValue;
         }
       } else {
-        object[fieldName] = fieldValue as SchemaValue;
+        object[fieldName] = fieldValue;
       }
     }
 

--- a/packages/zimic-http/src/searchParams/HttpSearchParams.ts
+++ b/packages/zimic-http/src/searchParams/HttpSearchParams.ts
@@ -188,12 +188,12 @@ class HttpSearchParams<
         const existingParamValue = object[paramName] as SchemaValue[];
 
         if (Array.isArray<SchemaValue>(existingParamValue)) {
-          existingParamValue.push(paramValue as SchemaValue);
+          existingParamValue.push(paramValue);
         } else {
           object[paramName] = [existingParamValue, paramValue] as SchemaValue;
         }
       } else {
-        object[paramName] = paramValue as SchemaValue;
+        object[paramName] = paramValue;
       }
     }
 

--- a/packages/zimic-ws/src/client/WebSocketClient.ts
+++ b/packages/zimic-ws/src/client/WebSocketClient.ts
@@ -161,7 +161,7 @@ export class WebSocketClient<Schema extends WebSocketSchema> implements Omit<
 
   get readyState(): WebSocketClient.ReadyState {
     const readyState = this.socket?.readyState ?? WebSocket.CLOSED;
-    return readyState as WebSocketClient.ReadyState;
+    return readyState;
   }
 
   get bufferedAmount() {


### PR DESCRIPTION
After https://github.com/zimicjs/zimic/pull/1277, some casts in `@zimic/http` and `@zimic/ws` are no longer needed.