### PR TITLE
feat(interceptor): validate base url in `createHttpInterceptor` (#477)

### DIFF
--- a/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/baseURLs.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/__tests__/shared/baseURLs.ts
@@ -1,5 +1,6 @@
 import { expectFetchError } from '@zimic/utils/fetch';
 import { joinURL, UnsupportedURLProtocolError } from '@zimic/utils/url';
+import { ValidationError } from '@zimic/utils/validation';
 import { beforeEach, expect, expectTypeOf, it, vi } from 'vitest';
 
 import { promiseIfRemote } from '@/http/interceptorWorker/__tests__/utils/promises';
@@ -185,6 +186,32 @@ export function declareBaseURLHttpInterceptorTests(options: RuntimeSharedHttpInt
 
     expect(handler).not.toHaveBeenCalled();
   });
+
+  const invalidBaseURLs = [
+    { label: 'undefined', value: undefined, expectedType: 'undefined' },
+    { label: 'null', value: null, expectedType: 'null' },
+    { label: 'a number', value: 5, expectedType: 'number' },
+    { label: 'a boolean', value: true, expectedType: 'boolean' },
+    { label: 'an object', value: {}, expectedType: 'object' },
+    { label: 'an array', value: [], expectedType: 'object' },
+    { label: 'a URL', value: new URL('http://localhost:3000'), expectedType: 'object' },
+  ];
+
+  it.each(invalidBaseURLs)(
+    'should throw an error if provided a base URL that is not a string ($label)',
+    async ({ value, expectedType }) => {
+      const handler = vi.fn();
+
+      // @ts-expect-error Forcing an invalid base URL type.
+      const invalidBaseURL: string = value;
+
+      await expect(async () => {
+        await usingHttpInterceptor({ ...interceptorOptions, baseURL: invalidBaseURL }, handler);
+      }).rejects.toThrow(new ValidationError(`Expected options.baseURL to be string, but got ${expectedType}.`));
+
+      expect(handler).not.toHaveBeenCalled();
+    },
+  );
 
   if (type === 'local') {
     it.each(SUPPORTED_BASE_URL_PROTOCOLS)(

--- a/packages/zimic-interceptor/src/http/interceptor/factory.ts
+++ b/packages/zimic-interceptor/src/http/interceptor/factory.ts
@@ -1,4 +1,5 @@
 import { HttpSchema } from '@zimic/http';
+import { assertTypeOf } from '@zimic/utils/validation';
 
 import UnknownHttpInterceptorTypeError from './errors/UnknownHttpInterceptorTypeError';
 import LocalHttpInterceptor from './LocalHttpInterceptor';
@@ -30,6 +31,8 @@ export function createHttpInterceptor<Schema extends HttpSchema>(
 export function createHttpInterceptor<Schema extends HttpSchema>(
   options: HttpInterceptorOptions,
 ): PublicLocalHttpInterceptor<Schema> | PublicRemoteHttpInterceptor<Schema> {
+  assertTypeOf('options.baseURL', options.baseURL, 'string');
+
   const type = options.type;
 
   if (isLocalHttpInterceptorOptions(options)) {


### PR DESCRIPTION
## Summary

`createHttpInterceptor` now checks that `options.baseURL` is a string before creating an interceptor. Invalid values throw a clear `ValidationError` instead of an opaque URL parsing error or being accepted through runtime coercion.

### Changes

- Validate `options.baseURL` with `assertTypeOf` at the start of `createHttpInterceptor`.
- Cover invalid values including `undefined`, `null`, numbers, booleans, objects, arrays, and `URL` instances.
- Run the shared tests across local and remote interceptors in both Node and browser environments.

Validation passed with `types:check`, `lint:turbo`, `style:check`, and the HTTP interceptor test suites.

### Checks

- [x] **Validation**: I have run the project type-check, lint, and test scripts related to my changes, or confirmed that none apply.
- [x] **Tests**: I have created or updated tests to cover my changes, or confirmed that this pull request does not require test changes.
- [x] **Public API**: I have aligned public exports, documentation, and examples with my changes, or confirmed that this pull request does not affect them.
- [x] **Compatibility**: I have confirmed that my changes are backwards compatible, or confirmed that the breaking changes are documented and approved by the team.

`baseURL` was already typed as a string, so there are no public type changes. One runtime behavior changes: passing a `URL` instance was previously accepted through coercion and now throws a `ValidationError`. Validation of the public `interceptor.baseURL` setter remains out of scope for this pull request.

Part of #477.
