### PR TITLE
chore(root): disable deps verification before pnpm run

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ engineStrict: false
 sideEffectsCache: false
 ignoreWorkspaceCycles: true
 linkWorkspacePackages: true
+verifyDepsBeforeRun: false
 
 minimumReleaseAgeExclude:
   - '@zimic/*'


### PR DESCRIPTION
pnpm 11 introduces `verifyDepsBeforeRun` enabled by default, meaning that dependencies are verified and installed automatically before running `pnpm run ...`. This is not ideal for out use case, because we may execute many `pnpm run` commands in parallel and installing dependencies in each one of them generates high memory usage in development.

This sets `verifyDepsBeforeRun: false`, returning the behavior before pnpm 11.