### PR TITLE
fix(web): upgrade websocket-driver to latest version

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,7 @@ overrides:
   webpack@5: ^5.104.1
   yaml@2: ^2.8.3
   webpackbar: ^7.0.0
+  websocket-driver: ^0.7.5
 
 importers:
 
@@ -10128,8 +10129,8 @@ packages:
       webpack:
         optional: true
 
-  websocket-driver@0.7.4:
-    resolution: {integrity: sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==}
+  websocket-driver@0.7.5:
+    resolution: {integrity: sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==}
     engines: {node: '>=0.8.0'}
 
   websocket-extensions@0.1.4:
@@ -16552,7 +16553,7 @@ snapshots:
 
   faye-websocket@0.11.4:
     dependencies:
-      websocket-driver: 0.7.4
+      websocket-driver: 0.7.5
 
   fb-watchman@2.0.2:
     dependencies:
@@ -20393,7 +20394,7 @@ snapshots:
     dependencies:
       faye-websocket: 0.11.4
       uuid: 11.1.1
-      websocket-driver: 0.7.4
+      websocket-driver: 0.7.5
 
   sort-css-media-queries@2.2.0: {}
 
@@ -21393,7 +21394,7 @@ snapshots:
     optionalDependencies:
       webpack: 5.106.2(postcss@8.5.15)
 
-  websocket-driver@0.7.4:
+  websocket-driver@0.7.5:
     dependencies:
       http-parser-js: 0.5.10
       safe-buffer: 5.2.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,7 +42,6 @@ overrides:
   webpack-dev-server@5: ^5.2.5
   webpack@5: ^5.104.1
   yaml@2: ^2.8.3
-  webpackbar: ^7.0.0
   websocket-driver: ^0.7.5
 
 importers:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -78,9 +78,6 @@ overrides:
 
   yaml@2: ^2.8.3
 
-  # Temporary workaround for https://github.com/facebook/docusaurus/issues/11923.
-  webpackbar: ^7.0.0
-
   websocket-driver: ^0.7.5
 
 allowBuilds:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -81,6 +81,8 @@ overrides:
   # Temporary workaround for https://github.com/facebook/docusaurus/issues/11923.
   webpackbar: ^7.0.0
 
+  websocket-driver: ^0.7.5
+
 allowBuilds:
   '@swc/core': true
   '@zimic/interceptor': true


### PR DESCRIPTION
### Fixes

- [web] Upgrade websocket-driver to its latest version

### Chore

- [root] Removed a dependency override for `webpackbar`, which was no longer necessary after https://github.com/facebook/docusaurus/issues/11923 was resolved.
