### PR TITLE
fix(utils): support union stringified json types (#479)

### DIFF
--- a/packages/zimic-interceptor/src/utils/webSocket/__tests__/WebSocketClient.node.test.ts
+++ b/packages/zimic-interceptor/src/utils/webSocket/__tests__/WebSocketClient.node.test.ts
@@ -1,5 +1,6 @@
 import { startHttpServer, stopHttpServer } from '@zimic/utils/server';
 import { waitFor, waitForNot } from '@zimic/utils/time';
+import { JSONStringified } from '@zimic/utils/types';
 import { createServer } from 'http';
 import ClientSocket from 'isomorphic-ws';
 import { AddressInfo } from 'net';
@@ -167,7 +168,7 @@ describe('Web socket client', () => {
         if (typeof message.data !== 'string') {
           throw new Error('Unexpected message type');
         }
-        eventMessages.push(JSON.parse(message.data) as EventMessage);
+        eventMessages.push(JSON.parse(message.data as JSONStringified<EventMessage>));
       });
 
       const eventMessage: EventMessage['data'] = { message: 'test' };
@@ -224,7 +225,7 @@ describe('Web socket client', () => {
         if (typeof message.data !== 'string') {
           throw new Error('Unexpected message type');
         }
-        requestMessages.push(JSON.parse(message.data) as RequestMessage);
+        requestMessages.push(JSON.parse(message.data as JSONStringified<RequestMessage>));
       });
 
       const requestMessage: RequestMessage['data'] = { question: 'test' };
@@ -443,7 +444,7 @@ describe('Web socket client', () => {
         if (typeof message.data !== 'string') {
           throw new Error('Unexpected message type');
         }
-        requestMessages.push(JSON.parse(message.data) as RequestMessage);
+        requestMessages.push(JSON.parse(message.data as JSONStringified<RequestMessage>));
       });
 
       const requestMessage: RequestMessage['data'] = { question: 'test' };
@@ -501,7 +502,7 @@ describe('Web socket client', () => {
         if (typeof message.data !== 'string') {
           throw new Error('Unexpected message type');
         }
-        requestMessages.push(JSON.parse(message.data) as RequestMessage);
+        requestMessages.push(JSON.parse(message.data as JSONStringified<RequestMessage>));
       });
 
       type ReplyMessage = WebSocketReplyMessage<Schema, 'with-reply'>;

--- a/packages/zimic-utils/src/types/__tests__/json.test.ts
+++ b/packages/zimic-utils/src/types/__tests__/json.test.ts
@@ -132,7 +132,7 @@ describe('JSON types', () => {
   it('should convert types to their JSON-stringified versions', () => {
     expectTypeOf(JSON.stringify('')).toEqualTypeOf<JSONStringified<string>>();
     expectTypeOf(JSON.stringify(0)).toEqualTypeOf<JSONStringified<number>>();
-    expectTypeOf(JSON.stringify(true)).toEqualTypeOf<JSONStringified<boolean>>();
+    expectTypeOf(JSON.stringify(true)).toEqualTypeOf<JSONStringified<true> | JSONStringified<false>>();
     expectTypeOf(JSON.stringify(null)).toEqualTypeOf<JSONStringified<null>>();
     expectTypeOf(JSON.stringify(undefined)).toEqualTypeOf<JSONStringified<undefined>>();
     expectTypeOf(JSON.stringify(['a', 'b', 'c'])).toEqualTypeOf<JSONStringified<string[]>>();

--- a/packages/zimic-utils/src/types/__tests__/json.test.ts
+++ b/packages/zimic-utils/src/types/__tests__/json.test.ts
@@ -160,6 +160,8 @@ describe('JSON types', () => {
   });
 
   it('should parse JSON-stringified types to their JSON-serialized versions', () => {
+    expectTypeOf(JSON.parse('""')).toBeAny();
+
     expectTypeOf(JSON.parse(JSON.stringify(''))).toEqualTypeOf<string>();
     expectTypeOf(JSON.parse(JSON.stringify(0))).toEqualTypeOf<number>();
     expectTypeOf(JSON.parse(JSON.stringify(true))).toEqualTypeOf<boolean>();

--- a/packages/zimic-utils/src/types/json.ts
+++ b/packages/zimic-utils/src/types/json.ts
@@ -99,11 +99,13 @@ declare global {
     ): Value extends Value ? JSONStringified<Value> : never;
 
     // eslint-disable-next-line @typescript-eslint/method-signature-style
-    parse<StringifiedValue>(
+    parse<StringifiedValue extends string>(
       text: StringifiedValue,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       reviver?: (this: any, key: string, value: any) => any,
-    ): StringifiedValue extends JSONStringified<infer Value> ? JSONSerialized<Value> : never;
+      // Any is the default return type of `JSON.parse` when the input is a string, so we use it here as well.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ): StringifiedValue extends JSONStringified<infer Value> ? JSONSerialized<Value> : any;
   }
 }
 

--- a/packages/zimic-utils/src/types/json.ts
+++ b/packages/zimic-utils/src/types/json.ts
@@ -96,14 +96,14 @@ declare global {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       replacer?: ((this: any, key: string, value: Value) => any) | (number | string)[] | null,
       space?: string | number,
-    ): JSONStringified<Value>;
+    ): Value extends Value ? JSONStringified<Value> : never;
 
     // eslint-disable-next-line @typescript-eslint/method-signature-style
-    parse<Value>(
-      text: JSONStringified<Value>,
+    parse<StringifiedValue>(
+      text: StringifiedValue,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       reviver?: (this: any, key: string, value: any) => any,
-    ): JSONSerialized<Value>;
+    ): StringifiedValue extends JSONStringified<infer Value> ? JSONSerialized<Value> : never;
   }
 }
 

--- a/packages/zimic-ws/src/client/__tests__/WebSocketClient.test.ts
+++ b/packages/zimic-ws/src/client/__tests__/WebSocketClient.test.ts
@@ -15,10 +15,16 @@ import { delayWebSocketClose, delayWebSocketListenerTrigger } from './utils';
 describe('WebSocketClient', () => {
   let httpServer: HttpServer;
 
-  type Schema = WebSocketSchema<{
-    type: 'message';
-    data: string;
-  }>;
+  type Schema = WebSocketSchema<
+    | {
+        type: 'message';
+        data: string;
+      }
+    | {
+        type: 'count';
+        data: number;
+      }
+  >;
 
   let webSocketServer: WebSocketServer<Schema>;
   let webSocketClient: WebSocketClient<Schema> | undefined;
@@ -230,7 +236,12 @@ describe('WebSocketClient', () => {
       webSocketServer.addEventListener('connection', (serverWebSocketClient) => {
         serverWebSocketClient.addEventListener('message', (event) => {
           const message = JSON.parse(event.data);
+
           expectTypeOf(message).toEqualTypeOf<Schema>();
+          expectTypeOf(message.type).toEqualTypeOf<'message' | 'count'>();
+          expectTypeOf(message.data).toEqualTypeOf<string | number>();
+
+          expect(message.type).toBe('message');
 
           serverWebSocketClient.send(
             JSON.stringify({


### PR DESCRIPTION
## Summary

Support union types in the JSON stringification and parsing type declarations.

### Changes

- Make `JSON.stringify` and `JSON.parse` preserve union stringified types.
- Update JSON type tests and WebSocket client coverage for union message schemas.

Part of #479. Depends on #1333.
