### PR TITLE
chore(root): increase pnpm minimum release age

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,4 @@
-minimumReleaseAge: 1440
+minimumReleaseAge: 4320 # 3 days in minutes
 autoInstallPeers: true
 engineStrict: false
 sideEffectsCache: false


### PR DESCRIPTION
This pull request increases the minimum release age for installed packages to 3 days. This aims at reducing the risk of supply chain attacks, which have been happening more frequently in open source projects.