### PR TITLE
fix(http): expect `application/` prefix in url encoded content type

### DIFF
--- a/packages/zimic-http/src/cli/typegen/__tests__/fixtures/openapi/filters.comments.ts
+++ b/packages/zimic-http/src/cli/typegen/__tests__/fixtures/openapi/filters.comments.ts
@@ -119,7 +119,7 @@ export type MyServiceSchema = HttpSchema<{
             }
           | {
               headers: {
-                'content-type': 'x-www-form-urlencoded';
+                'content-type': 'application/x-www-form-urlencoded';
                 'x-upload-id'?: string;
               };
               body: HttpSearchParams<{

--- a/packages/zimic-http/src/cli/typegen/__tests__/fixtures/openapi/filters.multiple.ts
+++ b/packages/zimic-http/src/cli/typegen/__tests__/fixtures/openapi/filters.multiple.ts
@@ -83,7 +83,7 @@ export type MyServiceSchema = HttpSchema<{
             }
           | {
               headers: {
-                'content-type': 'x-www-form-urlencoded';
+                'content-type': 'application/x-www-form-urlencoded';
                 'x-upload-id'?: string;
               };
               body: HttpSearchParams<{

--- a/packages/zimic-http/src/cli/typegen/__tests__/fixtures/openapi/filters.multipleFromFile.notPruned.ts
+++ b/packages/zimic-http/src/cli/typegen/__tests__/fixtures/openapi/filters.multipleFromFile.notPruned.ts
@@ -84,7 +84,7 @@ export type MyServiceSchema = HttpSchema<{
             }
           | {
               headers: {
-                'content-type': 'x-www-form-urlencoded';
+                'content-type': 'application/x-www-form-urlencoded';
                 'x-upload-id'?: string;
               };
               body: HttpSearchParams<{

--- a/packages/zimic-http/src/cli/typegen/__tests__/fixtures/openapi/filters.multipleFromFile.ts
+++ b/packages/zimic-http/src/cli/typegen/__tests__/fixtures/openapi/filters.multipleFromFile.ts
@@ -84,7 +84,7 @@ export type MyServiceSchema = HttpSchema<{
             }
           | {
               headers: {
-                'content-type': 'x-www-form-urlencoded';
+                'content-type': 'application/x-www-form-urlencoded';
                 'x-upload-id'?: string;
               };
               body: HttpSearchParams<{

--- a/packages/zimic-http/src/cli/typegen/__tests__/fixtures/openapi/filters.negative.1.ts
+++ b/packages/zimic-http/src/cli/typegen/__tests__/fixtures/openapi/filters.negative.1.ts
@@ -97,7 +97,7 @@ export type MyServiceSchema = HttpSchema<{
             }
           | {
               headers: {
-                'content-type': 'x-www-form-urlencoded';
+                'content-type': 'application/x-www-form-urlencoded';
                 'x-upload-id'?: string;
               };
               body: HttpSearchParams<{

--- a/packages/zimic-http/src/cli/typegen/__tests__/fixtures/openapi/filters.negative.2.ts
+++ b/packages/zimic-http/src/cli/typegen/__tests__/fixtures/openapi/filters.negative.2.ts
@@ -29,7 +29,7 @@ export type MyServiceSchema = HttpSchema<{
             }
           | {
               headers: {
-                'content-type': 'x-www-form-urlencoded';
+                'content-type': 'application/x-www-form-urlencoded';
                 'x-upload-id'?: string;
               };
               body: HttpSearchParams<{

--- a/packages/zimic-http/src/cli/typegen/__tests__/fixtures/openapi/filters.negative.3.ts
+++ b/packages/zimic-http/src/cli/typegen/__tests__/fixtures/openapi/filters.negative.3.ts
@@ -90,7 +90,7 @@ export type MyServiceSchema = HttpSchema<{
             }
           | {
               headers: {
-                'content-type': 'x-www-form-urlencoded';
+                'content-type': 'application/x-www-form-urlencoded';
                 'x-upload-id'?: string;
               };
               body: HttpSearchParams<{

--- a/packages/zimic-http/src/cli/typegen/__tests__/fixtures/openapi/filters.ts
+++ b/packages/zimic-http/src/cli/typegen/__tests__/fixtures/openapi/filters.ts
@@ -112,7 +112,7 @@ export type MyServiceSchema = HttpSchema<{
             }
           | {
               headers: {
-                'content-type': 'x-www-form-urlencoded';
+                'content-type': 'application/x-www-form-urlencoded';
                 'x-upload-id'?: string;
               };
               body: HttpSearchParams<{

--- a/packages/zimic-http/src/cli/typegen/__tests__/fixtures/openapi/filters.yaml
+++ b/packages/zimic-http/src/cli/typegen/__tests__/fixtures/openapi/filters.yaml
@@ -164,7 +164,7 @@ paths:
                 properties:
                   id:
                     type: string
-            x-www-form-urlencoded:
+            application/x-www-form-urlencoded:
               schema:
                 type: object
                 properties:

--- a/packages/zimic-http/src/cli/typegen/__tests__/fixtures/openapi/searchParams.comments.ts
+++ b/packages/zimic-http/src/cli/typegen/__tests__/fixtures/openapi/searchParams.comments.ts
@@ -110,7 +110,7 @@ export type MyServiceSchema = HttpSchema<{
         /** Success */
         200: {
           headers: {
-            'content-type': 'x-www-form-urlencoded';
+            'content-type': 'application/x-www-form-urlencoded';
           };
           body: HttpSearchParams<{
             search: MyServiceComponents['schemas']['search'];
@@ -128,7 +128,7 @@ export type MyServiceSchema = HttpSchema<{
         /** Success */
         200: {
           headers: {
-            'content-type': 'x-www-form-urlencoded';
+            'content-type': 'application/x-www-form-urlencoded';
           };
           body: HttpSearchParams<{
             search?: (string | null) | string[];

--- a/packages/zimic-http/src/cli/typegen/__tests__/fixtures/openapi/searchParams.ts
+++ b/packages/zimic-http/src/cli/typegen/__tests__/fixtures/openapi/searchParams.ts
@@ -84,7 +84,7 @@ export type MyServiceSchema = HttpSchema<{
       response: {
         200: {
           headers: {
-            'content-type': 'x-www-form-urlencoded';
+            'content-type': 'application/x-www-form-urlencoded';
           };
           body: HttpSearchParams<{
             search: MyServiceComponents['schemas']['search'];
@@ -101,7 +101,7 @@ export type MyServiceSchema = HttpSchema<{
       response: {
         200: {
           headers: {
-            'content-type': 'x-www-form-urlencoded';
+            'content-type': 'application/x-www-form-urlencoded';
           };
           body: HttpSearchParams<{
             search?: (string | null) | string[];

--- a/packages/zimic-http/src/cli/typegen/__tests__/fixtures/openapi/searchParams.yaml
+++ b/packages/zimic-http/src/cli/typegen/__tests__/fixtures/openapi/searchParams.yaml
@@ -119,7 +119,7 @@ paths:
         '200':
           description: Success
           content:
-            x-www-form-urlencoded:
+            application/x-www-form-urlencoded:
               schema:
                 type: object
                 required:
@@ -143,7 +143,7 @@ paths:
         '200':
           description: Success
           content:
-            x-www-form-urlencoded:
+            application/x-www-form-urlencoded:
               schema:
                 type: object
                 properties:

--- a/packages/zimic-http/src/typegen/openapi/transform/methods.ts
+++ b/packages/zimic-http/src/typegen/openapi/transform/methods.ts
@@ -432,9 +432,7 @@ export function normalizeResponses(responses: MethodMember, context: TypeTransfo
   const newIdentifier = ts.factory.createIdentifier('response');
   const newQuestionToken = undefined;
 
-  const newMembers = responses.type.members
-    .map((response) => normalizeResponse(response, context), context)
-    .filter(isDefined);
+  const newMembers = responses.type.members.map((response) => normalizeResponse(response, context)).filter(isDefined);
 
   const sortedNewMembers = Array.from(newMembers).sort((response, otherResponse) => {
     return response.statusCode.value.localeCompare(otherResponse.statusCode.value);

--- a/packages/zimic-http/src/typegen/openapi/transform/methods.ts
+++ b/packages/zimic-http/src/typegen/openapi/transform/methods.ts
@@ -190,7 +190,7 @@ function normalizeRequestBodyMember(
 
   if (contentType === 'multipart/form-data') {
     newType = wrapFormDataContentType(newType, context);
-  } else if (contentType === 'x-www-form-urlencoded') {
+  } else if (contentType === 'application/x-www-form-urlencoded') {
     newType = wrapURLEncodedContentType(newType, context);
   }
 


### PR DESCRIPTION
`@zimic/http`'s typegen incorrectly expected URL-encoded content types to be `x-www-form-urlencoded`. However, the correct content type is `application/x-www-form-urlencoded`, prefixed with `application/`.

**Changes:**
- Update OpenAPI transform logic to wrap `application/x-www-form-urlencoded` bodies as `HttpSearchParams<...>`.
- Update OpenAPI fixture specs (`.yaml`) to use the correct content-type key.
- Update generated fixture outputs (`.ts`, including comment fixtures) to reflect the corrected `content-type` literal.